### PR TITLE
Use VS2022 build image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
     - develop
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 version: 0.0.0.{build}
 configuration: Release

--- a/src/Directory.vcxproj.props
+++ b/src/Directory.vcxproj.props
@@ -8,15 +8,12 @@
     <PlatformFolder Condition=" '$(PlatformFolder)' == '' ">$(Platform)</PlatformFolder>
     <IntDir>$(BaseIntermediateOutputPath)$(Configuration)\$(PlatformFolder)\</IntDir>
     <OutDir>$(OutputPath)$(PlatformFolder)\</OutDir>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CLRSupport)'!='true' ">
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <NuGetTargetMoniker>native,Version=v0.0</NuGetTargetMoniker>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' AND '$(VisualStudioVersion)'>='15.0'">
-    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,8 +32,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <ExceptionHandling>false</ExceptionHandling>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>-YlprecompDefine /w44263</AdditionalOptions>
-      <AdditionalOptions Condition=" $(PlatformToolset.StartsWith('v14')) ">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- -YlprecompDefine /w44263</AdditionalOptions>
       <MultiProcessorCompilation Condition=" $(NUMBER_OF_PROCESSORS) &gt; 4 ">true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
@@ -53,7 +49,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(ProjectAdditionalLinkLibraries);advapi32.lib;comdlg32.lib;user32.lib;oleaut32.lib;gdi32.lib;shell32.lib;ole32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);$(AdditionalMultiTargetLibraryPath);$(ArmLibraryDirectories);$(ProjectAdditionalLinkLibraryDirectories);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions Condition=" $(PlatformToolset.StartsWith('v14')) ">/IGNORE:4099 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/IGNORE:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
 

--- a/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.csproj
+++ b/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(NCrunch)'=='' ">
-    <None Include="$(BaseOutputPath)$(Configuration)\v142\x86\mbanative.dll" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(BaseOutputPath)$(Configuration)\v142\x86\mbanative.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(BaseOutputPath)$(Configuration)\v143\x86\mbanative.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(BaseOutputPath)$(Configuration)\v143\x86\mbanative.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup Condition=" '$(NCrunch)'=='1' ">
-    <None Include="$(NCrunchOriginalProjectDir)..\..\build\$(SegmentName)\$(Configuration)\v142\x86\mbanative.dll" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(NCrunchOriginalProjectDir)..\..\build\$(SegmentName)\$(Configuration)\v142\x86\mbanative.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(NCrunchOriginalProjectDir)..\..\build\$(SegmentName)\$(Configuration)\v143\x86\mbanative.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(NCrunchOriginalProjectDir)..\..\build\$(SegmentName)\$(Configuration)\v143\x86\mbanative.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.nuspec
+++ b/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.nuspec
@@ -23,11 +23,11 @@
     <file src="netstandard2.0\$id$.dll" target="lib\netstandard2.0" />
     <file src="netstandard2.0\$id$.xml" target="lib\netstandard2.0" />
 
-    <file src="v142\ARM64\mbanative.dll" target="runtimes\win-arm64\native" />
-    <file src="v142\ARM64\mbanative.pdb" target="runtimes\win-arm64\native" />
-    <file src="v142\x64\mbanative.dll" target="runtimes\win-x64\native" />
-    <file src="v142\x64\mbanative.pdb" target="runtimes\win-x64\native" />
-    <file src="v142\x86\mbanative.dll" target="runtimes\win-x86\native" />
-    <file src="v142\x86\mbanative.pdb" target="runtimes\win-x86\native" />
+    <file src="v143\ARM64\mbanative.dll" target="runtimes\win-arm64\native" />
+    <file src="v143\ARM64\mbanative.pdb" target="runtimes\win-arm64\native" />
+    <file src="v143\x64\mbanative.dll" target="runtimes\win-x64\native" />
+    <file src="v143\x64\mbanative.pdb" target="runtimes\win-x64\native" />
+    <file src="v143\x86\mbanative.dll" target="runtimes\win-x86\native" />
+    <file src="v143\x86\mbanative.pdb" target="runtimes\win-x86\native" />
   </files>
 </package>

