### PR TITLE
Prepares issue 5371 for review and comment.

### DIFF
--- a/src/ext/Util/ca/scauser.h
+++ b/src/ext/Util/ca/scauser.h
@@ -31,6 +31,7 @@ struct SCA_USER
     WCHAR wzDomain[MAX_DARWIN_COLUMN + 1];
     WCHAR wzName[MAX_DARWIN_COLUMN + 1];
     WCHAR wzPassword[MAX_DARWIN_COLUMN + 1];
+    WCHAR wzComment[MAX_DARWIN_COLUMN + 1];
     INT iAttributes;
 
     SCA_GROUP *psgGroups;

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.en-us.wxl
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.en-us.wxl
@@ -1,0 +1,9 @@
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="CreateUser" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+        <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+    </Package>
+
+    <Fragment>
+            <StandardDirectory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="CreateUser" />
+            </StandardDirectory>
+        </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/PackageComponents.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/PackageComponents.wxs
@@ -1,0 +1,9 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component Id="MyComponentId" Guid="9250C606-D0E8-4384-B304-C673A7F6F448">
+                <util:User Id="NewUser" Name="Fred" Password="Flintstone" Comment="See if we can put a comment on Fred's account" CreateUser="yes" UpdateIfExists="yes" Vital="yes" RemoveOnUninstall="yes" LogonAsBatchJob="no" LogonAsService="no" Disabled="no" PasswordNeverExpires="yes" PasswordExpired="no" CanNotChangePassword="no" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/ext/Util/wixext/Symbols/UserSymbol.cs
+++ b/src/ext/Util/wixext/Symbols/UserSymbol.cs
@@ -15,6 +15,7 @@ namespace WixToolset.Util
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Name), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Domain), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Password), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(UserSymbolFields.Comment), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Attributes), IntermediateFieldType.Number),
             },
             typeof(UserSymbol));
@@ -31,6 +32,7 @@ namespace WixToolset.Util.Symbols
         Name,
         Domain,
         Password,
+        Comment,
         Attributes,
     }
 
@@ -68,6 +70,12 @@ namespace WixToolset.Util.Symbols
         {
             get => this.Fields[(int)UserSymbolFields.Password].AsString();
             set => this.Set((int)UserSymbolFields.Password, value);
+        }
+
+        public string Comment
+        {
+            get => this.Fields[(int)UserSymbolFields.Comment].AsString();
+            set => this.Set((int)UserSymbolFields.Comment, value);
         }
 
         public int Attributes

--- a/src/ext/Util/wixext/UtilCompiler.cs
+++ b/src/ext/Util/wixext/UtilCompiler.cs
@@ -2680,18 +2680,18 @@ namespace WixToolset.Util
                             var bitnessValue = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
                             switch (bitnessValue)
                             {
-                            case "always32":
-                                win64 = false;
-                                break;
-                            case "always64":
-                                win64 = true;
-                                break;
-                            case "default":
-                            case "":
-                                break;
-                            default:
-                                this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, attrib.Name.LocalName, attrib.Name.LocalName, bitnessValue, "default", "always32", "always64"));
-                                break;
+                                case "always32":
+                                    win64 = false;
+                                    break;
+                                case "always64":
+                                    win64 = true;
+                                    break;
+                                case "default":
+                                case "":
+                                    break;
+                                default:
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, attrib.Name.LocalName, attrib.Name.LocalName, bitnessValue, "default", "always32", "always64"));
+                                    break;
                             }
                             break;
                         case "Root":
@@ -3253,6 +3253,7 @@ namespace WixToolset.Util
             int attributes = 0;
             string domain = null;
             string name = null;
+            string comment = null;
             string password = null;
 
             foreach (var attrib in element.Attributes())
@@ -3274,6 +3275,14 @@ namespace WixToolset.Util
                             {
                                 attributes |= UserPasswdCantChange;
                             }
+                            break;
+                        case "Comment":
+                            if (null == componentId)
+                            {
+                                this.Messaging.Write(UtilErrors.IllegalAttributeWithoutComponent(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName));
+                            }
+
+                            comment = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
                             break;
                         case "CreateUser":
                             if (null == componentId)
@@ -3452,6 +3461,7 @@ namespace WixToolset.Util
                     Name = name,
                     Domain = domain,
                     Password = password,
+                    Comment = comment,
                     Attributes = attributes,
                 });
             }

--- a/src/ext/Util/wixext/UtilTableDefinitions.cs
+++ b/src/ext/Util/wixext/UtilTableDefinitions.cs
@@ -229,6 +229,7 @@ namespace WixToolset.Util
                 new ColumnDefinition("Name", ColumnType.String, 255, primaryKey: false, nullable: false, ColumnCategory.Formatted, description: "User name", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Domain", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User domain", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Password", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User password", modularizeType: ColumnModularizeType.Property),
+                new ColumnDefinition("Comment", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User comment", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Attributes", ColumnType.Number, 4, primaryKey: false, nullable: true, ColumnCategory.Unknown, minValue: 0, maxValue: 65535, description: "Attributes describing how to create the user"),
             },
             symbolIdIsPrimaryKey: true


### PR DESCRIPTION
Test produces a CreateUser folder on the desktop,
containing test.msi, which can be installed and
uninstalled for manual testing. This test is in need
of a virtual environment in which to safely run the
desired tests.

Tests should cover install and uninstall with
verification of user account (with comment) creation
and destruction.

Tests should also cover situations such as the user
account already existing and other options controlling
the possible options controlling the desired action.