### PR TITLE
Put back protection for wixstdba controls from thmutil declarative behavior

### DIFF
--- a/src/Directory.vcxproj.props
+++ b/src/Directory.vcxproj.props
@@ -35,7 +35,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <ExceptionHandling>false</ExceptionHandling>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>-YlprecompDefine</AdditionalOptions>
+      <AdditionalOptions>-YlprecompDefine /w44263</AdditionalOptions>
       <AdditionalOptions Condition=" $(PlatformToolset.StartsWith('v14')) ">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation Condition=" $(NUMBER_OF_PROCESSORS) &gt; 4 ">true</MultiProcessorCompilation>
     </ClCompile>

--- a/src/api/burn/balutil/inc/BAFunctions.h
+++ b/src/api/burn/balutil/inc/BAFunctions.h
@@ -141,6 +141,7 @@ struct BA_FUNCTIONS_ONTHEMECONTROLLOADING_RESULTS
     DWORD cbSize;
     BOOL fProcessed;
     WORD wId;
+    BOOL fDisableAutomaticFunctionality;
 };
 
 struct BA_FUNCTIONS_ONTHEMECONTROLWMCOMMAND_ARGS

--- a/src/api/burn/balutil/inc/BalBaseBAFunctions.h
+++ b/src/api/burn/balutil/inc/BalBaseBAFunctions.h
@@ -835,7 +835,8 @@ public: // IBAFunctions
     virtual STDMETHODIMP OnThemeControlLoading(
         __in LPCWSTR /*wzName*/,
         __inout BOOL* /*pfProcessed*/,
-        __inout WORD* /*pwId*/
+        __inout WORD* /*pwId*/,
+        __inout BOOL* /*pfDisableAutomaticFunctionality*/
         )
     {
         return S_OK;

--- a/src/api/burn/balutil/inc/BalBaseBAFunctionsProc.h
+++ b/src/api/burn/balutil/inc/BalBaseBAFunctionsProc.h
@@ -30,7 +30,7 @@ static HRESULT BalBaseBAFunctionsProcOnThemeControlLoading(
     __inout BA_FUNCTIONS_ONTHEMECONTROLLOADING_RESULTS* pResults
     )
 {
-    return pBAFunctions->OnThemeControlLoading(pArgs->wzName, &pResults->fProcessed, &pResults->wId);
+    return pBAFunctions->OnThemeControlLoading(pArgs->wzName, &pResults->fProcessed, &pResults->wId, &pResults->fDisableAutomaticFunctionality);
 }
 
 static HRESULT BalBaseBAFunctionsProcOnThemeControlWmCommand(

--- a/src/api/burn/balutil/inc/IBAFunctions.h
+++ b/src/api/burn/balutil/inc/IBAFunctions.h
@@ -35,7 +35,8 @@ DECLARE_INTERFACE_IID_(IBAFunctions, IBootstrapperApplication, "0FB445ED-17BD-49
     STDMETHOD(OnThemeControlLoading)(
         __in LPCWSTR wzName,
         __inout BOOL* pfProcessed,
-        __inout WORD* pwId
+        __inout WORD* pwId,
+        __inout BOOL* pfDisableAutomaticFunctionality
         ) = 0;
 
     // OnThemeControlWmCommand - Called when WM_COMMAND is received for a control.

--- a/src/ext/Bal/Samples/bafunctions/WixSampleBAFunctions.cpp
+++ b/src/ext/Bal/Samples/bafunctions/WixSampleBAFunctions.cpp
@@ -8,6 +8,7 @@ class CWixSampleBAFunctions : public CBalBaseBAFunctions
 {
 public: // IBootstrapperApplication
     virtual STDMETHODIMP OnDetectBegin(
+        __in BOOL fCached,
         __in BOOL fInstalled,
         __in DWORD cPackages,
         __inout BOOL* pfCancel
@@ -15,7 +16,7 @@ public: // IBootstrapperApplication
     {
         HRESULT hr = S_OK;
 
-        BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Running detect begin BA function. fInstalled=%d, cPackages=%u, fCancel=%d", fInstalled, cPackages, *pfCancel);
+        BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Running detect begin BA function. fCached=%d, fInstalled=%d, cPackages=%u, fCancel=%d", fCached, fInstalled, cPackages, *pfCancel);
 
         //-------------------------------------------------------------------------------------------------
         // YOUR CODE GOES HERE

--- a/src/ext/Bal/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/Bal/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -275,7 +275,8 @@ public: // IBootstrapperApplication
     virtual STDMETHODIMP OnDetectPackageComplete(
         __in LPCWSTR wzPackageId,
         __in HRESULT /*hrStatus*/,
-        __in BOOTSTRAPPER_PACKAGE_STATE state
+        __in BOOTSTRAPPER_PACKAGE_STATE state,
+        __in BOOL /*fCached*/
         )
     {
         WIXSTDBA_PACKAGE_INFO* pPackageInfo = NULL;

--- a/src/ext/Bal/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/Bal/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -2927,6 +2927,7 @@ private:
 
                 fProcessed = TRUE;
                 pResults->wId = pAssignControl->wId;
+                pResults->fDisableAutomaticFunctionality = pAssignControl->fDisableAutomaticFunctionality;
                 ExitFunction();
             }
         }
@@ -2938,6 +2939,7 @@ private:
 
             themeControlLoadingResults.cbSize = sizeof(themeControlLoadingResults);
             themeControlLoadingResults.wId = pResults->wId;
+            themeControlLoadingResults.fDisableAutomaticFunctionality = pResults->fDisableAutomaticFunctionality;
 
             hr = m_pfnBAFunctionsProc(BA_FUNCTIONS_MESSAGE_ONTHEMECONTROLLOADING, &themeControlLoadingArgs, &themeControlLoadingResults, m_pvBAFunctionsProcContext);
 
@@ -2953,6 +2955,7 @@ private:
                 {
                     fProcessed = TRUE;
                     pResults->wId = themeControlLoadingResults.wId;
+                    pResults->fDisableAutomaticFunctionality = themeControlLoadingResults.fDisableAutomaticFunctionality;
                 }
             }
         }
@@ -4040,7 +4043,7 @@ LExit:
         BalExitOnNullWithLastError(pfnBAFunctionsCreate, hr, "Failed to get BAFunctionsCreate entry-point from: %ls", sczBafPath);
 
         bafCreateArgs.cbSize = sizeof(bafCreateArgs);
-        bafCreateArgs.qwBAFunctionsAPIVersion = MAKEQWORDVERSION(2021, 9, 20, 0);
+        bafCreateArgs.qwBAFunctionsAPIVersion = MAKEQWORDVERSION(2021, 11, 8, 0);
         bafCreateArgs.pBootstrapperCreateArgs = &m_createArgs;
 
         bafCreateResults.cbSize = sizeof(bafCreateResults);
@@ -4138,138 +4141,161 @@ public:
         pAssignControl->wId = WIXSTDBA_CONTROL_INSTALL_BUTTON;
         pAssignControl->wzName = L"InstallButton";
         pAssignControl->ppControl = &m_pControlInstallButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlInstallButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EULA_RICHEDIT;
         pAssignControl->wzName = L"EulaRichedit";
         pAssignControl->ppControl = &m_pControlEulaRichedit;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlEulaRichedit = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EULA_LINK;
         pAssignControl->wzName = L"EulaHyperlink";
         pAssignControl->ppControl = &m_pControlEulaHyperlink;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlEulaHyperlink = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EULA_ACCEPT_CHECKBOX;
         pAssignControl->wzName = L"EulaAcceptCheckbox";
         pAssignControl->ppControl = &m_pControlEulaAcceptCheckbox;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlEulaAcceptCheckbox = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_REPAIR_BUTTON;
         pAssignControl->wzName = L"RepairButton";
         pAssignControl->ppControl = &m_pControlRepairButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlRepairButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_UNINSTALL_BUTTON;
         pAssignControl->wzName = L"UninstallButton";
         pAssignControl->ppControl = &m_pControlUninstallButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlUninstallButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_CACHE_PROGRESS_PACKAGE_TEXT;
         pAssignControl->wzName = L"CacheProgressPackageText";
         pAssignControl->ppControl = &m_pControlCacheProgressPackageText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlCacheProgressPackageText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_CACHE_PROGRESS_BAR;
         pAssignControl->wzName = L"CacheProgressbar";
         pAssignControl->ppControl = &m_pControlCacheProgressbar;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlCacheProgressbar = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_CACHE_PROGRESS_TEXT;
         pAssignControl->wzName = L"CacheProgressText";
         pAssignControl->ppControl = &m_pControlCacheProgressText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlCacheProgressText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EXECUTE_PROGRESS_PACKAGE_TEXT;
         pAssignControl->wzName = L"ExecuteProgressPackageText";
         pAssignControl->ppControl = &m_pControlExecuteProgressPackageText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlExecuteProgressPackageText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EXECUTE_PROGRESS_BAR;
         pAssignControl->wzName = L"ExecuteProgressbar";
         pAssignControl->ppControl = &m_pControlExecuteProgressbar;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlExecuteProgressbar = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EXECUTE_PROGRESS_TEXT;
         pAssignControl->wzName = L"ExecuteProgressText";
         pAssignControl->ppControl = &m_pControlExecuteProgressText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlExecuteProgressText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_EXECUTE_PROGRESS_ACTIONDATA_TEXT;
         pAssignControl->wzName = L"ExecuteProgressActionDataText";
         pAssignControl->ppControl = &m_pControlExecuteProgressActionDataText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlExecuteProgressActionDataText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_OVERALL_PROGRESS_PACKAGE_TEXT;
         pAssignControl->wzName = L"OverallProgressPackageText";
         pAssignControl->ppControl = &m_pControlOverallProgressPackageText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlOverallProgressPackageText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_OVERALL_PROGRESS_BAR;
         pAssignControl->wzName = L"OverallProgressbar";
         pAssignControl->ppControl = &m_pControlOverallProgressbar;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlOverallProgressbar = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_OVERALL_CALCULATED_PROGRESS_BAR;
         pAssignControl->wzName = L"OverallCalculatedProgressbar";
         pAssignControl->ppControl = &m_pControlOverallCalculatedProgressbar;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlOverallCalculatedProgressbar = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_OVERALL_PROGRESS_TEXT;
         pAssignControl->wzName = L"OverallProgressText";
         pAssignControl->ppControl = &m_pControlOverallProgressText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlOverallProgressText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_PROGRESS_CANCEL_BUTTON;
         pAssignControl->wzName = L"ProgressCancelButton";
         pAssignControl->ppControl = &m_pControlProgressCancelButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlProgressCancelButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_LAUNCH_BUTTON;
         pAssignControl->wzName = L"LaunchButton";
         pAssignControl->ppControl = &m_pControlLaunchButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlLaunchButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_SUCCESS_RESTART_BUTTON;
         pAssignControl->wzName = L"SuccessRestartButton";
         pAssignControl->ppControl = &m_pControlSuccessRestartButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlSuccessRestartButton = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_FAILURE_LOGFILE_LINK;
         pAssignControl->wzName = L"FailureLogFileLink";
         pAssignControl->ppControl = &m_pControlFailureLogFileLink;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlFailureLogFileLink = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_FAILURE_MESSAGE_TEXT;
         pAssignControl->wzName = L"FailureMessageText";
         pAssignControl->ppControl = &m_pControlFailureMessageText;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlFailureMessageText = NULL;
         ++pAssignControl;
 
         pAssignControl->wId = WIXSTDBA_CONTROL_FAILURE_RESTART_BUTTON;
         pAssignControl->wzName = L"FailureRestartButton";
         pAssignControl->ppControl = &m_pControlFailureRestartButton;
+        pAssignControl->fDisableAutomaticFunctionality = TRUE;
         m_pControlFailureRestartButton = NULL;
 
         C_ASSERT(LAST_WIXSTDBA_CONTROL == WIXSTDBA_CONTROL_FAILURE_RESTART_BUTTON + 1);

--- a/src/libs/dutil/WixToolset.DUtil/inc/thmutil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/thmutil.h
@@ -196,6 +196,7 @@ struct THEME_ASSIGN_CONTROL_ID
     WORD wId;       // id to apply to control
     LPCWSTR wzName; // name of control to match
     const THEME_CONTROL** ppControl;
+    BOOL fDisableAutomaticFunctionality; // prevent declarative functionality from interfering with the application's imperative code
 };
 
 const WORD THEME_FIRST_ASSIGN_CONTROL_ID = 0x4000; // Recommended first control id to be assigned.
@@ -223,7 +224,7 @@ typedef struct _THEME_CONTROL
 
     LPWSTR sczEnableCondition;
     LPWSTR sczVisibleCondition;
-    BOOL fDisableVariableFunctionality;
+    BOOL fDisableAutomaticFunctionality;
 
     union
     {
@@ -470,6 +471,8 @@ typedef struct _THEME_LOADINGCONTROL_RESULTS
     // The values [100, THEME_FIRST_ASSIGN_CONTROL_ID) are reserved for thmutil.
     // Due to this value being packed into 16 bits for many system window messages, this is restricted to a WORD.
     WORD wId;
+    // Used to prevent declarative functionality from interfering with the application's imperative code.
+    BOOL fDisableAutomaticFunctionality;
 } THEME_LOADINGCONTROL_RESULTS;
 
 

--- a/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
@@ -6363,15 +6363,15 @@ static HRESULT LoadControls(
                 {
                     ::SendMessageW(pControl->hWnd, LVM_SETIMAGELIST, static_cast<WPARAM>(LVSIL_NORMAL), reinterpret_cast<LPARAM>(pControl->ListView.rghImageList[0]));
                 }
-                else if (pControl->ListView.rghImageList[1])
+                if (pControl->ListView.rghImageList[1])
                 {
                     ::SendMessageW(pControl->hWnd, LVM_SETIMAGELIST, static_cast<WPARAM>(LVSIL_SMALL), reinterpret_cast<LPARAM>(pControl->ListView.rghImageList[1]));
                 }
-                else if (pControl->ListView.rghImageList[2])
+                if (pControl->ListView.rghImageList[2])
                 {
                     ::SendMessageW(pControl->hWnd, LVM_SETIMAGELIST, static_cast<WPARAM>(LVSIL_STATE), reinterpret_cast<LPARAM>(pControl->ListView.rghImageList[2]));
                 }
-                else if (pControl->ListView.rghImageList[3])
+                if (pControl->ListView.rghImageList[3])
                 {
                     ::SendMessageW(pControl->hWnd, LVM_SETIMAGELIST, static_cast<WPARAM>(LVSIL_GROUPHEADER), reinterpret_cast<LPARAM>(pControl->ListView.rghImageList[3]));
                 }

--- a/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
@@ -1834,6 +1834,10 @@ static HRESULT ParseTheme(
     hr = ParseImages(hModule, wzRelativePath, pThemeElement, pTheme);
     ThmExitOnFailure(hr, "Failed to parse theme images.");
 
+    // Parse any image lists.
+    hr = ParseImageLists(hModule, wzRelativePath, pThemeElement, pTheme);
+    ThmExitOnFailure(hr, "Failed to parse image lists.");
+
     // Parse the window element.
     hr = ParseWindow(hModule, wzRelativePath, pThemeElement, pTheme);
     ThmExitOnFailure(hr, "Failed to parse theme window element.");
@@ -2597,10 +2601,6 @@ static HRESULT ParseWindow(
     {
         ThmExitWithRootFailure(hr, E_INVALIDDATA, "Window elements must contain either the Caption or StringId attribute.");
     }
-
-    // Parse any image lists.
-    hr = ParseImageLists(hModule, wzRelativePath, pixn, pTheme);
-    ThmExitOnFailure(hr, "Failed to parse image lists.");
 
     // Parse the pages.
     hr = ParsePages(hModule, wzRelativePath, pixn, pTheme);

--- a/src/samples/thmviewer/display.cpp
+++ b/src/samples/thmviewer/display.cpp
@@ -327,9 +327,10 @@ static BOOL DisplayOnThmLoadedControl(
     }
     else if (THEME_CONTROL_TYPE_PROGRESSBAR == pControl->type)
     {
-        DWORD dwId = ::SetTimer(pTheme->hwndParent, reinterpret_cast<UINT_PTR>(pControl), 500, NULL);
-        dwId = dwId; // prevents warning in "ship" build.
-        Assert(dwId == pControl->wId);
+        UINT_PTR timerId = reinterpret_cast<UINT_PTR>(pControl);
+        UINT_PTR id = ::SetTimer(pTheme->hwndParent, timerId, 500, NULL);
+        id = id; // prevents warning in "ship" build.
+        Assert(id == timerId);
     }
 
 LExit:

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/BafThmUtilTesting.cpp
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/BafThmUtilTesting.cpp
@@ -46,7 +46,8 @@ public: // IBAFunctions
     virtual STDMETHODIMP OnThemeControlLoading(
         __in LPCWSTR wzName,
         __inout BOOL* pfProcessed,
-        __inout WORD* pwId
+        __inout WORD* pwId,
+        __inout BOOL* /*pfDisableAutomaticFunctionality*/
         )
     {
         if (CSTR_EQUAL == ::CompareStringW(LOCALE_NEUTRAL, 0, wzName, -1, L"InstallTestButton", -1))

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingTheme.xml
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingTheme.xml
@@ -28,12 +28,13 @@
     <Image Id="progressbar" ImageResource="30" />
     <Image Id="progressbar_reverse" ImageResource="31" />
 
+    <ImageList Name="Stars">
+        <ImageListItem ImageResource="2" />
+        <ImageListItem ImageResource="3" />
+        <ImageListItem ImageResource="4" />
+    </ImageList>
+
     <Window Width="600" Height="450" FontId="Default" Caption="BafThmUtilTestingTheme" HexStyle="10cf0000" AutoResize="yes">
-        <ImageList Name="Stars">
-            <ImageListItem ImageResource="2" />
-            <ImageListItem ImageResource="3" />
-            <ImageListItem ImageResource="4" />
-        </ImageList>
         <Page Name="Transparency">
             <Label X="6" Y="6" Width="-6" Height="94" FontId="Default">
                 This page has three versions of an image. The top image is a bitmap with a transparent background, the yellow star should be visible but its black background should not (this is currently broken). The middle image is the same bitmap except the black background is fully opaque so the yellow star should be visible on a black background. The bottom image in a PNG version of the top image and should look exactly the same.

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingThemeLoose.xml
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingThemeLoose.xml
@@ -28,12 +28,13 @@
     <Image Id="progressbar" ImageFile="progressbar.bmp" />
     <Image Id="progressbar_reverse" ImageFile="progressbar_reverse.bmp" />
 
+    <ImageList Name="Stars">
+        <ImageListItem ImageFile="star_transparent.bmp" />
+        <ImageListItem ImageFile="star_opaque.bmp" />
+        <ImageListItem ImageFile="star_transparent.png" />
+    </ImageList>
+
     <Window Width="600" Height="450" FontId="Default" Caption="BafThmUtilTestingTheme" HexStyle="10cf0000" AutoResize="yes">
-        <ImageList Name="Stars">
-            <ImageListItem ImageFile="star_transparent.bmp" />
-            <ImageListItem ImageFile="star_opaque.bmp" />
-            <ImageListItem ImageFile="star_transparent.png" />
-        </ImageList>
         <Page Name="Transparency">
             <Label X="6" Y="6" Width="-6" Height="94" FontId="Default">
                 This page has three versions of an image. The top image is a bitmap with a transparent background, the yellow star should be visible but its black background should not (this is currently broken). The middle image is the same bitmap except the black background is fully opaque so the yellow star should be visible on a black background. The bottom image in a PNG version of the top image and should look exactly the same.


### PR DESCRIPTION
Move ImageList element back under Theme since it's not a control.