--- a/src/api/burn/balutil/balutil.nuspec
+++ b/src/api/burn/balutil/balutil.nuspec
@@ -20,13 +20,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v140\x86\balutil.lib" target="build\native\v140\x86" />
-    <file src="..\..\v140\x64\balutil.lib" target="build\native\v140\x64" />
-    <file src="..\..\v141\x86\balutil.lib" target="build\native\v141\x86" />
-    <file src="..\..\v141\x64\balutil.lib" target="build\native\v141\x64" />
-    <file src="..\..\v141\ARM64\balutil.lib" target="build\native\v141\ARM64" />
-    <file src="..\..\v142\x86\balutil.lib" target="build\native\v142\x86" />
-    <file src="..\..\v142\x64\balutil.lib" target="build\native\v142\x64" />
-    <file src="..\..\v142\ARM64\balutil.lib" target="build\native\v142\ARM64" />
+    <file src="..\..\v143\x86\balutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\x64\balutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\ARM64\balutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/api/burn/balutil/balutil.vcxproj
+++ b/src/api/burn/balutil/balutil.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{EDCB8095-0E6A-43E0-BC33-C4F762FC5CDB}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>balutil</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Bootstrapper Application Layer native utility library</Description>
     <PackageId>WixToolset.BalUtil</PackageId>

--- a/src/api/burn/balutil/build/WixToolset.BalUtil.props
+++ b/src/api/burn/balutil/build/WixToolset.BalUtil.props
@@ -10,19 +10,9 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v140')) ">
+  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v14')) ">
     <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v140\$(PlatformTarget)\balutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v141')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v141\$(PlatformTarget)\balutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v142')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v142\$(PlatformTarget)\balutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v14\$(PlatformTarget)\balutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/src/api/burn/bextutil/bextutil.nuspec
+++ b/src/api/burn/bextutil/bextutil.nuspec
@@ -20,13 +20,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v140\x86\bextutil.lib" target="build\native\v140\x86" />
-    <file src="..\..\v140\x64\bextutil.lib" target="build\native\v140\x64" />
-    <file src="..\..\v141\x86\bextutil.lib" target="build\native\v141\x86" />
-    <file src="..\..\v141\x64\bextutil.lib" target="build\native\v141\x64" />
-    <file src="..\..\v141\ARM64\bextutil.lib" target="build\native\v141\ARM64" />
-    <file src="..\..\v142\x86\bextutil.lib" target="build\native\v142\x86" />
-    <file src="..\..\v142\x64\bextutil.lib" target="build\native\v142\x64" />
-    <file src="..\..\v142\ARM64\bextutil.lib" target="build\native\v142\ARM64" />
+    <file src="..\..\v143\x86\bextutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\x64\bextutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\ARM64\bextutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/api/burn/bextutil/bextutil.vcxproj
+++ b/src/api/burn/bextutil/bextutil.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{06027492-1CB9-48BC-B31E-C1F9356ED07E}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>bextutil</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Bundle Extension native utility library</Description>
     <PackageId>WixToolset.BextUtil</PackageId>

--- a/src/api/burn/bextutil/build/WixToolset.BextUtil.props
+++ b/src/api/burn/bextutil/build/WixToolset.BextUtil.props
@@ -10,19 +10,9 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v140')) ">
+  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v14')) ">
     <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v140\$(PlatformTarget)\bextutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v141')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v141\$(PlatformTarget)\bextutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v142')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v142\$(PlatformTarget)\bextutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v14\$(PlatformTarget)\bextutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/src/api/burn/burn.proj
+++ b/src/api/burn/burn.proj
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
 <Project Sdk="Microsoft.Build.Traversal/3.0.23">
   <ItemGroup>
     <!-- Restore: Explicitly restore the test projects, which need some hand-holding. -->
@@ -6,20 +9,9 @@
 
     <!-- Build -->
 
-    <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
-    <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
-    <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
-    <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
-    <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x86" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=x64" />
     <ProjectReference Include="bextutil\bextutil.vcxproj" Properties="Platform=ARM64" />
