### PR TITLE
Always populate bind variables for file version and language

### DIFF
--- a/src/ext/Bal/test/examples/.data/notanexe.exe
+++ b/src/ext/Bal/test/examples/.data/notanexe.exe
@@ -1,0 +1,1 @@
+This is notanexe.exe

--- a/src/ext/Bal/test/examples/EarliestCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/EarliestCoreBundleSCD/SelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleSCD/SelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.EarliestCoreMBA.scd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" PerMachine="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/EarliestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.EarliestCoreMBA.trimmedscd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" PerMachine="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/FullFramework2Bundle/Bundle.wxs
+++ b/src/ext/Bal/test/examples/FullFramework2Bundle/Bundle.wxs
@@ -8,7 +8,7 @@
             <bal:WixManagedBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/FullFramework4Bundle/Bundle.wxs
+++ b/src/ext/Bal/test/examples/FullFramework4Bundle/Bundle.wxs
@@ -8,7 +8,7 @@
             <bal:WixManagedBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleSCD/SelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleSCD/SelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.LatestCoreMBA.scd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" PerMachine="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.LatestCoreMBA.trimmedscd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" PerMachine="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/WPFCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/WPFCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="c:\windows\system32\kernel32.dll" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/wix/WixToolset.Core.Native/Cabinet.cs
+++ b/src/wix/WixToolset.Core.Native/Cabinet.cs
@@ -57,19 +57,6 @@ namespace WixToolset.Core.Native
             }
 
             wixnative.Run();
-
-#if TOOD_ERROR_HANDLING
-            catch (COMException ce)
-            {
-                // If we get a "the file exists" error, we must have a full temp directory - so report the issue
-                if (0x80070050 == unchecked((uint)ce.ErrorCode))
-                {
-                    throw new WixException(WixErrors.FullTempDirectory("WSC", Path.GetTempPath()));
-                }
-
-                throw;
-            }
-#endif
         }
 
         /// <summary>

--- a/src/wix/WixToolset.Core.Native/WixNativeException.cs
+++ b/src/wix/WixToolset.Core.Native/WixNativeException.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core.Native
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    internal class WixNativeException : Exception
+    {
+        private static readonly string LineSeparator = Environment.NewLine + "  ";
+
+        public WixNativeException()
+        {
+        }
+
+        public WixNativeException(string message) : base(message)
+        {
+        }
+
+        public WixNativeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected WixNativeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public static WixNativeException FromOutputLines(int errorCode, IReadOnlyCollection<string> lines)
+        {
+            var exception = new Win32Exception(errorCode);
+            var output = String.Join(LineSeparator, lines);
+            return new WixNativeException($"wixnative.exe failed with error code: {exception.ErrorCode} - {exception.Message} Output:{LineSeparator}{output}", exception);
+        }
+    }
+}

--- a/src/wix/WixToolset.Core.Native/WixNativeExe.cs
+++ b/src/wix/WixToolset.Core.Native/WixNativeExe.cs
@@ -4,7 +4,6 @@ namespace WixToolset.Core.Native
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Diagnostics;
     using System.IO;
 
@@ -53,6 +52,9 @@ namespace WixToolset.Core.Native
                 process.ErrorDataReceived += (s, a) => outputLines.Add(a.Data);
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
+
+                // Send the stdin preamble.
+                process.StandardInput.WriteLine(":");
 
                 if (this.stdinLines.Count > 0)
                 {

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateFileFacadesCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateFileFacadesCommand.cs
@@ -195,22 +195,13 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 {
                     facade.Language = language;
                 }
+            }
 
-                // Populate the binder variables for this file information if requested.
-                if (null != this.VariableCache)
-                {
-                    if (!String.IsNullOrEmpty(facade.Version))
-                    {
-                        var key = String.Format(CultureInfo.InvariantCulture, "fileversion.{0}", facade.Id);
-                        this.VariableCache[key] = facade.Version;
-                    }
-
-                    if (!String.IsNullOrEmpty(facade.Language))
-                    {
-                        var key = String.Format(CultureInfo.InvariantCulture, "filelanguage.{0}", facade.Id);
-                        this.VariableCache[key] = facade.Language;
-                    }
-                }
+            // Populate the binder variables for this file information if requested.
+            if (null != this.VariableCache)
+            {
+                this.VariableCache[$"fileversion.{facade.Id}"] = facade.Version ?? String.Empty;
+                this.VariableCache[$"filelanguage.{facade.Id}"] = facade.Language ?? String.Empty;
             }
 
             // If this is a CLR assembly, load the assembly and get the assembly name information

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BindVariables/PackageWithBindVariables.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BindVariables/PackageWithBindVariables.wxs
@@ -1,0 +1,20 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="PacakgeWithBindVariables" Version="!(bind.fileversion.TestBinaryFile)" Manufacturer="Example Corporation" UpgradeCode="00000000-0000-0000-0000-000000000000">
+
+    <Property Id="TestPackageManufacturer" Value="!(bind.Property.Manufacturer)" />
+    <Property Id="TestPackageName" Value="!(bind.Property.ProductName)" />
+    <Property Id="TestPackageVersion" Value="!(bind.Property.ProductVersion)" />
+
+    <Property Id="TestTextVersion" Value="v!(bind.fileversion.TestTextFile)" />
+    <Property Id="TestTextLangauge" Value="!(bind.filelanguage.TestTextFile)" />
+
+    <Feature Id="ProductFeature">
+      <Component Directory="ProgramFiles6432Folder" Subdirectory="test">
+        <File Id="TestBinaryFile" Source="burn.exe" />
+      </Component>
+      <Component Directory="ProgramFiles6432Folder" Subdirectory="test">
+        <File Id="TestTextFile" Source="data\test.txt" />
+      </Component>
+    </Feature>
+  </Package>
+</Wix>

