### PR TITLE
Add NativeMachine to Burn and WIX_NATIVE_MACHINE to UtilExtension

### DIFF
--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -97,6 +97,10 @@ static HRESULT InitializeVariableVersionNT(
     __in DWORD_PTR dwpData,
     __inout BURN_VARIANT* pValue
     );
+static HRESULT InitializeVariableNativeMachine(
+    __in DWORD_PTR dwpData,
+    __inout BURN_VARIANT* pValue
+    );
 static HRESULT InitializeVariableOsInfo(
     __in DWORD_PTR dwpData,
     __inout BURN_VARIANT* pValue
@@ -223,6 +227,7 @@ extern "C" HRESULT VariableInitialize(
         {L"LocalAppDataFolder", InitializeVariableCsidlFolder, CSIDL_LOCAL_APPDATA},
         {VARIABLE_LOGONUSER, InitializeVariableLogonUser, 0},
         {L"MyPicturesFolder", InitializeVariableCsidlFolder, CSIDL_MYPICTURES},
+        {L"NativeMachine", InitializeVariableNativeMachine, 0},
         {L"NTProductType", InitializeVariableOsInfo, OS_INFO_VARIABLE_NTProductType},
         {L"NTSuiteBackOffice", InitializeVariableOsInfo, OS_INFO_VARIABLE_NTSuiteBackOffice},
         {L"NTSuiteDataCenter", InitializeVariableOsInfo, OS_INFO_VARIABLE_NTSuiteDataCenter},
@@ -1821,6 +1826,26 @@ static HRESULT InitializeVariableSystemInfo(
     }
 
     hr = BVariantCopy(&value, pValue);
+    ExitOnFailure(hr, "Failed to set variant value.");
+
+LExit:
+    return hr;
+}
+
+static HRESULT InitializeVariableNativeMachine(
+    __in DWORD_PTR dwpData,
+    __inout BURN_VARIANT* pValue
+    )
+{
+    UNREFERENCED_PARAMETER(dwpData);
+    
+    HRESULT hr = S_OK;
+    USHORT usNativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+
+    hr = ProcNativeMachine(::GetCurrentProcess(), &usNativeMachine);
+    ExitOnFailure(hr, "Failed to get native machine value.");
+    
+    hr = BVariantSetNumeric(pValue, usNativeMachine);
     ExitOnFailure(hr, "Failed to set variant value.");
 
 LExit:

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -1845,8 +1845,11 @@ static HRESULT InitializeVariableNativeMachine(
     hr = ProcNativeMachine(::GetCurrentProcess(), &usNativeMachine);
     ExitOnFailure(hr, "Failed to get native machine value.");
     
-    hr = BVariantSetNumeric(pValue, usNativeMachine);
-    ExitOnFailure(hr, "Failed to set variant value.");
+    if (hr != S_FALSE)
+    {
+        hr = BVariantSetNumeric(pValue, usNativeMachine);
+        ExitOnFailure(hr, "Failed to set variant value.");
+    }
 
 LExit:
     return hr;

--- a/src/burn/test/BurnUnitTest/VariableTest.cpp
+++ b/src/burn/test/BurnUnitTest/VariableTest.cpp
@@ -477,6 +477,7 @@ namespace Bootstrapper
                 Assert::Equal(E_INVALIDARG, hr);
                 Assert::False(EvaluateConditionHelper(&variables, L"VersionNT = \"VAL\""));
 
+                VariableGetNumericHelper(&variables, L"NativeMachine");
                 VariableGetNumericHelper(&variables, L"NTProductType");
                 VariableGetNumericHelper(&variables, L"NTSuiteBackOffice");
                 VariableGetNumericHelper(&variables, L"NTSuiteDataCenter");

--- a/src/ext/Util/ca/OsInfo.cpp
+++ b/src/ext/Util/ca/OsInfo.cpp
@@ -506,7 +506,10 @@ extern "C" UINT __stdcall WixQueryNativeMachine(
     hr = ::ProcNativeMachine(::GetCurrentProcess(), &usNativeMachine);
     ExitOnFailure(hr, "Failed to get native machine value.");
 
-    WcaSetIntProperty(L"WIX_NATIVE_MACHINE", usNativeMachine);
+    if (hr != S_FALSE)
+    {
+        WcaSetIntProperty(L"WIX_NATIVE_MACHINE", usNativeMachine);
+    }
 
 LExit:
     if (FAILED(hr))

--- a/src/ext/Util/ca/OsInfo.cpp
+++ b/src/ext/Util/ca/OsInfo.cpp
@@ -485,3 +485,31 @@ LExit:
     }
     return WcaFinalize(er);
 }
+
+/********************************************************************
+WixQueryNativeMachine - entry point for WixQueryNativeMachine custom action
+
+ Called as Type 1 custom action (DLL from the Binary table) from 
+ Windows Installer to set properties that indicates the native machine architecture
+********************************************************************/
+extern "C" UINT __stdcall WixQueryNativeMachine(
+    __in MSIHANDLE hInstall
+    )
+{
+    HRESULT hr = S_OK;
+    USHORT usNativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+    DWORD er = ERROR_SUCCESS;
+
+    hr = WcaInitialize(hInstall, "WixQueryNativeMachine");
+    ExitOnFailure(hr, "WixQueryNativeMachine failed to initialize");
+    
+    hr = ::ProcNativeMachine(::GetCurrentProcess(), &usNativeMachine);
+    ExitOnFailure(hr, "Failed to get native machine value.");
+
+    WcaSetIntProperty(L"WIX_NATIVE_MACHINE", usNativeMachine);
+
+LExit:
+    if (FAILED(hr))
+        er = ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}

--- a/src/ext/Util/ca/utilca.def
+++ b/src/ext/Util/ca/utilca.def
@@ -22,6 +22,7 @@ EXPORTS
     WixQueryOsDirs
     WixQueryOsWellKnownSID
     WixQueryOsDriverInfo
+    WixQueryNativeMachine
 ; netshortcuts.cpp
     WixSchedInternetShortcuts
     WixCreateInternetShortcuts

--- a/src/ext/Util/wixlib/UtilExtension_Platform.wxi
+++ b/src/ext/Util/wixlib/UtilExtension_Platform.wxi
@@ -353,6 +353,18 @@
             <Custom Action="$(var.Prefix)QueryOsDriverInfo$(var.Suffix)" After="AppSearch" Overridable="yes" Condition="VersionNT &gt; 400 OR (VersionNT = 400 AND ServicePackLevel &gt; 3)" />
         </InstallUISequence>
     </Fragment>
+    
+    <Fragment>
+        <CustomAction Id="$(var.Prefix)QueryNativeMachine$(var.Suffix)" DllEntry="WixQueryNativeMachine" Execute="firstSequence" Return="check" SuppressModularization="yes" BinaryRef="$(var.Prefix)UtilCA$(var.Suffix)" />
+
+        <InstallExecuteSequence>
+            <Custom Action="$(var.Prefix)QueryNativeMachine$(var.Suffix)" After="AppSearch" Overridable="yes" Condition="VersionNT &gt; 400 OR (VersionNT = 400 AND ServicePackLevel &gt; 3)" />
+        </InstallExecuteSequence>
+
+        <InstallUISequence>
+            <Custom Action="$(var.Prefix)QueryNativeMachine$(var.Suffix)" After="AppSearch" Overridable="yes" Condition="VersionNT &gt; 400 OR (VersionNT = 400 AND ServicePackLevel &gt; 3)" />
+        </InstallUISequence>
+    </Fragment>
 
     <Fragment>
         <Binary Id="$(var.Prefix)UtilCA$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))utilca.dll" />

--- a/src/libs/dutil/WixToolset.DUtil/inc/procutil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/procutil.h
@@ -22,6 +22,10 @@ HRESULT DAPI ProcWow64(
     __in HANDLE hProcess,
     __out BOOL* pfWow64
     );
+HRESULT DAPI ProcNativeMachine(
+    __in HANDLE hProcess,
+    __out USHORT* pusNativeMachine
+    );
 HRESULT DAPI ProcDisableWowFileSystemRedirection(
     __in PROC_FILESYSTEMREDIRECTION* pfsr
     );

--- a/src/libs/dutil/WixToolset.DUtil/procutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/procutil.cpp
@@ -124,7 +124,8 @@ extern "C" HRESULT DAPI ProcNativeMachine(
     __out USHORT* pusNativeMachine
     )
 {
-    HRESULT hr = S_OK;
+    // S_FALSE will indicate that the method is not supported.
+    HRESULT hr = S_FALSE;
 
     typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2)(HANDLE, USHORT *, USHORT *);
     LPFN_ISWOW64PROCESS2 pfnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process2");
@@ -136,6 +137,7 @@ extern "C" HRESULT DAPI ProcNativeMachine(
         {
             ExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process2.");
         }
+        hr = S_OK;
     }
 
 LExit:

--- a/src/libs/dutil/WixToolset.DUtil/procutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/procutil.cpp
@@ -88,32 +88,55 @@ extern "C" HRESULT DAPI ProcWow64(
 
     if (pfnIsWow64Process2)
     {
-        USHORT pProcessMachine = IMAGE_FILE_MACHINE_UNKNOWN;
-        if (!pfnIsWow64Process2(hProcess, &pProcessMachine, nullptr))
+        USHORT usProcessMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+        if (!pfnIsWow64Process2(hProcess, &usProcessMachine, nullptr))
         {
             ProcExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process2.");
         }
 
-        if (pProcessMachine != IMAGE_FILE_MACHINE_UNKNOWN)
+        if (usProcessMachine != IMAGE_FILE_MACHINE_UNKNOWN)
         {
             fIsWow64 = TRUE;
         }
     }
     else
     {
-    typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
-    LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process");
+        typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
+        LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process");
 
-    if (pfnIsWow64Process)
-    {
-        if (!pfnIsWow64Process(hProcess, &fIsWow64))
+        if (pfnIsWow64Process)
         {
+            if (!pfnIsWow64Process(hProcess, &fIsWow64))
+            {
                 ProcExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process.");
             }
         }
     }
 
     *pfWow64 = fIsWow64;
+
+LExit:
+    return hr;
+}
+
+extern "C" HRESULT DAPI ProcNativeMachine(
+    __in HANDLE hProcess,
+    __out USHORT* pusNativeMachine
+    )
+{
+    HRESULT hr = S_OK;
+
+    typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2)(HANDLE, USHORT *, USHORT *);
+    LPFN_ISWOW64PROCESS2 pfnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process2");
+
+    if (pfnIsWow64Process2)
+    {
+        USHORT usProcessMachineUnused = IMAGE_FILE_MACHINE_UNKNOWN;
+        if (!pfnIsWow64Process2(hProcess, &usProcessMachineUnused, pusNativeMachine))
+        {
+            ExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process2.");
+        }
+    }
 
 LExit:
     return hr;

--- a/src/wix/WixToolset.Converters/WixConverter.cs
+++ b/src/wix/WixToolset.Converters/WixConverter.cs
@@ -1374,6 +1374,9 @@ namespace WixToolset.Converters
                 case "WIX_ACCOUNT_PERFLOGUSERS_NODOMAIN":
                     newElementName = "QueryWindowsWellKnownSIDs";
                     break;
+                case "WIX_NATIVE_MACHINE":
+                    newElementName = "QueryNativeMachine";
+                    break;
             }
 
             if (!String.IsNullOrEmpty(newElementName)

--- a/src/wix/WixToolset.Core/CompilerCore.cs
+++ b/src/wix/WixToolset.Core/CompilerCore.cs
@@ -61,6 +61,7 @@ namespace WixToolset.Core
                 "LocalAppDataFolder",
                 "LogonUser",
                 "MyPicturesFolder",
+                "NativeMachine",
                 "NTProductType",
                 "NTSuiteBackOffice",
                 "NTSuiteDataCenter",


### PR DESCRIPTION
Add the ability for bundles and MSI's to detect when running on an ARM64 machine.

This directly plumbs the result of https://docs.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2 `pNativeMachine` argument, which is documented as 
> On success, returns a pointer to a possible [IMAGE_FILE_MACHINE_*](https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants) value identifying the native architecture of host system.

Issue: https://github.com/wixtoolset/issues/issues/6556
Wix3: https://github.com/wixtoolset/wix3/pull/538