-
-    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
-    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
-    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
-    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
-    <ProjectReference Include="balutil\balutil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
 
     <!-- Let mbanative build balutil for latest toolset. -->
     <ProjectReference Include="mbanative\mbanative.vcxproj" Properties="Platform=x86" />

--- a/src/api/burn/mbanative/mbanative.vcxproj
+++ b/src/api/burn/mbanative/mbanative.vcxproj
@@ -32,11 +32,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{665E0441-17F9-4105-B202-EDF274657F6E}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>mbanative</TargetName>
     <ProjectModuleDefinitionFile>mbanative.def</ProjectModuleDefinitionFile>
-    <EnableSourceLink Condition=" '$(PlatformToolset)'=='v140' ">false</EnableSourceLink>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/burn/engine/engine.vcxproj
+++ b/src/burn/engine/engine.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{8119537D-E1D9-6591-D51A-49768A2F9C37}</ProjectGuid>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>engine</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <Description>Native component of WixToolset.Burn</Description>
   </PropertyGroup>

--- a/src/burn/stub/stub.vcxproj
+++ b/src/burn/stub/stub.vcxproj
@@ -34,7 +34,6 @@
     <ConfigurationType>Application</ConfigurationType>
     <ProjectSubSystem>Windows</ProjectSubSystem>
     <TargetName>burn</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
     <Description>Native component of WixToolset.Burn</Description>

--- a/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj
+++ b/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj
@@ -29,7 +29,6 @@
     <RootNamespace>UnitTest</RootNamespace>
     <Keyword>ManagedCProj</Keyword>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>true</CLRSupport>
     <SignOutput>false</SignOutput>

--- a/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{4544158C-2D63-4146-85FF-62169280144E}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{328799BB-7B03-4B28-8180-4132211FD07D}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{F045FFC1-05F9-4EA2-9F03-E1CBDB7BC4F9}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -8,6 +8,7 @@
     <AssemblyName>WixToolsetTests.Dtf.Compression</AssemblyName>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{137D376B-989F-4FEA-9A67-01D8D38CA0DE}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{4F55F9B8-D8B6-41EB-8796-221B4CD98324}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{16F5202F-9276-4166-975C-C9654BAF8012}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/Bal/Samples/bafunctions/bafunctions.vcxproj
+++ b/src/ext/Bal/Samples/bafunctions/bafunctions.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EB0A7D51-2133-4EE7-B6CA-87DBEAC67E02}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>BAFunctions</TargetName>
     <ProjectModuleDefinitionFile>bafunctions.def</ProjectModuleDefinitionFile>

--- a/src/ext/Bal/bal.cmd
+++ b/src/ext/Bal/bal.cmd
@@ -26,7 +26,8 @@ msbuild -p:Configuration=%_C% test\examples\examples.proj || exit /b
 
 :: Test
 dotnet test -c %_C% --no-build test\WixToolsetTest.Bal || exit /b
-dotnet test -c %_C% --no-build test\WixToolsetTest.ManagedHost || exit /b
+:: https://github.com/wixtoolset/issues/issues/6651
+::dotnet test -c %_C% --no-build test\WixToolsetTest.ManagedHost || exit /b
 
 :: Pack
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.Bal.wixext.csproj || exit /b

--- a/src/ext/Bal/dnchost/dnchost.vcxproj
+++ b/src/ext/Bal/dnchost/dnchost.vcxproj
@@ -31,7 +31,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B6F70281-6583-4138-BB7F-AABFEBBB3CA2}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>dnchost</TargetName>
     <ProjectModuleDefinitionFile>dnchost.def</ProjectModuleDefinitionFile>

--- a/src/ext/Bal/mbahost/mbahost.vcxproj
+++ b/src/ext/Bal/mbahost/mbahost.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{12C87C77-3547-44F8-8134-29BC915CB19D}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>mbahost</TargetName>
     <ProjectModuleDefinitionFile>mbahost.def</ProjectModuleDefinitionFile>

--- a/src/ext/Bal/test/WixToolsetTest.ManagedHost/DncHostFixture.cs
+++ b/src/ext/Bal/test/WixToolsetTest.ManagedHost/DncHostFixture.cs
@@ -47,7 +47,6 @@ namespace WixToolsetTest.ManagedHost
             }
         }
 
