### PR TITLE
See wixtoolset/Issues/4726.

### DIFF
--- a/src/wix/test/WixToolsetTest.CoreIntegration/AdvertisedTypeLibVersionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/AdvertisedTypeLibVersionFixture.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class AdvertisedTypeLibVersionFixture
+    {
+        [Fact]
+        public void Allows16BitTypeLibMajorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "AdvertisedTypeLib", "MajorVersion16Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+            }
+        }
+
+        [Fact]
+        public void DoesNotAllow17BitTypeLibMajorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "AdvertisedTypeLib", "MajorVersion17Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                Assert.True(result.ExitCode == (int)ErrorMessages.Ids.IntegralValueOutOfRange);
+            }
+        }
+
+        [Fact]
+        public void Allows8BitTypeLibMinorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "AdvertisedTypeLib", "MinorVersion8Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+            }
+        }
+
+        [Fact]
+        public void DoesNotAllow9BitTypeLibMinorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "AdvertisedTypeLib", "MinorVersion9Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                Assert.True(result.ExitCode == (int)ErrorMessages.Ids.IntegralValueOutOfRange);
+            }
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MajorVersion16Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MajorVersion16Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="yes" Language="1033" MajorVersion="65535" MinorVersion="0" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MajorVersion17Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MajorVersion17Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="yes" Language="1033" MajorVersion="65536" MinorVersion="0" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MinorVersion8Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MinorVersion8Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="yes" Language="1033" MajorVersion="1" MinorVersion="255" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MinorVersion9Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AdvertisedTypeLib/MinorVersion9Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="yes" Language="1033" MajorVersion="1" MinorVersion="256" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MajorVersion16Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MajorVersion16Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="no" Language="1033" MajorVersion="65535" MinorVersion="0" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MajorVersion17Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MajorVersion17Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="no" Language="1033" MajorVersion="65536" MinorVersion="0" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MinorVersion16Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MinorVersion16Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="no" Language="1033" MajorVersion="1" MinorVersion="65535" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MinorVersion17Bit.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/UnadvertisedTypeLib/MinorVersion17Bit.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <Component Id="TypeLibComp" Directory="INSTALLFOLDER" Guid="8E262DD2-04FE-4213-92D9-CFA0D392DC46">
+                <File Source="test.txt" Name="TypeLibComp.txt">
+                    <TypeLib Id="FF19093C-EA7A-4C41-9C1B-D706ECD9009F" Advertise="no" Language="1033" MajorVersion="1" MinorVersion="65536" />
+                </File>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UnadvertisedTypeLibVersionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UnadvertisedTypeLibVersionFixture.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class UnadvertisedTypeLibVersionFixture
+    {
+        [Fact]
+        public void Allows16BitTypeLibMajorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "UnadvertisedTypeLib", "MajorVersion16Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+            }
+        }
+
+        [Fact]
+        public void DoesNotAllow17BitTypeLibMajorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "UnadvertisedTypeLib", "MajorVersion17Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                Assert.True(result.ExitCode == (int)ErrorMessages.Ids.IntegralValueOutOfRange);
+            }
+        }
+
+        [Fact]
+        public void Allows16BitTypeLibMinorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "UnadvertisedTypeLib", "MinorVersion16Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+            }
+        }
+
+        [Fact]
+        public void DoesNotAllow17BitTypeLibMinorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "UnadvertisedTypeLib", "MinorVersion17Bit.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                Assert.True(result.ExitCode == (int)ErrorMessages.Ids.IntegralValueOutOfRange);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements actually failing and potentially failing tests for the proper enforcement of proper field widths for major an minor version numbers for advertised and unadvertised type ibraries.

Implements the enforcement of proper field widths for major an minor version numbers for advertised and unadvertised type libraries.

Fixes wixtoolset/Issues#4726.