### PR TITLE
Prepares for review and discussion of Issue 5371

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
 
     <!-- This is C++-specific but used from managed projects to pick up native build artifacts. -->
-    <WixNativeSdkLibraryToolset>v141</WixNativeSdkLibraryToolset>
+    <WixNativeSdkLibraryToolset>v143</WixNativeSdkLibraryToolset>
     <PlatformToolset Condition=" '$(ConfigurationType)' == 'StaticLibrary' ">$(WixNativeSdkLibraryToolset)</PlatformToolset>
     <PlatformToolset Condition=" '$(PlatformToolset)' == '' ">v143</PlatformToolset>
 

--- a/src/Directory.csproj.props
+++ b/src/Directory.csproj.props
@@ -8,6 +8,6 @@
     <CreateDocumentation Condition=" '$(CreateDocumentationFile)'!='true' ">false</CreateDocumentation>
     <DocumentationFile Condition=" '$(CreateDocumentationFile)'=='true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <DebugType Condition=" '$(DebugType)'=='' ">embedded</DebugType>
-    <RunAnalyzers>false</RunAnalyzers>
+    <RunAnalyzers>false</RunAnalyzers> <!-- xxxxx Stopgap for use until analyzers have been customized xxxxx -->
   </PropertyGroup>
 </Project>

--- a/src/Directory.csproj.props
+++ b/src/Directory.csproj.props
@@ -8,5 +8,6 @@
     <CreateDocumentation Condition=" '$(CreateDocumentationFile)'!='true' ">false</CreateDocumentation>
     <DocumentationFile Condition=" '$(CreateDocumentationFile)'=='true' ">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <DebugType Condition=" '$(DebugType)'=='' ">embedded</DebugType>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/api/burn/balutil/balutil.nuspec
+++ b/src/api/burn/balutil/balutil.nuspec
@@ -20,8 +20,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x86\balutil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\x64\balutil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\ARM64\balutil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x86\balutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\x64\balutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\ARM64\balutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/api/burn/balutil/balutil.vcxproj
+++ b/src/api/burn/balutil/balutil.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -28,7 +27,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EDCB8095-0E6A-43E0-BC33-C4F762FC5CDB}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -36,22 +34,36 @@
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Bootstrapper Application Layer native utility library</Description>
     <PackageId>WixToolset.BalUtil</PackageId>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="..\..\..\NativeMultiTargeting.Build.props" />
-
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-
   <ImportGroup Label="Shared">
   </ImportGroup>
-
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>inc;..\WixToolset.BootstrapperCore.Native\inc</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
-
   <ItemGroup>
     <ClCompile Include="BalBootstrapperEngine.cpp" />
     <ClCompile Include="balcondition.cpp" />
@@ -79,13 +91,10 @@
     <ClInclude Include="inc\IBootstrapperEngine.h" />
     <ClInclude Include="precomp.h" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
-
     <PackageReference Include="WixToolset.DUtil" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/api/burn/bextutil/bextutil.nuspec
+++ b/src/api/burn/bextutil/bextutil.nuspec
@@ -20,8 +20,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x86\bextutil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\x64\bextutil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\ARM64\bextutil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x86\bextutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\x64\bextutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\ARM64\bextutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/api/burn/bextutil/bextutil.vcxproj
+++ b/src/api/burn/bextutil/bextutil.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -28,7 +27,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06027492-1CB9-48BC-B31E-C1F9356ED07E}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -36,22 +34,36 @@
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Bundle Extension native utility library</Description>
     <PackageId>WixToolset.BextUtil</PackageId>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="..\..\..\NativeMultiTargeting.Build.props" />
-
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-
   <ImportGroup Label="Shared">
   </ImportGroup>
-
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>inc;..\WixToolset.BootstrapperCore.Native\inc</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
-
   <ItemGroup>
     <ClCompile Include="BextBundleExtensionEngine.cpp" />
     <ClCompile Include="bextutil.cpp" />
@@ -68,13 +80,10 @@
     <ClInclude Include="inc\IBundleExtensionEngine.h" />
     <ClInclude Include="precomp.h" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
-
     <PackageReference Include="WixToolset.DUtil" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/burn/engine/engine.vcxproj
+++ b/src/burn/engine/engine.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -28,27 +27,41 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8119537D-E1D9-6591-D51A-49768A2F9C37}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>engine</TargetName>
     <CharacterSet>Unicode</CharacterSet>
     <Description>Native component of WixToolset.Burn</Description>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>..\..\api\burn\WixToolset.BootstrapperCore.Native\inc;$(ProjectAdditionalIncludeDirectories)</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
-
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-
   <ItemGroup>
     <ClCompile Include="apply.cpp" />
     <ClCompile Include="approvedexe.cpp" />
@@ -94,7 +107,6 @@
     <ClCompile Include="variable.cpp" />
     <ClCompile Include="variant.cpp" />
   </ItemGroup>
-
   <ItemGroup>
     <ClInclude Include="apply.h" />
     <ClInclude Include="approvedexe.h" />
@@ -143,7 +155,6 @@
     <ClInclude Include="variable.h" />
     <ClInclude Include="variant.h" />
   </ItemGroup>
-
   <ItemGroup>
     <CustomBuild Include="engine.mc">
       <Message>Compiling message file...</Message>
@@ -152,7 +163,6 @@ rc.exe -fo "$(OutDir)engine.res" "$(IntDir)engine.messages.rc"</Command>
       <Outputs>$(IntDir)engine.messages.h;$(IntDir)engine.messages.rc</Outputs>
     </CustomBuild>
   </ItemGroup>