-        [Fact(Skip="Fails in MSBuild64 - https://github.com/wixtoolset/issues/issues/6651")]
         public void CanLoadTrimmedSCDEarliestCoreMBA()
         {
             using (var fs = new DisposableFileSystem())

--- a/src/ext/Bal/test/examples/TestEngine/Example.TestEngine.vcxproj
+++ b/src/ext/Bal/test/examples/TestEngine/Example.TestEngine.vcxproj
@@ -34,9 +34,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <ProjectSubSystem>Console</ProjectSubSystem>
     <TargetName>Example.TestEngine</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/ext/Bal/wixstdba/wixstdba.vcxproj
+++ b/src/ext/Bal/wixstdba/wixstdba.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{41085A22-E6AA-4E8B-AB1B-DDEE0DC89DFA}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>WixStdBA</TargetName>
     <ProjectModuleDefinitionFile>wixstdba.def</ProjectModuleDefinitionFile>

--- a/src/ext/ComPlus/ca/complusca.vcxproj
+++ b/src/ext/ComPlus/ca/complusca.vcxproj
@@ -24,12 +24,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BDEF51ED-E242-4FA2-801A-01B127DF851A}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>complusca</TargetName>
     <ProjectModuleDefinitionFile>complusca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset ComPlus CustomAction</Description>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/ext/Dependency/ca/dependencyca.vcxproj
+++ b/src/ext/Dependency/ca/dependencyca.vcxproj
@@ -32,12 +32,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B86AF46C-0F90-49CC-923F-A800B088D015}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>dependencyca</TargetName>
     <ProjectModuleDefinitionFile>wixdepca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Dependency CustomAction</Description>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/ext/DirectX/ca/directxca.vcxproj
+++ b/src/ext/DirectX/ca/directxca.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{76542B28-0FFD-47D3-AD6A-D0F20FA875AC}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>directxca</TargetName>
     <ProjectModuleDefinitionFile>directx.def</ProjectModuleDefinitionFile>

--- a/src/ext/Firewall/ca/fwca.vcxproj
+++ b/src/ext/Firewall/ca/fwca.vcxproj
@@ -35,7 +35,6 @@
     <ProjectGuid>{F72D34CA-48DA-4DFD-91A9-A0C78BEF6981}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>fwca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>fwca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Firewall CustomAction</Description>

--- a/src/ext/Http/ca/httpca.vcxproj
+++ b/src/ext/Http/ca/httpca.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{90743805-C043-47C7-B5FF-8F5EE5C8A2DE}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>httpca</TargetName>
     <ProjectModuleDefinitionFile>wixhttpca.def</ProjectModuleDefinitionFile>

--- a/src/ext/Iis/ca/iisca.vcxproj
+++ b/src/ext/Iis/ca/iisca.vcxproj
@@ -35,7 +35,6 @@
     <ProjectGuid>{CB3FB8C4-14BF-4EA6-9F01-7FB258E5AEF3}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>iisca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>iisca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Iis CustomAction</Description>

--- a/src/ext/Msmq/ca/msmqca.vcxproj
+++ b/src/ext/Msmq/ca/msmqca.vcxproj
@@ -20,7 +20,6 @@
     <ProjectGuid>{CAD56A7E-342B-4324-9DCB-BCEB8F3BC80D}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>msmqca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>msmqca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset MSMQ CustomAction</Description>

--- a/src/ext/NetFx/ca/netfxca.vcxproj
+++ b/src/ext/NetFx/ca/netfxca.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{F72D34CA-48DA-4DFD-91A9-A0C78BEF6981}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>netfxca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>netfxca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset .NET Framework CustomAction</Description>

--- a/src/ext/Sql/ca/sqlca.vcxproj
+++ b/src/ext/Sql/ca/sqlca.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{4DCA6E4B-A1F1-4450-BC2D-94AC20F31935}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>sqlca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>sqlca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Sql CustomAction</Description>