--- a/src/wix/wixnative/extractcab.cpp
+++ b/src/wix/wixnative/extractcab.cpp
@@ -2,12 +2,12 @@
 
 #include "precomp.h"
 
-static HRESULT ProgressCallback(BOOL fBeginFile, LPCWSTR wzFileId, LPVOID pvContext);
+static HRESULT ProgressCallback(__in BOOL fBeginFile, __in_z LPCWSTR wzFileId, __in_opt LPVOID pvContext);
 
 
 HRESULT ExtractCabCommand(
     __in int argc,
-    __in LPWSTR argv[]
+    __in_ecount(argc) LPWSTR argv[]
 )
 {
     HRESULT hr = E_INVALIDARG;
@@ -37,8 +37,8 @@ LExit:
 
 static HRESULT ProgressCallback(
     __in BOOL fBeginFile,
-    __in LPCWSTR wzFileId,
-    __in LPVOID /*pvContext*/
+    __in_z LPCWSTR wzFileId,
+    __in_opt LPVOID /*pvContext*/
 )
 {
     if (fBeginFile)

--- a/src/wix/wixnative/precomp.h
+++ b/src/wix/wixnative/precomp.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 #include <aclapi.h>
 #include <mergemod.h>
+#include <strsafe.h>
 
 #include "dutil.h"
 #include "conutil.h"
@@ -13,7 +14,8 @@
 #include "cabcutil.h"
 #include "cabutil.h"
 
-HRESULT SmartCabCommand(int argc, LPWSTR argv[]);
-HRESULT ResetAclsCommand(int argc, LPWSTR argv[]);
-HRESULT EnumCabCommand(int argc, LPWSTR argv[]);
-HRESULT ExtractCabCommand(int argc, LPWSTR argv[]);
+HRESULT WixNativeReadStdinPreamble();
+HRESULT SmartCabCommand(__in int argc, __in_ecount(argc) LPWSTR argv[]);
+HRESULT ResetAclsCommand(__in int argc, __in_ecount(argc) LPWSTR argv[]);
+HRESULT EnumCabCommand(__in int argc, __in_ecount(argc) LPWSTR argv[]);
+HRESULT ExtractCabCommand(__in int argc, __in_ecount(argc) LPWSTR argv[]);

--- a/src/wix/wixnative/resetacls.cpp
+++ b/src/wix/wixnative/resetacls.cpp
@@ -2,7 +2,9 @@
 
 #include "precomp.h"
 
-HRESULT ResetAclsCommand(int argc, LPWSTR argv[])
+HRESULT ResetAclsCommand(
+    __in int argc,
+    __in_ecount(argc) LPWSTR argv[])
 {
     Unused(argc);
     Unused(argv);
@@ -23,6 +25,9 @@ HRESULT ResetAclsCommand(int argc, LPWSTR argv[])
     {
         ConsoleExitOnLastError(hr, CONSOLE_COLOR_RED, "failed to initialize ACL");
     }
+
+    hr = WixNativeReadStdinPreamble();
+    ExitOnFailure(hr, "failed to read stdin preamble before resetting ACLs");
 
     // Reset the existing security permissions on each provided file.
     for (;;)

--- a/src/wix/wixnative/smartcab.cpp
+++ b/src/wix/wixnative/smartcab.cpp
@@ -1,14 +1,15 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 #include "precomp.h"
+#include "fileutil.h"
 
-static HRESULT CompressFiles(HANDLE hCab);
-static void __stdcall CabNamesCallback(LPWSTR wzFirstCabName, LPWSTR wzNewCabName, LPWSTR wzFileToken);
+static HRESULT CompressFiles(__in HANDLE hCab);
+static void __stdcall CabNamesCallback(__in_z LPWSTR wzFirstCabName, __in_z LPWSTR wzNewCabName, __in_z LPWSTR wzFileToken);
 
 
 HRESULT SmartCabCommand(
     __in int argc,
-    __in LPWSTR argv[]
+    __in_ecount(argc) LPWSTR argv[]
 )
 {
     HRESULT hr = E_INVALIDARG;
@@ -66,6 +67,9 @@ HRESULT SmartCabCommand(
 
     if (uiFileCount > 0)
     {
+        hr = WixNativeReadStdinPreamble();
+        ExitOnFailure(hr, "failed to read stdin preamble before smartcabbing");
+
         hr = CompressFiles(hCab);
         ExitOnFailure(hr, "failed to compress files into cabinet: %ls", wzCabPath);
     }
@@ -151,9 +155,9 @@ LExit:
 // Second argument is name of the new cabinet that would be formed by splitting e.g. "cab1b.cab"
 // Third argument is the file token of the first file present in the splitting cabinet
 static void __stdcall CabNamesCallback(
-    __in LPWSTR wzFirstCabName,
-    __in LPWSTR wzNewCabName,
-    __in LPWSTR wzFileToken
+    __in_z LPWSTR wzFirstCabName,
+    __in_z LPWSTR wzNewCabName,
+    __in_z LPWSTR wzFileToken
 )
 {
     ConsoleWriteLine(CONSOLE_COLOR_NORMAL, "%ls\t%ls\t%ls", wzFirstCabName, wzNewCabName, wzFileToken);


### PR DESCRIPTION
Always populating the values (using "" for null) makes it easier to
diagnose when you finally get the bind variable syntax correct.
Previously, incorrect syntax and not having a value both resulted in
errors.