-
   <Target Name="SetWixVersion" DependsOnTargets="__SetPropertiesFromGit" BeforeTargets="ClCompile">
     <PropertyGroup>
       <rmj>$(GitBaseVersionMajor)</rmj>
@@ -162,20 +172,16 @@ rc.exe -fo "$(OutDir)engine.res" "$(IntDir)engine.messages.rc"</Command>
       <szVerMajorMinorBuild>$(rmj).$(rmm).$(rup).$(rpr)</szVerMajorMinorBuild>
       <wixver>rmj=$(rmj);rmm=$(rmm);rup=$(rup);rpr=$(rpr);szVerMajorMinorBuild="$(szVerMajorMinorBuild)"</wixver>
     </PropertyGroup>
-
     <ItemGroup>
       <ClCompile>
         <PreprocessorDefinitions>$(wixver);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>
-
   <ItemGroup>
     <PackageReference Include="WixToolset.DUtil" />
-
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{4544158C-2D63-4146-85FF-62169280144E}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -10,19 +10,24 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="CabTest.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Dtf.Compression\WixToolset.Dtf.Compression.csproj">
       <Project>{45D81DAB-0559-4836-8106-CE9987FD4AB5}</Project>
@@ -37,7 +42,6 @@
       <Name>WixToolsetTests.Dtf.Compression</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{328799BB-7B03-4B28-8180-4132211FD07D}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -10,17 +10,22 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ZipTest.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Dtf.Compression\WixToolset.Dtf.Compression.csproj">
       <Project>{45D81DAB-0559-4836-8106-CE9987FD4AB5}</Project>
@@ -35,7 +40,6 @@
       <Name>WixToolsetTests.Dtf.Compression</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{F045FFC1-05F9-4EA2-9F03-E1CBDB7BC4F9}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,28 +9,32 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="CompressionTestUtil.cs" />
     <Compile Include="MisbehavingStreamContext.cs" />
     <Compile Include="OptionStreamContext.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Dtf.Compression\WixToolset.Dtf.Compression.csproj">
       <Project>{45D81DAB-0559-4836-8106-CE9987FD4AB5}</Project>
       <Name>WixToolset.Dtf.Compression</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{137D376B-989F-4FEA-9A67-01D8D38CA0DE}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -10,12 +10,18 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomActionTest.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
@@ -26,7 +32,6 @@
       <Name>WixToolsetTests.Dtf.WindowsInstaller</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{4F55F9B8-D8B6-41EB-8796-221B4CD98324}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -10,18 +10,23 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="LinqTest.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Dtf.WindowsInstaller\WixToolset.Dtf.WindowsInstaller.csproj">
       <Project>{85225597-5121-4361-8332-4E3246D5BBF5}</Project>
@@ -36,7 +41,6 @@
       <Name>WixToolsetTests.Dtf.WindowsInstaller</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{16F5202F-9276-4166-975C-C9654BAF8012}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -10,8 +10,15 @@
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-  
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="EmbeddedExternalUI.cs" />
     <Compile Include="Schema.cs" />
@@ -19,21 +26,18 @@
     <Compile Include="WindowsInstallerTransactions.cs" />
     <Compile Include="WindowsInstallerUtils.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Dtf.WindowsInstaller\WixToolset.Dtf.WindowsInstaller.csproj">
       <Project>{85225597-5121-4361-8332-4E3246D5BBF5}</Project>
       <Name>WixToolset.Dtf.WindowsInstaller</Name>
     </ProjectReference>
   </ItemGroup>
-
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="Pack" DependsOnTargets="Build" />
 </Project>