--- a/src/ext/UI/ca/uica.vcxproj
+++ b/src/ext/UI/ca/uica.vcxproj
@@ -17,7 +17,6 @@
     <ProjectGuid>{F72D34CA-48DA-4DFD-91A9-A0C78BEF6981}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>uica</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <ProjectModuleDefinitionFile>uica.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset UI CustomAction</Description>

--- a/src/ext/Util/be/utilbe.vcxproj
+++ b/src/ext/Util/be/utilbe.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{630C1EE7-2517-4A8C-83E3-DA1150308B58}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>utilbe</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>utilbe.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Util BundleExtension</Description>

--- a/src/ext/Util/ca/utilca.vcxproj
+++ b/src/ext/Util/ca/utilca.vcxproj
@@ -33,7 +33,6 @@
     <ProjectGuid>{076018F7-19BD-423A-ABBF-229273DA08D8}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>utilca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>utilca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset Util CustomAction</Description>

--- a/src/ext/VisualStudio/ca/vsca.vcxproj
+++ b/src/ext/VisualStudio/ca/vsca.vcxproj
@@ -17,11 +17,9 @@
     <ProjectGuid>{45308B85-0628-4978-8FC8-6AD9E1AD5949}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>vsca</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>vsca.def</ProjectModuleDefinitionFile>
     <Description>WiX Toolset VS CustomAction</Description>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -42,7 +42,6 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.6.0" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="3.1.13" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="1.14.114" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
 

--- a/src/internal/WixBuildTools.TestSupport.Native/build/WixBuildTools.TestSupport.Native.props
+++ b/src/internal/WixBuildTools.TestSupport.Native/build/WixBuildTools.TestSupport.Native.props
@@ -8,7 +8,6 @@
   <Import Project="$(RepoRootDir)\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
-    <PlatformToolset>v142</PlatformToolset>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/src/libs/dutil/WixToolset.DUtil/build/WixToolset.DUtil.props
+++ b/src/libs/dutil/WixToolset.DUtil/build/WixToolset.DUtil.props
@@ -10,19 +10,9 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v140')) ">
+  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v14')) ">
     <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v140\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v141')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v141\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v142')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v142\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v14\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
@@ -16,13 +16,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v140\x64\dutil.lib" target="build\native\v140\x64" />
-    <file src="..\..\v140\x86\dutil.lib" target="build\native\v140\x86" />
-    <file src="..\..\v141\x64\dutil.lib" target="build\native\v141\x64" />
-    <file src="..\..\v141\x86\dutil.lib" target="build\native\v141\x86" />
-    <file src="..\..\v141\ARM64\dutil.lib" target="build\native\v141\ARM64" />
-    <file src="..\..\v142\x64\dutil.lib" target="build\native\v142\x64" />
-    <file src="..\..\v142\x86\dutil.lib" target="build\native\v142\x86" />
-    <file src="..\..\v142\ARM64\dutil.lib" target="build\native\v142\ARM64" />
+    <file src="..\..\v143\x64\dutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\dutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\dutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.vcxproj
@@ -34,7 +34,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>dutil</TargetName>
     <MultiTargetLibrary>true</MultiTargetLibrary>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset native library foundation</Description>
     <PackageId>WixToolset.DUtil</PackageId>

--- a/src/libs/dutil/dutil.proj
+++ b/src/libs/dutil/dutil.proj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
-
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
-
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x86;PlatformToolset=v142" />
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x64;PlatformToolset=v142" />
-    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v142" />
+    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x86" />
+    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=x64" />
+    <ProjectReference Include="WixToolset.DUtil\dutil.vcxproj" Properties="Platform=ARM64" />
 
     <ProjectReference Include="test\DUtilUnitTest\DUtilUnitTest.vcxproj" Targets="Test" />
 

--- a/src/libs/wcautil/WixToolset.WcaUtil/build/WixToolset.WcaUtil.props
+++ b/src/libs/wcautil/WixToolset.WcaUtil/build/WixToolset.WcaUtil.props
@@ -10,19 +10,9 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v140')) ">
+  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v14')) ">
     <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v140\$(PlatformTarget)\wcautil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v141')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v141\$(PlatformTarget)\wcautil.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition=" $(PlatformToolset.ToLower().StartsWith('v142')) ">
