### PR TITLE
Only build mbanative for latest toolset

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
     - develop
 
-image: vs2019-16-11-2
+image: Visual Studio 2019
 
 version: 0.0.0.{build}
 configuration: Release

--- a/src/api/burn/burn.proj
+++ b/src/api/burn/burn.proj
@@ -6,7 +6,6 @@
 
     <!-- Build -->
 
-    <!-- Let bextutil build balutil. -->
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
@@ -15,12 +14,14 @@
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x64" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=ARM64" />
-    
-    <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
-    <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
-    <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
-    <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
-    <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
+
+    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
+    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
+    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
+    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
+    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
+
+    <!-- Let mbanative build balutil for latest toolset. -->
     <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x86" />
     <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x64" />
     <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=ARM64" />


### PR DESCRIPTION
This allows going to latest tools/images.

I'm relying on CI for this one since I haven't installed VS2022, Win11 SDK, or .NET 6 locally.