### PR TITLE
Make heat use passed in extensions

### DIFF
--- a/src/wix/heat/AssemblyHarvester.cs
+++ b/src/wix/heat/AssemblyHarvester.cs
@@ -10,7 +10,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from an assembly file.
     /// </summary>
-    public class AssemblyHarvester
+    public sealed class AssemblyHarvester
     {
         /// <summary>
         /// Harvest the registry values written by RegisterAssembly.

--- a/src/wix/heat/AssemblyHarvester.cs
+++ b/src/wix/heat/AssemblyHarvester.cs
@@ -10,7 +10,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from an assembly file.
     /// </summary>
-    internal class AssemblyHarvester
+    public class AssemblyHarvester
     {
         /// <summary>
         /// Harvest the registry values written by RegisterAssembly.

--- a/src/wix/heat/DirectoryHarvester.cs
+++ b/src/wix/heat/DirectoryHarvester.cs
@@ -12,7 +12,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a directory from the file system.
     /// </summary>
-    internal class DirectoryHarvester : BaseHarvesterExtension
+    public class DirectoryHarvester : BaseHarvesterExtension
     {
         private FileHarvester fileHarvester;
 

--- a/src/wix/heat/DirectoryHarvester.cs
+++ b/src/wix/heat/DirectoryHarvester.cs
@@ -12,7 +12,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a directory from the file system.
     /// </summary>
-    public class DirectoryHarvester : BaseHarvesterExtension
+    public sealed class DirectoryHarvester : BaseHarvesterExtension
     {
         private FileHarvester fileHarvester;
 

--- a/src/wix/heat/DllHarvester.cs
+++ b/src/wix/heat/DllHarvester.cs
@@ -11,7 +11,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from a native DLL file.
     /// </summary>
-    public class DllHarvester
+    public sealed class DllHarvester
     {
         /// <summary>
         /// Harvest the registry values written by calling DllRegisterServer on the specified file.

--- a/src/wix/heat/DllHarvester.cs
+++ b/src/wix/heat/DllHarvester.cs
@@ -11,7 +11,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from a native DLL file.
     /// </summary>
-    internal class DllHarvester
+    public class DllHarvester
     {
         /// <summary>
         /// Harvest the registry values written by calling DllRegisterServer on the specified file.

--- a/src/wix/heat/FileHarvester.cs
+++ b/src/wix/heat/FileHarvester.cs
@@ -12,7 +12,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a file from the file system.
     /// </summary>
-    internal class FileHarvester : BaseHarvesterExtension
+    public class FileHarvester : BaseHarvesterExtension
     {
         private string rootedDirectoryRef;
         private bool setUniqueIdentifiers;

--- a/src/wix/heat/FileHarvester.cs
+++ b/src/wix/heat/FileHarvester.cs
@@ -12,7 +12,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a file from the file system.
     /// </summary>
-    public class FileHarvester : BaseHarvesterExtension
+    public sealed class FileHarvester : BaseHarvesterExtension
     {
         private string rootedDirectoryRef;
         private bool setUniqueIdentifiers;

--- a/src/wix/heat/IIsFinalizeHarvesterMutator.cs
+++ b/src/wix/heat/IIsFinalizeHarvesterMutator.cs
@@ -13,7 +13,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The finalize harvester mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    internal class IIsFinalizeHarvesterMutator : BaseMutatorExtension
+    public class IIsFinalizeHarvesterMutator : BaseMutatorExtension
     {
         private Hashtable directoryPaths;
         private Hashtable filePaths;

--- a/src/wix/heat/IIsFinalizeHarvesterMutator.cs
+++ b/src/wix/heat/IIsFinalizeHarvesterMutator.cs
@@ -13,7 +13,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The finalize harvester mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    public class IIsFinalizeHarvesterMutator : BaseMutatorExtension
+    public sealed class IIsFinalizeHarvesterMutator : BaseMutatorExtension
     {
         private Hashtable directoryPaths;
         private Hashtable filePaths;

--- a/src/wix/heat/IIsHarvesterMutator.cs
+++ b/src/wix/heat/IIsHarvesterMutator.cs
@@ -13,7 +13,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The harvester mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    public class IIsHarvesterMutator : BaseMutatorExtension
+    public sealed class IIsHarvesterMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private DirectoryHarvester directoryHarvester;

--- a/src/wix/heat/IIsHarvesterMutator.cs
+++ b/src/wix/heat/IIsHarvesterMutator.cs
@@ -13,7 +13,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The harvester mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    internal class IIsHarvesterMutator : BaseMutatorExtension
+    public class IIsHarvesterMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private DirectoryHarvester directoryHarvester;

--- a/src/wix/heat/IIsHeatExtension.cs
+++ b/src/wix/heat/IIsHeatExtension.cs
@@ -8,7 +8,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// An IIS harvesting extension for the WiX Toolset Harvester application.
     /// </summary>
-    public class IIsHeatExtension : BaseHeatExtension
+    public sealed class IIsHeatExtension : BaseHeatExtension
     {
         /// <summary>
         /// Gets the supported command line types for this extension.

--- a/src/wix/heat/IIsHeatExtension.cs
+++ b/src/wix/heat/IIsHeatExtension.cs
@@ -8,7 +8,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// An IIS harvesting extension for the WiX Toolset Harvester application.
     /// </summary>
-    internal class IIsHeatExtension : BaseHeatExtension
+    public class IIsHeatExtension : BaseHeatExtension
     {
         /// <summary>
         /// Gets the supported command line types for this extension.

--- a/src/wix/heat/IIsWebSiteHarvester.cs
+++ b/src/wix/heat/IIsWebSiteHarvester.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The web site harvester for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    internal class IIsWebSiteHarvester : BaseHarvesterExtension
+    public class IIsWebSiteHarvester : BaseHarvesterExtension
     {
         /// <summary>
         /// Harvest a WiX document.

--- a/src/wix/heat/IIsWebSiteHarvester.cs
+++ b/src/wix/heat/IIsWebSiteHarvester.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The web site harvester for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    public class IIsWebSiteHarvester : BaseHarvesterExtension
+    public sealed class IIsWebSiteHarvester : BaseHarvesterExtension
     {
         /// <summary>
         /// Harvest a WiX document.

--- a/src/wix/heat/PayloadHarvester.cs
+++ b/src/wix/heat/PayloadHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a payload from the file system.
     /// </summary>
-    internal class PayloadHarvester : BaseHarvesterExtension
+    public class PayloadHarvester : BaseHarvesterExtension
     {
         private bool setUniqueIdentifiers;
         private WixBundlePackageType packageType;

--- a/src/wix/heat/PayloadHarvester.cs
+++ b/src/wix/heat/PayloadHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a payload from the file system.
     /// </summary>
-    public class PayloadHarvester : BaseHarvesterExtension
+    public sealed class PayloadHarvester : BaseHarvesterExtension
     {
         private bool setUniqueIdentifiers;
         private WixBundlePackageType packageType;

--- a/src/wix/heat/PerformanceCategoryHarvester.cs
+++ b/src/wix/heat/PerformanceCategoryHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a file from the file system.
     /// </summary>
-    public class PerformanceCategoryHarvester : BaseHarvesterExtension
+    public sealed class PerformanceCategoryHarvester : BaseHarvesterExtension
     {
         /// <summary>
         /// Harvest a performance category.

--- a/src/wix/heat/PerformanceCategoryHarvester.cs
+++ b/src/wix/heat/PerformanceCategoryHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a file from the file system.
     /// </summary>
-    internal class PerformanceCategoryHarvester : BaseHarvesterExtension
+    public class PerformanceCategoryHarvester : BaseHarvesterExtension
     {
         /// <summary>
         /// Harvest a performance category.
@@ -71,8 +71,8 @@ namespace WixToolset.Harvesters
                 {
                     perfCategory.MultiInstance = Util.YesNoType.yes;
                 }
-                
-                // If it's multi-instance, check if there are any instances and get counters from there; else we get 
+
+                // If it's multi-instance, check if there are any instances and get counters from there; else we get
                 // the counters straight up. For multi-instance, GetCounters() fails if there are any instances. If there
                 // are no instances, then GetCounters(instance) can't be called since there is no instance. Instances
                 // will exist for each counter even if only one of the counters was "intialized."
@@ -81,7 +81,7 @@ namespace WixToolset.Harvesters
                 PerformanceCounter[] counters = hasInstances
                     ? pcc.GetCounters(instances.First())
                     : pcc.GetCounters();
-                    
+
                 foreach (PerformanceCounter counter in counters)
                 {
                     Util.PerformanceCounter perfCounter = new Util.PerformanceCounter();

--- a/src/wix/heat/Program.cs
+++ b/src/wix/heat/Program.cs
@@ -13,6 +13,7 @@ namespace WixToolset.Tools.Heat
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
     using WixToolset.Harvesters;
+    using WixToolset.Harvesters.Extensibility;
     using WixToolset.Tools.Core;
 
     /// <summary>
@@ -70,7 +71,14 @@ namespace WixToolset.Tools.Heat
             var arguments = serviceProvider.GetService<ICommandLineArguments>();
             arguments.Populate(args);
 
-            var commandLine = HeatCommandLineFactory.CreateCommandLine(serviceProvider);
+            var extensionManager = serviceProvider.GetService<IExtensionManager>();
+            foreach (var extension in arguments.Extensions)
+            {
+                extensionManager.Load(extension);
+            }
+            var heatExtensions = extensionManager.GetServices<IHeatExtension>();
+
+            var commandLine = HeatCommandLineFactory.CreateCommandLine(serviceProvider, heatExtensions);
             var command = commandLine.ParseStandardCommandLine(arguments);
             return command?.ExecuteAsync(CancellationToken.None) ?? Task.FromResult(1);
         }

--- a/src/wix/heat/RegFileHarvester.cs
+++ b/src/wix/heat/RegFileHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a reg file.
     /// </summary>
-    internal class RegFileHarvester : BaseHarvesterExtension
+    public class RegFileHarvester : BaseHarvesterExtension
     {
         private static readonly string ComponentPrefix = "cmp";
 
@@ -295,25 +295,25 @@ namespace WixToolset.Harvesters
                 value = parts[1].Substring(4);
                 type = Wix.RegistryValue.TypeType.binary;
             }
-            else if (parts[1].StartsWith("dword:")) 
+            else if (parts[1].StartsWith("dword:"))
             {
                 // dword
                 value = parts[1].Substring(6);
                 type = Wix.RegistryValue.TypeType.integer;
             }
-            else if (parts[1].StartsWith("hex(2):")) 
+            else if (parts[1].StartsWith("hex(2):"))
             {
                 // expandable string
                 value = parts[1].Substring(7);
                 type = Wix.RegistryValue.TypeType.expandable;
             }
-            else if (parts[1].StartsWith("hex(7):")) 
+            else if (parts[1].StartsWith("hex(7):"))
             {
                 // multi-string
                 value = parts[1].Substring(7);
                 type = Wix.RegistryValue.TypeType.multiString;
             }
-            else if (parts[1].StartsWith("hex(")) 
+            else if (parts[1].StartsWith("hex("))
             {
                 // Give a better error when we find something that isn't supported
                 // by specifying the type that isn't supported.
@@ -332,7 +332,7 @@ namespace WixToolset.Harvesters
                 type = 0;
                 return false;
             }
-            else if (parts[1].StartsWith("\"")) 
+            else if (parts[1].StartsWith("\""))
             {
                 // string
                 value = parts[1].Substring(1, parts[1].Length - 2);

--- a/src/wix/heat/RegFileHarvester.cs
+++ b/src/wix/heat/RegFileHarvester.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for a reg file.
     /// </summary>
-    public class RegFileHarvester : BaseHarvesterExtension
+    public sealed class RegFileHarvester : BaseHarvesterExtension
     {
         private static readonly string ComponentPrefix = "cmp";
 

--- a/src/wix/heat/RegistryHarvester.cs
+++ b/src/wix/heat/RegistryHarvester.cs
@@ -16,7 +16,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from the registry.
     /// </summary>
-    public class RegistryHarvester : IDisposable
+    public sealed class RegistryHarvester : IDisposable
     {
         private const string HKCRPathInHKLM = @"Software\Classes";
         private string remappedPath;

--- a/src/wix/heat/RegistryHarvester.cs
+++ b/src/wix/heat/RegistryHarvester.cs
@@ -16,7 +16,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from the registry.
     /// </summary>
-    internal class RegistryHarvester : IDisposable
+    public class RegistryHarvester : IDisposable
     {
         private const string HKCRPathInHKLM = @"Software\Classes";
         private string remappedPath;
@@ -69,7 +69,7 @@ namespace WixToolset.Harvesters
                     this.RemapRegistryKey(NativeMethods.HkeyUsers, String.Concat(this.remappedPath, @"\\HKEY_USERS"));
                     this.RemapRegistryKey(NativeMethods.HkeyCurrentUser, String.Concat(this.remappedPath, @"\\HKEY_CURRENT_USER"));
 
-                    // Typelib registration on Windows Vista requires that the key 
+                    // Typelib registration on Windows Vista requires that the key
                     // HKLM\Software\Classes exist, so add it to the remapped root
                     Registry.LocalMachine.CreateSubKey(HKCRPathInHKLM);
                 }

--- a/src/wix/heat/TypeLibraryHarvester.cs
+++ b/src/wix/heat/TypeLibraryHarvester.cs
@@ -10,7 +10,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from a type library file.
     /// </summary>
-    public class TypeLibraryHarvester
+    public sealed class TypeLibraryHarvester
     {
         /// <summary>
         /// Harvest the registry values written by RegisterTypeLib.

--- a/src/wix/heat/TypeLibraryHarvester.cs
+++ b/src/wix/heat/TypeLibraryHarvester.cs
@@ -10,7 +10,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring from a type library file.
     /// </summary>
-    internal class TypeLibraryHarvester
+    public class TypeLibraryHarvester
     {
         /// <summary>
         /// Harvest the registry values written by RegisterTypeLib.

--- a/src/wix/heat/UtilFinalizeHarvesterMutator.cs
+++ b/src/wix/heat/UtilFinalizeHarvesterMutator.cs
@@ -17,7 +17,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The finalize harvester mutator for the WiX Toolset Utility Extension.
     /// </summary>
-    public class UtilFinalizeHarvesterMutator : BaseMutatorExtension
+    public sealed class UtilFinalizeHarvesterMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private ArrayList directories;

--- a/src/wix/heat/UtilFinalizeHarvesterMutator.cs
+++ b/src/wix/heat/UtilFinalizeHarvesterMutator.cs
@@ -17,7 +17,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The finalize harvester mutator for the WiX Toolset Utility Extension.
     /// </summary>
-    internal class UtilFinalizeHarvesterMutator : BaseMutatorExtension
+    public class UtilFinalizeHarvesterMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private ArrayList directories;
@@ -996,7 +996,7 @@ namespace WixToolset.Harvesters
 
                     // escape literal $ characters
                     file.Source = file.Source.Replace("$", "$$");
-                    
+
                     if (null != sourceDirSubstitution && file.Source.StartsWith("SourceDir\\", StringComparison.Ordinal))
                     {
                         file.Source = file.Source.Substring(9).Insert(0, sourceDirSubstitution);
@@ -1059,7 +1059,7 @@ namespace WixToolset.Harvesters
                 }
             }
 
-        
+
             ArrayList reversedDirectoryPaths = new ArrayList();
 
             // reverse the indexed directory paths to ensure the longest paths are found first
@@ -1090,7 +1090,7 @@ namespace WixToolset.Harvesters
                 }
             }
         }
-        
+
         private static bool IsVb6RegistryValue(Wix.RegistryValue registryValue)
         {
             if (Wix.RegistryValue.ActionType.write == registryValue.Action && Wix.RegistryRootType.HKCR == registryValue.Root)

--- a/src/wix/heat/UtilHarvesterMutator.cs
+++ b/src/wix/heat/UtilHarvesterMutator.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The WiX Toolset harvester mutator.
     /// </summary>
-    public class UtilHarvesterMutator : BaseMutatorExtension
+    public sealed class UtilHarvesterMutator : BaseMutatorExtension
     {
         // Flags for SetErrorMode() native method.
         private const UInt32 SEM_FAILCRITICALERRORS = 0x0001;

--- a/src/wix/heat/UtilHarvesterMutator.cs
+++ b/src/wix/heat/UtilHarvesterMutator.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The WiX Toolset harvester mutator.
     /// </summary>
-    internal class UtilHarvesterMutator : BaseMutatorExtension
+    public class UtilHarvesterMutator : BaseMutatorExtension
     {
         // Flags for SetErrorMode() native method.
         private const UInt32 SEM_FAILCRITICALERRORS = 0x0001;

--- a/src/wix/heat/UtilHeatExtension.cs
+++ b/src/wix/heat/UtilHeatExtension.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// A utility heat extension for the WiX Toolset Harvester application.
     /// </summary>
-    internal class UtilHeatExtension : BaseHeatExtension
+    public class UtilHeatExtension : BaseHeatExtension
     {
         public UtilHeatExtension(IServiceProvider serviceProvider)
         {
@@ -44,7 +44,7 @@ namespace WixToolset.Harvesters
                     new HeatCommandLineOption("-cg <ComponentGroupName>", "component group name (cannot contain spaces e.g -cg MyComponentGroup)"),
                     new HeatCommandLineOption("-dr <DirectoryName>", "directory reference to root directories (cannot contain spaces e.g. -dr MyAppDirRef)"),
                     new HeatCommandLineOption("-var <VariableName>", "substitute File/@Source=\"SourceDir\" with a preprocessor or a wix variable" + Environment.NewLine +
-                                                      "(e.g. -var var.MySource will become File/@Source=\"$(var.MySource)\\myfile.txt\" and " + Environment.NewLine + 
+                                                      "(e.g. -var var.MySource will become File/@Source=\"$(var.MySource)\\myfile.txt\" and " + Environment.NewLine +
                                                       "-var wix.MySource will become File/@Source=\"!(wix.MySource)\\myfile.txt\""),
                     new HeatCommandLineOption("-gg", "generate guids now"),
                     new HeatCommandLineOption("-g1", "generated guids are not in brackets"),
@@ -379,7 +379,7 @@ namespace WixToolset.Harvesters
         {
             string truncatedCommandSwitch = args[index];
             string commandSwitchValue = args[index + 1];
-            
+
             //increment the index to the switch value
             index++;
 

--- a/src/wix/heat/UtilHeatExtension.cs
+++ b/src/wix/heat/UtilHeatExtension.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// A utility heat extension for the WiX Toolset Harvester application.
     /// </summary>
-    public class UtilHeatExtension : BaseHeatExtension
+    public sealed class UtilHeatExtension : BaseHeatExtension
     {
         public UtilHeatExtension(IServiceProvider serviceProvider)
         {

--- a/src/wix/heat/UtilMutator.cs
+++ b/src/wix/heat/UtilMutator.cs
@@ -13,7 +13,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The template type.
     /// </summary>
-    internal enum TemplateType
+    public enum TemplateType
     {
         /// <summary>
         /// A fragment template.
@@ -34,7 +34,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    internal class UtilMutator : BaseMutatorExtension
+    public class UtilMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private ArrayList componentGroups;
@@ -108,10 +108,10 @@ namespace WixToolset.Harvesters
 
         /// <summary>
         /// Gets or sets the option to set the format of guids.
-        /// D - 32 digits separated by hyphens: 
-        ///     xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx 
-        /// B - 32 digits separated by hyphens, enclosed in brackets: 
-        ///     {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx} 
+        /// D - 32 digits separated by hyphens:
+        ///     xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        /// B - 32 digits separated by hyphens, enclosed in brackets:
+        ///     {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
         /// </summary>
         /// <value>Guid format either B or D.</value>
         public string GuidFormat

--- a/src/wix/heat/UtilMutator.cs
+++ b/src/wix/heat/UtilMutator.cs
@@ -34,7 +34,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// The mutator for the WiX Toolset Internet Information Services Extension.
     /// </summary>
-    public class UtilMutator : BaseMutatorExtension
+    public sealed class UtilMutator : BaseMutatorExtension
     {
         private ArrayList components;
         private ArrayList componentGroups;

--- a/src/wix/heat/UtilTransformMutator.cs
+++ b/src/wix/heat/UtilTransformMutator.cs
@@ -9,7 +9,7 @@ namespace WixToolset.Harvesters
     using WixToolset.Harvesters.Data;
     using WixToolset.Harvesters.Extensibility;
 
-    public class UtilTransformMutator : BaseMutatorExtension
+    public sealed class UtilTransformMutator : BaseMutatorExtension
     {
         private string transform;
         private int transformSequence;

--- a/src/wix/heat/UtilTransformMutator.cs
+++ b/src/wix/heat/UtilTransformMutator.cs
@@ -9,7 +9,7 @@ namespace WixToolset.Harvesters
     using WixToolset.Harvesters.Data;
     using WixToolset.Harvesters.Extensibility;
 
-    internal class UtilTransformMutator : BaseMutatorExtension
+    public class UtilTransformMutator : BaseMutatorExtension
     {
         private string transform;
         private int transformSequence;

--- a/src/wix/heat/VSHeatExtension.cs
+++ b/src/wix/heat/VSHeatExtension.cs
@@ -11,7 +11,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Defines generated element types.
     /// </summary>
-    internal enum GenerateType
+    public enum GenerateType
     {
         /// <summary>Generate Components.</summary>
         Components,
@@ -29,7 +29,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// VS-related extensions for the WiX Toolset Harvester application.
     /// </summary>
-    internal class VSHeatExtension : BaseHeatExtension
+    public class VSHeatExtension : BaseHeatExtension
     {
         /// <summary>
         /// Gets the supported command line types for this extension.
@@ -45,7 +45,7 @@ namespace WixToolset.Harvesters
                     new HeatCommandLineOption("-configuration", "configuration to set when harvesting the project"),
                     new HeatCommandLineOption("-directoryid", "overridden directory id for generated directory elements"),
                     new HeatCommandLineOption("-generate", Environment.NewLine +
-                        "            specify what elements to generate, one of:" + Environment.NewLine + 
+                        "            specify what elements to generate, one of:" + Environment.NewLine +
                         "                components, container, payloadgroup, packagegroup" + Environment.NewLine +
                         "                (default is components)"),
                     new HeatCommandLineOption("-msbuildbinpath", "msbuild bin directory path"),
@@ -94,7 +94,7 @@ namespace WixToolset.Harvesters
                         {
                             throw new WixException(HarvesterErrors.InvalidDirectoryId(args[i]));
                         }
-                        
+
                         directoryIds = args[i];
                     }
                     else if ("-generate" == args[i])
@@ -187,7 +187,7 @@ namespace WixToolset.Harvesters
                         {
                             throw new WixException(HarvesterErrors.InvalidProjectName(args[i]));
                         }
-                        
+
                         projectName = args[i];
                     }
                     else if ("-suid" == args[i])

--- a/src/wix/heat/VSHeatExtension.cs
+++ b/src/wix/heat/VSHeatExtension.cs
@@ -29,7 +29,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// VS-related extensions for the WiX Toolset Harvester application.
     /// </summary>
-    public class VSHeatExtension : BaseHeatExtension
+    public sealed class VSHeatExtension : BaseHeatExtension
     {
         /// <summary>
         /// Gets the supported command line types for this extension.

--- a/src/wix/heat/VSProjectHarvester.cs
+++ b/src/wix/heat/VSProjectHarvester.cs
@@ -19,7 +19,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for the outputs of a VS project.
     /// </summary>
-    internal class VSProjectHarvester : BaseHarvesterExtension
+    public class VSProjectHarvester : BaseHarvesterExtension
     {
         // These format strings are used for generated element identifiers.
         //   {0} = project name

--- a/src/wix/heat/VSProjectHarvester.cs
+++ b/src/wix/heat/VSProjectHarvester.cs
@@ -19,7 +19,7 @@ namespace WixToolset.Harvesters
     /// <summary>
     /// Harvest WiX authoring for the outputs of a VS project.
     /// </summary>
-    public class VSProjectHarvester : BaseHarvesterExtension
+    public sealed class VSProjectHarvester : BaseHarvesterExtension
     {
         // These format strings are used for generated element identifiers.
         //   {0} = project name


### PR DESCRIPTION
While the command line service was parsing and building a list of extensions to be passed to the heat tool, they weren't actually being used in the heat command line.

The extension manager now loads all passed-in extensions and gets any appropriate `IHeatExtension`s.  
This PR will also open up all built-in heat extensions, harvesters, and mutators for external use like they were in WiX3.

Fixes: wixtoolset/issues#6564