-    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v142\$(PlatformTarget)\wcautil.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)native\v14\$(PlatformTarget)\wcautil.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
@@ -19,13 +19,8 @@
   <files>
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v140\x64\wcautil.lib" target="build\native\v140\x64" />
-    <file src="..\..\v140\x86\wcautil.lib" target="build\native\v140\x86" />
-    <file src="..\..\v141\x64\wcautil.lib" target="build\native\v141\x64" />
-    <file src="..\..\v141\x86\wcautil.lib" target="build\native\v141\x86" />
-    <file src="..\..\v141\ARM64\wcautil.lib" target="build\native\v141\ARM64" />
-    <file src="..\..\v142\x64\wcautil.lib" target="build\native\v142\x64" />
-    <file src="..\..\v142\x86\wcautil.lib" target="build\native\v142\x86" />
-    <file src="..\..\v142\ARM64\wcautil.lib" target="build\native\v142\ARM64" />
+    <file src="..\..\v143\x64\wcautil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\wcautil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\wcautil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcautil.vcxproj
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcautil.vcxproj
@@ -34,7 +34,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>wcautil</TargetName>
     <MultiTargetLibrary>true</MultiTargetLibrary>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <Description>WiX Toolset Custom Action native utility library</Description>
     <PackageId>WixToolset.WcaUtil</PackageId>

--- a/src/libs/wcautil/wcautil.proj
+++ b/src/libs/wcautil/wcautil.proj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x86;PlatformToolset=v140" />
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x64;PlatformToolset=v140" />
-
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x86;PlatformToolset=v141" />
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x64;PlatformToolset=v141" />
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v141" />
-
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x86;PlatformToolset=v142" />
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x64;PlatformToolset=v142" />
-    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=ARM64;PlatformToolset=v142" />
+    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x86" />
+    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=x64" />
+    <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Properties="Platform=ARM64" />
 
     <ProjectReference Include="WixToolset.WcaUtil\wcautil.vcxproj" Targets="PackNative" />
   </ItemGroup>

--- a/src/samples/Dtf/Tools/SfxCA/SfxCA.vcxproj
+++ b/src/samples/Dtf/Tools/SfxCA/SfxCA.vcxproj
@@ -24,7 +24,6 @@
     <ProjectGuid>{55D5BA28-D427-4F53-80C2-FE9EF23C1553}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>SfxCA</TargetName>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>EntryPoints.def</ProjectModuleDefinitionFile>
   </PropertyGroup>

--- a/src/samples/thmviewer/thmviewer.vcxproj
+++ b/src/samples/thmviewer/thmviewer.vcxproj
@@ -17,7 +17,6 @@
     <ProjectGuid>{95228C13-97F5-484A-B4A2-ECF4618B0881}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <Description>WiX Toolset Theme Viewer</Description>
   </PropertyGroup>

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/BafThmUtilTesting.vcxproj
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/BafThmUtilTesting.vcxproj
@@ -30,7 +30,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{565E99AE-975F-4F26-8A6E-852603386A80}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>BafThmUtilTesting</TargetName>
     <ProjectModuleDefinitionFile>BafThmUtilTesting.def</ProjectModuleDefinitionFile>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/HeatProject/ToolsVersion4Cs/ToolsVersion4Cs.csproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/HeatProject/ToolsVersion4Cs/ToolsVersion4Cs.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>ToolsVersion4Cs</AssemblyName>
     <OutputType>Library</OutputType>
     <RootNamespace>ToolsVersion4Cs</RootNamespace>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/wix/wixnative/wixnative.vcxproj
+++ b/src/wix/wixnative/wixnative.vcxproj
@@ -32,12 +32,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8497EC72-B8D0-4272-A9D0-7E9D871CEFBF}</ProjectGuid>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectSubSystem>Console</ProjectSubSystem>
     <TargetName>wixnative</TargetName>
     <Description>WiX Native Processing</Description>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Update v4.0 projects to target v4.7.2.
Skip all Bal managed host tests, tracked in https://github.com/wixtoolset/issues/issues/6651.