### PR TITLE
Issue4770

### DIFF
--- a/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
+++ b/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
     <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <ProjectReference Include="..\WixToolsetTest.BuildTasks\WixToolsetTest.BuildTasks.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/Package.en-us.wxl
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/Package.en-us.wxl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/Package.wxs
@@ -1,0 +1,29 @@
+<?foreach falseValue in ; 0; 00; no; No; NO; false; False; FALSE; off; Off; OFF ?>
+    <?if $(var.falseValue) ?> <?warning  $(var.falseValue) is not false ?> <?endif ?>
+<?endforeach ?>
+
+<?ifdef $(sys.WIXVERSION) ?>
+<?if $(sys.WIXMAJORVERSION) >= 4 AND $(sys.WIXMAJORVERSION) < 5 ?>
+  <?warning WiX v4 is in effect! ?>
+<?endif?>
+<?endif?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
+    
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/PackageComponents.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/PackageComponents.wxs
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="test.txt" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/data/test.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExtendedPreprocessorFalsehood/data/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -14,6 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="TestData\ExtendedPreprocessorFalsehood\data\test.txt" />
+    <None Remove="TestData\ExtendedPreprocessorFalsehood\Package.en-us.wxl" />
+    <None Remove="TestData\ExtendedPreprocessorFalsehood\Package.wxs" />
+    <None Remove="TestData\ExtendedPreprocessorFalsehood\PackageComponents.wxs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\WixToolset.Core\WixToolset.Core.csproj" />
     <ProjectReference Include="..\..\WixToolset.Core.Burn\WixToolset.Core.Burn.csproj" />
     <ProjectReference Include="..\..\WixToolset.Core.WindowsInstaller\WixToolset.Core.WindowsInstaller.csproj" />


### PR DESCRIPTION
Extended the notion of falsehood in preprocessor expressions.

Added code to allow "", "0", "no", "false" and "off" (ignoring case, with or without quotes) to serve as alternative representations of falsehood in the preprocessor. In the case of zero, any number of digits are allowed

Fixes.wixtoolset/issues#4770.