--- a/src/dtf/dtf.sln
+++ b/src/dtf/dtf.sln
@@ -1,21 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.8
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.Compression", "WixToolset.Dtf.Compression\WixToolset.Dtf.Compression.csproj", "{2D62850C-9F81-4BE9-BDF3-9379389C8F7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.Compression", "WixToolset.Dtf.Compression\WixToolset.Dtf.Compression.csproj", "{2D62850C-9F81-4BE9-BDF3-9379389C8F7B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.Compression.Cab", "WixToolset.Dtf.Compression.Cab\WixToolset.Dtf.Compression.Cab.csproj", "{15895FD1-DD68-407B-8717-08F6DD14F02C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.Compression.Cab", "WixToolset.Dtf.Compression.Cab\WixToolset.Dtf.Compression.Cab.csproj", "{15895FD1-DD68-407B-8717-08F6DD14F02C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.Compression.Zip", "WixToolset.Dtf.Compression.Zip\WixToolset.Dtf.Compression.Zip.csproj", "{261F2857-B521-42A4-A3E0-B5165F225E50}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.Compression.Zip", "WixToolset.Dtf.Compression.Zip\WixToolset.Dtf.Compression.Zip.csproj", "{261F2857-B521-42A4-A3E0-B5165F225E50}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.Resources", "WixToolset.Dtf.Resources\WixToolset.Dtf.Resources.csproj", "{44931ECB-8D6F-4C12-A872-64E261B6A98E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.Resources", "WixToolset.Dtf.Resources\WixToolset.Dtf.Resources.csproj", "{44931ECB-8D6F-4C12-A872-64E261B6A98E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.WindowsInstaller", "WixToolset.Dtf.WindowsInstaller\WixToolset.Dtf.WindowsInstaller.csproj", "{24121677-0ED0-41B5-833F-1B9A18E87BF4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.WindowsInstaller", "WixToolset.Dtf.WindowsInstaller\WixToolset.Dtf.WindowsInstaller.csproj", "{24121677-0ED0-41B5-833F-1B9A18E87BF4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.WindowsInstaller.Linq", "WixToolset.Dtf.WindowsInstaller.Linq\WixToolset.Dtf.WindowsInstaller.Linq.csproj", "{CD7A37D8-9D8C-41BD-B78F-DB5E0C299D2E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.WindowsInstaller.Linq", "WixToolset.Dtf.WindowsInstaller.Linq\WixToolset.Dtf.WindowsInstaller.Linq.csproj", "{CD7A37D8-9D8C-41BD-B78F-DB5E0C299D2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolset.Dtf.WindowsInstaller.Package", "WixToolset.Dtf.WindowsInstaller.Package\WixToolset.Dtf.WindowsInstaller.Package.csproj", "{1A9940A7-3E29-4428-B753-C4CC66058F1A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Dtf.WindowsInstaller.Package", "WixToolset.Dtf.WindowsInstaller.Package\WixToolset.Dtf.WindowsInstaller.Package.csproj", "{1A9940A7-3E29-4428-B753-C4CC66058F1A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixToolsetTests.Dtf.Compression", "WixToolsetTests.Dtf.Compression\WixToolsetTests.Dtf.Compression.csproj", "{F045FFC1-05F9-4EA2-9F03-E1CBDB7BC4F9}"
 EndProject
@@ -195,23 +195,9 @@ Global
 		{4F55F9B8-D8B6-41EB-8796-221B4CD98324}.Release|x64.Build.0 = Release|Any CPU
 		{4F55F9B8-D8B6-41EB-8796-221B4CD98324}.Release|x86.ActiveCfg = Release|Any CPU
 		{4F55F9B8-D8B6-41EB-8796-221B4CD98324}.Release|x86.Build.0 = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|x64.Build.0 = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Debug|x86.Build.0 = Debug|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|x64.ActiveCfg = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|x64.Build.0 = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|x86.ActiveCfg = Release|Any CPU
-		{E7A00377-A0B5-400F-8337-C0814AAC7153}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB57C98D-C0C2-4805-AED3-C19B47759DBD}

--- a/src/ext/Util/ca/scauser.cpp
+++ b/src/ext/Util/ca/scauser.cpp
@@ -11,8 +11,8 @@ enum eGroupQuery { vgqGroup = 1, vgqComponent, vgqName, vgqDomain };
 LPCWSTR vcsUserGroupQuery = L"SELECT `User_`, `Group_` FROM `Wix4UserGroup` WHERE `User_`=?";
 enum eUserGroupQuery { vugqUser = 1, vugqGroup };
 
-LPCWSTR vActionableQuery = L"SELECT `User`,`Component_`,`Name`,`Domain`,`Password`,`Attributes` FROM `Wix4User` WHERE `Component_` IS NOT NULL";
-enum eActionableQuery { vaqUser = 1, vaqComponent, vaqName, vaqDomain, vaqPassword, vaqAttributes };
+LPCWSTR vActionableQuery = L"SELECT `User`,`Component_`,`Name`,`Domain`,`Password`,'Comment',`Attributes` FROM `Wix4User` WHERE `Component_` IS NOT NULL";
+enum eActionableQuery { vaqUser = 1, vaqComponent, vaqName, vaqDomain, vaqPassword, vaqComment, vaqAttributes };
 
 
 static HRESULT AddUserToList(
@@ -351,6 +351,11 @@ HRESULT ScaUserRead(
             hr = ::StringCchCopyW(psu->wzPassword, countof(psu->wzPassword), pwzData);
             ExitOnFailure(hr, "failed to copy user password");
 
+            hr = WcaGetRecordFormattedString(hRec, vaqComment, &pwzData);
+            ExitOnFailure(hr, "failed to get Wix4User.Comment");
+            hr = ::StringCchCopyW(psu->wzComment, countof(psu->wzComment), pwzData);
+            ExitOnFailure(hr, "failed to copy user comment: %ls", pwzData);
+
             hr = WcaGetRecordInteger(hRec, vaqAttributes, &psu->iAttributes);
             ExitOnFailure(hr, "failed to get Wix4User.Attributes");
 
@@ -492,13 +497,15 @@ HRESULT ScaUserExecute(
     {
         USER_EXISTS ueUserExists = USER_EXISTS_INDETERMINATE;
 
-        // Always put the User Name and Domain plus Attributes on the front of the CustomAction
+        // Always put the User Name, Domain, and Comment plus Attributes on the front of the CustomAction
         // data.  Sometimes we'll add more data.
         Assert(psu->wzName);
         hr = WcaWriteStringToCaData(psu->wzName, &pwzActionData);
         ExitOnFailure(hr, "Failed to add user name to custom action data: %ls", psu->wzName);
         hr = WcaWriteStringToCaData(psu->wzDomain, &pwzActionData);
         ExitOnFailure(hr, "Failed to add user domain to custom action data: %ls", psu->wzDomain);
+        hr = WcaWriteStringToCaData(psu->wzComment, &pwzActionData);
+        ExitOnFailure(hr, "Failed to add user comment to custom action data: %ls", psu->wzComment);
         hr = WcaWriteIntegerToCaData(psu->iAttributes, &pwzActionData);
         ExitOnFailure(hr, "failed to add user attributes to custom action data for user: %ls", psu->wzKey);
 
@@ -544,7 +551,7 @@ HRESULT ScaUserExecute(
 
         if (WcaIsInstalling(psu->isInstalled, psu->isAction))
         {
-            // If the user exists, check to see if we are supposed to fail if user the exists before
+            // If the user exists, check to see if we are supposed to fail if the user exists before
             // the install.
             if (USER_EXISTS_YES == ueUserExists)
             {

--- a/src/ext/Util/ca/scauser.h
+++ b/src/ext/Util/ca/scauser.h
@@ -31,6 +31,7 @@ struct SCA_USER
     WCHAR wzDomain[MAX_DARWIN_COLUMN + 1];
     WCHAR wzName[MAX_DARWIN_COLUMN + 1];
     WCHAR wzPassword[MAX_DARWIN_COLUMN + 1];
+    WCHAR wzComment[MAX_DARWIN_COLUMN + 1];
     INT iAttributes;
 
     SCA_GROUP *psgGroups;

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.en-us.wxl
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.en-us.wxl
@@ -1,0 +1,9 @@
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/Package.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="CreateUser" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+        <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+    </Package>
+
+    <Fragment>
+            <StandardDirectory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="CreateUser" />
+            </StandardDirectory>
+        </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/PackageComponents.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/CreateUser/PackageComponents.wxs
@@ -1,0 +1,9 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component Id="MyComponentId" Guid="9250C606-D0E8-4384-B304-C673A7F6F448">
+                <util:User Id="NewUser" Name="Fred" Password="Flintstone" Comment="See if we can put a comment on Fred's account" CreateUser="yes" UpdateIfExists="yes" Vital="yes" RemoveOnUninstall="yes" LogonAsBatchJob="no" LogonAsService="no" Disabled="no" PasswordNeverExpires="yes" PasswordExpired="no" CanNotChangePassword="no" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/ext/Util/wixext/Symbols/UserSymbol.cs
+++ b/src/ext/Util/wixext/Symbols/UserSymbol.cs
@@ -15,6 +15,7 @@ namespace WixToolset.Util
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Name), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Domain), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Password), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(UserSymbolFields.Comment), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(UserSymbolFields.Attributes), IntermediateFieldType.Number),
             },
             typeof(UserSymbol));
@@ -31,6 +32,7 @@ namespace WixToolset.Util.Symbols
         Name,
         Domain,
         Password,
+        Comment,
         Attributes,
     }
 
@@ -68,6 +70,12 @@ namespace WixToolset.Util.Symbols
         {
             get => this.Fields[(int)UserSymbolFields.Password].AsString();
             set => this.Set((int)UserSymbolFields.Password, value);
+        }
+
+        public string Comment
+        {
+            get => this.Fields[(int)UserSymbolFields.Comment].AsString();
+            set => this.Set((int)UserSymbolFields.Comment, value);
         }
 
         public int Attributes

--- a/src/ext/Util/wixext/UtilCompiler.cs
+++ b/src/ext/Util/wixext/UtilCompiler.cs
@@ -2680,18 +2680,18 @@ namespace WixToolset.Util
                             var bitnessValue = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
                             switch (bitnessValue)
                             {
-                            case "always32":
-                                win64 = false;
-                                break;
-                            case "always64":
-                                win64 = true;
-                                break;
-                            case "default":
-                            case "":
-                                break;
-                            default:
-                                this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, attrib.Name.LocalName, attrib.Name.LocalName, bitnessValue, "default", "always32", "always64"));
-                                break;
+                                case "always32":
+                                    win64 = false;
+                                    break;
+                                case "always64":
+                                    win64 = true;
+                                    break;
+                                case "default":
+                                case "":
+                                    break;
+                                default:
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, attrib.Name.LocalName, attrib.Name.LocalName, bitnessValue, "default", "always32", "always64"));
+                                    break;
                             }
                             break;
                         case "Root":
@@ -3253,6 +3253,7 @@ namespace WixToolset.Util
             int attributes = 0;
             string domain = null;
             string name = null;
+            string comment = null;
             string password = null;
 
             foreach (var attrib in element.Attributes())
@@ -3274,6 +3275,14 @@ namespace WixToolset.Util
                             {
                                 attributes |= UserPasswdCantChange;
                             }
+                            break;
+                        case "Comment":
+                            if (null == componentId)
+                            {
+                                this.Messaging.Write(UtilErrors.IllegalAttributeWithoutComponent(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName));
+                            }
+
+                            comment = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
                             break;
                         case "CreateUser":
                             if (null == componentId)
@@ -3452,6 +3461,7 @@ namespace WixToolset.Util
                     Name = name,
                     Domain = domain,
                     Password = password,
+                    Comment = comment,
                     Attributes = attributes,
                 });
             }

--- a/src/ext/Util/wixext/UtilTableDefinitions.cs
+++ b/src/ext/Util/wixext/UtilTableDefinitions.cs
@@ -229,6 +229,7 @@ namespace WixToolset.Util
                 new ColumnDefinition("Name", ColumnType.String, 255, primaryKey: false, nullable: false, ColumnCategory.Formatted, description: "User name", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Domain", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User domain", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Password", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User password", modularizeType: ColumnModularizeType.Property),
+                new ColumnDefinition("Comment", ColumnType.String, 255, primaryKey: false, nullable: true, ColumnCategory.Formatted, description: "User comment", modularizeType: ColumnModularizeType.Property),
                 new ColumnDefinition("Attributes", ColumnType.Number, 4, primaryKey: false, nullable: true, ColumnCategory.Unknown, minValue: 0, maxValue: 65535, description: "Attributes describing how to create the user"),
             },
             symbolIdIsPrimaryKey: true

--- a/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
@@ -16,8 +16,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x64\dutil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\x86\dutil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\ARM64\dutil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x64\dutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\dutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\dutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -28,7 +27,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1244E671-F108-4334-BA52-8A7517F26ECD}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -36,13 +34,29 @@
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset native library foundation</Description>
     <PackageId>WixToolset.DUtil</PackageId>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-
   <Import Project="..\..\..\NativeMultiTargeting.Build.props" />
-
   <ItemGroup>
     <ClCompile Include="acl2util.cpp" />
     <ClCompile Include="aclutil.cpp" />
@@ -109,7 +123,6 @@
     <ClCompile Include="wuautil.cpp" />
     <ClCompile Include="xmlutil.cpp" />
   </ItemGroup>
-
   <ItemGroup>
     <ClInclude Include="inc\aclutil.h" />
     <ClInclude Include="inc\apputil.h" />
@@ -168,15 +181,12 @@
     <ClInclude Include="inc\xmlutil.h" />
     <ClInclude Include="precomp.h" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="xsd\thmutil.xsd" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
@@ -57,6 +57,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="..\..\..\NativeMultiTargeting.Build.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalOptions>/INCREMENTAL:No %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalOptions>/INCREMENTAL:No %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalOptions>/INCREMENTAL:No %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalOptions>/INCREMENTAL:No %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="acl2util.cpp" />
     <ClCompile Include="aclutil.cpp" />

--- a/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj.filters
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj.filters
@@ -302,9 +302,6 @@
     <ClInclude Include="inc\reswutil.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="inc\rmutil.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="inc\rexutil.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -373,6 +370,5 @@
     <None Include="xsd\thmutil.xsd">
       <Filter>Header Files</Filter>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/src/libs/dutil/test/DUtilUnitTest/FileUtilTest.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/FileUtilTest.cpp
@@ -58,9 +58,9 @@ namespace DutilTests
             LPWSTR sczOutputPath = NULL;
             FILE_ENCODING feEncodingFound = FILE_ENCODING_UNSPECIFIED;
             BYTE *pbFile1 = NULL;
-            DWORD cbFile1 = 0;
+            size_t cbFile1 = 0;
             BYTE *pbFile2 = NULL;
-            DWORD cbFile2 = 0;
+            size_t cbFile2 = 0;
             size_t cbActualStringLength = 0;
 
             try

--- a/src/libs/dutil/test/DUtilUnitTest/FileUtilTest.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/FileUtilTest.cpp
@@ -58,9 +58,9 @@ namespace DutilTests
             LPWSTR sczOutputPath = NULL;
             FILE_ENCODING feEncodingFound = FILE_ENCODING_UNSPECIFIED;
             BYTE *pbFile1 = NULL;
-            size_t cbFile1 = 0;
+            SIZE_T cbFile1 = 0;
             BYTE *pbFile2 = NULL;
-            size_t cbFile2 = 0;
+            SIZE_T cbFile2 = 0;
             size_t cbActualStringLength = 0;
 
             try

--- a/src/libs/dutil/test/DUtilUnitTest/MemUtilTest.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/MemUtilTest.cpp
@@ -23,7 +23,7 @@ namespace DutilTests
         void MemUtilAppendTest()
         {
             HRESULT hr = S_OK;
-            DWORD dwSize;
+            size_t dwSize;
             ArrayValue *rgValues = NULL;
             DWORD cValues = 0;
 

--- a/src/libs/dutil/test/DUtilUnitTest/MemUtilTest.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/MemUtilTest.cpp
@@ -23,7 +23,7 @@ namespace DutilTests
         void MemUtilAppendTest()
         {
             HRESULT hr = S_OK;
-            size_t dwSize;
+            SIZE_T dwSize;
             ArrayValue *rgValues = NULL;
             DWORD cValues = 0;
 

--- a/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
@@ -39,7 +39,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -48,7 +48,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(5, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(5, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -57,7 +57,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<DWORD>(7, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(7, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -98,14 +98,14 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion1->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(4, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(4, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion1->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(6, pVersion1->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(6, pVersion1->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<DWORD>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -118,9 +118,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(19, pVersion2->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(2, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(4, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(4, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, -1);
@@ -175,7 +175,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(3, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(3, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -184,7 +184,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(3, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(3, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -193,7 +193,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<DWORD>(1, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(1, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -202,7 +202,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion4->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion4->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion4->cReleaseLabels);
-                Assert::Equal<DWORD>(0, pVersion4->cchMetadataOffset);
+                Assert::Equal<size_t>(0, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion4->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion5, pVersion5->sczVersion);
@@ -215,9 +215,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion5->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion5->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion5->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(3, pVersion5->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(3, pVersion5->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(4, pVersion5->cchMetadataOffset);
+                Assert::Equal<size_t>(4, pVersion5->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion5->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion6, pVersion6->sczVersion);
@@ -230,9 +230,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion6->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(4, pVersion6->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion6->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(3, pVersion6->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(3, pVersion6->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(5, pVersion6->cchMetadataOffset);
+                Assert::Equal<size_t>(5, pVersion6->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion6->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -281,9 +281,9 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(6, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(6, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -296,9 +296,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion2->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(2, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(2, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(3, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(3, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -311,9 +311,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion3->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion3->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(2, pVersion3->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(2, pVersion3->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(3, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(3, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -363,14 +363,14 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(5, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(5, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(7, pVersion1->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(7, pVersion1->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<DWORD>(8, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(8, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -382,14 +382,14 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(6, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(6, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(8, pVersion2->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(8, pVersion2->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<DWORD>(9, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(9, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -401,18 +401,18 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion3->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(4, pVersion3->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(4, pVersion3->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pVersion3->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(6, pVersion3->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(6, pVersion3->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion3->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion3->rgReleaseLabels[2].dwValue);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<DWORD>(8, pVersion3->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<size_t>(8, pVersion3->rgReleaseLabels[2].cchLabelOffset);
 
-                Assert::Equal<DWORD>(9, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(9, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -424,18 +424,18 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion4->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion4->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(6, pVersion4->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(6, pVersion4->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pVersion4->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion4->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(8, pVersion4->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(8, pVersion4->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion4->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion4->rgReleaseLabels[2].dwValue);
                 Assert::Equal<DWORD>(3, pVersion4->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<DWORD>(10, pVersion4->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<size_t>(10, pVersion4->rgReleaseLabels[2].cchLabelOffset);
 
-                Assert::Equal<DWORD>(13, pVersion4->cchMetadataOffset);
+                Assert::Equal<size_t>(13, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion4->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -478,7 +478,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -487,7 +487,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -496,7 +496,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -539,7 +539,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(11, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(11, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion1, pVersion2->sczVersion);
@@ -548,7 +548,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(11, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(11, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion1, pVersion3->sczVersion);
@@ -557,7 +557,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<DWORD>(11, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(11, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -594,7 +594,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(4294967295, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4294967295, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(43, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(43, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -603,7 +603,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(0, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(0, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -638,7 +638,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -647,7 +647,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -680,7 +680,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(4, pSource->dwRevision);
                 Assert::Equal<DWORD>(0, pSource->cReleaseLabels);
 
-                Assert::Equal<DWORD>(8, pSource->cchMetadataOffset);
+                Assert::Equal<size_t>(8, pSource->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pSource->fInvalid);
 
                 hr = VerCopyVersion(pSource, &pCopy);
@@ -724,26 +724,26 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(8, pSource->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(8, pSource->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<DWORD>(10, pSource->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<size_t>(10, pSource->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<DWORD>(12, pSource->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<size_t>(12, pSource->rgReleaseLabels[2].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[3].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[3].cchLabel);
-                Assert::Equal<DWORD>(14, pSource->rgReleaseLabels[3].cchLabelOffset);
+                Assert::Equal<size_t>(14, pSource->rgReleaseLabels[3].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pSource->rgReleaseLabels[4].fNumeric);
                 Assert::Equal<DWORD>(5, pSource->rgReleaseLabels[4].dwValue);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[4].cchLabel);
-                Assert::Equal<DWORD>(16, pSource->rgReleaseLabels[4].cchLabelOffset);
+                Assert::Equal<size_t>(16, pSource->rgReleaseLabels[4].cchLabelOffset);
 
-                Assert::Equal<DWORD>(18, pSource->cchMetadataOffset);
+                Assert::Equal<size_t>(18, pSource->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pSource->fInvalid);
 
                 hr = VerCopyVersion(pSource, &pCopy);
@@ -813,7 +813,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(0, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(0, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -822,7 +822,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<DWORD>(2, pVersion2->cchMetadataOffset);
+                Assert::Equal<size_t>(2, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -831,7 +831,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<DWORD>(4, pVersion3->cchMetadataOffset);
+                Assert::Equal<size_t>(4, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -840,7 +840,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(1, pVersion4->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion4->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion4->cReleaseLabels);
-                Assert::Equal<DWORD>(6, pVersion4->cchMetadataOffset);
+                Assert::Equal<size_t>(6, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion4->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion5, pVersion5->sczVersion);
@@ -849,7 +849,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(2, pVersion5->dwPatch);
                 Assert::Equal<DWORD>(1, pVersion5->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion5->cReleaseLabels);
-                Assert::Equal<DWORD>(8, pVersion5->cchMetadataOffset);
+                Assert::Equal<size_t>(8, pVersion5->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion5->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion6, pVersion6->sczVersion);
@@ -858,7 +858,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion6->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion6->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion6->cReleaseLabels);
-                Assert::Equal<DWORD>(2, pVersion6->cchMetadataOffset);
+                Assert::Equal<size_t>(2, pVersion6->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion6->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion7, pVersion7->sczVersion);
@@ -870,9 +870,9 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion7->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion7->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<DWORD>(2, pVersion7->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<size_t>(2, pVersion7->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<DWORD>(4, pVersion7->cchMetadataOffset);
+                Assert::Equal<size_t>(4, pVersion7->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion7->fInvalid);
             }
             finally
@@ -904,7 +904,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<DWORD>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
             }
             finally

--- a/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
@@ -39,7 +39,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -48,7 +48,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(5, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(5, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -57,7 +57,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<size_t>(7, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(7, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -98,14 +98,14 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion1->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(4, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(4, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion1->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(6, pVersion1->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(6, pVersion1->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -118,9 +118,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(19, pVersion2->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(2, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(4, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(4, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, -1);
@@ -175,7 +175,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(3, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(3, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -184,7 +184,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(3, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(3, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -193,7 +193,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<size_t>(1, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(1, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -202,7 +202,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion4->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion4->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion4->cReleaseLabels);
-                Assert::Equal<size_t>(0, pVersion4->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(0, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion4->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion5, pVersion5->sczVersion);
@@ -215,9 +215,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion5->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion5->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion5->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(3, pVersion5->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(3, pVersion5->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(4, pVersion5->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(4, pVersion5->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion5->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion6, pVersion6->sczVersion);
@@ -230,9 +230,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion6->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(4, pVersion6->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion6->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(3, pVersion6->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(3, pVersion6->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(5, pVersion6->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(5, pVersion6->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion6->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -281,9 +281,9 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(6, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(6, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -296,9 +296,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion2->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(2, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(2, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(3, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(3, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -311,9 +311,9 @@ namespace DutilTests
                 Assert::Equal<BOOL>(TRUE, pVersion3->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(2, pVersion3->rgReleaseLabels[0].dwValue);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(2, pVersion3->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(2, pVersion3->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(3, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(3, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -363,14 +363,14 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion1->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(5, pVersion1->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(5, pVersion1->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion1->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion1->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(7, pVersion1->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(7, pVersion1->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<size_t>(8, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(8, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -382,14 +382,14 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion2->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(6, pVersion2->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(6, pVersion2->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion2->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[1].dwValue);
                 Assert::Equal<DWORD>(1, pVersion2->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(8, pVersion2->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(8, pVersion2->rgReleaseLabels[1].cchLabelOffset);
 
-                Assert::Equal<size_t>(9, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(9, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -401,18 +401,18 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion3->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(4, pVersion3->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(4, pVersion3->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pVersion3->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(6, pVersion3->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(6, pVersion3->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion3->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion3->rgReleaseLabels[2].dwValue);
                 Assert::Equal<DWORD>(1, pVersion3->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<size_t>(8, pVersion3->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<SIZE_T>(8, pVersion3->rgReleaseLabels[2].cchLabelOffset);
 
-                Assert::Equal<size_t>(9, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(9, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -424,18 +424,18 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion4->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion4->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(6, pVersion4->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(6, pVersion4->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pVersion4->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion4->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(8, pVersion4->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(8, pVersion4->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pVersion4->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(0, pVersion4->rgReleaseLabels[2].dwValue);
                 Assert::Equal<DWORD>(3, pVersion4->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<size_t>(10, pVersion4->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<SIZE_T>(10, pVersion4->rgReleaseLabels[2].cchLabelOffset);
 
-                Assert::Equal<size_t>(13, pVersion4->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(13, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion4->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -478,7 +478,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -487,7 +487,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -496,7 +496,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -539,7 +539,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(11, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(11, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion1, pVersion2->sczVersion);
@@ -548,7 +548,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(11, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(11, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion1, pVersion3->sczVersion);
@@ -557,7 +557,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(30, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(40, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<size_t>(11, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(11, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion3->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -594,7 +594,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(4294967295, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4294967295, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(43, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(43, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -603,7 +603,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(0, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(0, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
@@ -638,7 +638,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -647,7 +647,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion2->fInvalid);
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 0);
@@ -680,7 +680,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(4, pSource->dwRevision);
                 Assert::Equal<DWORD>(0, pSource->cReleaseLabels);
 
-                Assert::Equal<size_t>(8, pSource->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(8, pSource->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pSource->fInvalid);
 
                 hr = VerCopyVersion(pSource, &pCopy);
@@ -724,26 +724,26 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(8, pSource->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(8, pSource->rgReleaseLabels[0].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[1].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[1].cchLabel);
-                Assert::Equal<size_t>(10, pSource->rgReleaseLabels[1].cchLabelOffset);
+                Assert::Equal<SIZE_T>(10, pSource->rgReleaseLabels[1].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[2].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[2].cchLabel);
-                Assert::Equal<size_t>(12, pSource->rgReleaseLabels[2].cchLabelOffset);
+                Assert::Equal<SIZE_T>(12, pSource->rgReleaseLabels[2].cchLabelOffset);
 
                 Assert::Equal<BOOL>(FALSE, pSource->rgReleaseLabels[3].fNumeric);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[3].cchLabel);
-                Assert::Equal<size_t>(14, pSource->rgReleaseLabels[3].cchLabelOffset);
+                Assert::Equal<SIZE_T>(14, pSource->rgReleaseLabels[3].cchLabelOffset);
 
                 Assert::Equal<BOOL>(TRUE, pSource->rgReleaseLabels[4].fNumeric);
                 Assert::Equal<DWORD>(5, pSource->rgReleaseLabels[4].dwValue);
                 Assert::Equal<DWORD>(1, pSource->rgReleaseLabels[4].cchLabel);
-                Assert::Equal<size_t>(16, pSource->rgReleaseLabels[4].cchLabelOffset);
+                Assert::Equal<SIZE_T>(16, pSource->rgReleaseLabels[4].cchLabelOffset);
 
-                Assert::Equal<size_t>(18, pSource->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(18, pSource->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pSource->fInvalid);
 
                 hr = VerCopyVersion(pSource, &pCopy);
@@ -813,7 +813,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(0, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(0, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion1->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion2, pVersion2->sczVersion);
@@ -822,7 +822,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion2->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion2->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion2->cReleaseLabels);
-                Assert::Equal<size_t>(2, pVersion2->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(2, pVersion2->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion2->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion3, pVersion3->sczVersion);
@@ -831,7 +831,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion3->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion3->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion3->cReleaseLabels);
-                Assert::Equal<size_t>(4, pVersion3->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(4, pVersion3->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion3->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion4, pVersion4->sczVersion);
@@ -840,7 +840,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(1, pVersion4->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion4->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion4->cReleaseLabels);
-                Assert::Equal<size_t>(6, pVersion4->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(6, pVersion4->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion4->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion5, pVersion5->sczVersion);
@@ -849,7 +849,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(2, pVersion5->dwPatch);
                 Assert::Equal<DWORD>(1, pVersion5->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion5->cReleaseLabels);
-                Assert::Equal<size_t>(8, pVersion5->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(8, pVersion5->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion5->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion6, pVersion6->sczVersion);
@@ -858,7 +858,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(0, pVersion6->dwPatch);
                 Assert::Equal<DWORD>(0, pVersion6->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion6->cReleaseLabels);
-                Assert::Equal<size_t>(2, pVersion6->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(2, pVersion6->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion6->fInvalid);
 
                 NativeAssert::StringEqual(wzVersion7, pVersion7->sczVersion);
@@ -870,9 +870,9 @@ namespace DutilTests
 
                 Assert::Equal<BOOL>(FALSE, pVersion7->rgReleaseLabels[0].fNumeric);
                 Assert::Equal<DWORD>(1, pVersion7->rgReleaseLabels[0].cchLabel);
-                Assert::Equal<size_t>(2, pVersion7->rgReleaseLabels[0].cchLabelOffset);
+                Assert::Equal<SIZE_T>(2, pVersion7->rgReleaseLabels[0].cchLabelOffset);
 
-                Assert::Equal<size_t>(4, pVersion7->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(4, pVersion7->cchMetadataOffset);
                 Assert::Equal<BOOL>(TRUE, pVersion7->fInvalid);
             }
             finally
@@ -904,7 +904,7 @@ namespace DutilTests
                 Assert::Equal<DWORD>(3, pVersion1->dwPatch);
                 Assert::Equal<DWORD>(4, pVersion1->dwRevision);
                 Assert::Equal<DWORD>(0, pVersion1->cReleaseLabels);
-                Assert::Equal<size_t>(7, pVersion1->cchMetadataOffset);
+                Assert::Equal<SIZE_T>(7, pVersion1->cchMetadataOffset);
                 Assert::Equal<BOOL>(FALSE, pVersion1->fInvalid);
             }
             finally

--- a/src/libs/libs.sln
+++ b/src/libs/libs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dutil", "dutil\WixToolset.DUtil\dutil.vcxproj", "{1244E671-F108-4334-BA52-8A7517F26ECD}"
 EndProject
@@ -36,13 +36,15 @@ Global
 		{1244E671-F108-4334-BA52-8A7517F26ECD}.Release|x86.ActiveCfg = Release|Win32
 		{1244E671-F108-4334-BA52-8A7517F26ECD}.Release|x86.Build.0 = Release|Win32
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|ARM64.ActiveCfg = Debug|Win32
-		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|x64.ActiveCfg = Debug|Win32
+		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|ARM64.ActiveCfg = Debug|x64
+		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|x64.ActiveCfg = Debug|x64
+		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|x64.Build.0 = Debug|x64
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|x86.ActiveCfg = Debug|Win32
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Debug|x86.Build.0 = Debug|Win32
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|Any CPU.ActiveCfg = Release|Win32
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|ARM64.ActiveCfg = Release|Win32
-		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|x64.ActiveCfg = Release|Win32
+		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|x64.ActiveCfg = Release|x64
+		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|x64.Build.0 = Release|x64
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|x86.ActiveCfg = Release|Win32
 		{AB7EE608-E5FB-42A5-831F-0DEEEA141223}.Release|x86.Build.0 = Release|Win32
 		{5B3714B6-3A76-463E-8595-D48DA276C512}.Debug|Any CPU.ActiveCfg = Debug|Win32

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
@@ -19,8 +19,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x64\wcautil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\x86\wcautil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\ARM64\wcautil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x64\wcautil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\wcautil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\wcautil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcautil.vcxproj
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcautil.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -28,7 +27,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5B3714B6-3A76-463E-8595-D48DA276C512}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -37,17 +35,32 @@
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Custom Action native utility library</Description>
     <PackageId>WixToolset.WcaUtil</PackageId>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-
   <Import Project="..\..\..\NativeMultiTargeting.Build.props" />
-
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>..\..\dutil\WixToolset.DUtil\inc</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
-
   <ItemGroup>
     <ClCompile Include="exbinary.cpp" />
     <ClCompile Include="wcalog.cpp" />
@@ -60,7 +73,6 @@
     <ClCompile Include="wcawrap.cpp" />
     <ClCompile Include="qtexec.cpp" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(Platform)' == 'Win32'">
     <ClInclude Include="custommsierrors.h">
       <GenerateWixInclude>caerr.wxi</GenerateWixInclude>
@@ -76,11 +88,9 @@
     <ClInclude Include="inc\wcawow64.h" />
     <ClInclude Include="inc\wcawrapquery.h" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/wix.vsconfig
+++ b/src/wix.vsconfig
@@ -2,7 +2,7 @@
   "version": "1.0",
   "components": [
     "Microsoft.Net.Component.4.7.2.TargetingPack",
-    "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
-    "Microsoft.VisualStudio.Component.VC.v141.ARM64"
+    "Microsoft.VisualStudio.Component.VC.v143.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.v143.ARM64"
   ]
 }


### PR DESCRIPTION
Test produces a CreateUser folder on the desktop,
containing test.msi, which can be installed and
uninstalled for manual testing. This test is in need
of a virtual environment in which to safely run the
desired tests.

Tests should cover install and uninstall with
verification of user account (with comment) creation
and destruction.

Tests should also cover situations such as the user
account already existing and other options controlling
the possible options controlling the desired action.
