### PR TITLE
More VS2022 fixes

### DIFF
--- a/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Cab/WixToolsetTests.Dtf.Compression.Cab.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{4544158C-2D63-4146-85FF-62169280144E}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression.Zip/WixToolsetTests.Dtf.Compression.Zip.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{328799BB-7B03-4B28-8180-4132211FD07D}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.Compression/WixToolsetTests.Dtf.Compression.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{F045FFC1-05F9-4EA2-9F03-E1CBDB7BC4F9}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -8,6 +8,7 @@
     <AssemblyName>WixToolsetTests.Dtf.Compression</AssemblyName>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.CustomActions/WixToolsetTests.Dtf.WindowsInstaller.CustomActions.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{137D376B-989F-4FEA-9A67-01D8D38CA0DE}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller.Linq/WixToolsetTests.Dtf.WindowsInstaller.Linq.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{4F55F9B8-D8B6-41EB-8796-221B4CD98324}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
+++ b/src/dtf/WixToolsetTests.Dtf.WindowsInstaller/WixToolsetTests.Dtf.WindowsInstaller.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{16F5202F-9276-4166-975C-C9654BAF8012}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -9,6 +9,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <CreateDocumentation>false</CreateDocumentation>
     <SignOutput>false</SignOutput>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/Bal/bal.cmd
+++ b/src/ext/Bal/bal.cmd
@@ -26,7 +26,8 @@ msbuild -p:Configuration=%_C% test\examples\examples.proj || exit /b
 
 :: Test
 dotnet test -c %_C% --no-build test\WixToolsetTest.Bal || exit /b
-dotnet test -c %_C% --no-build test\WixToolsetTest.ManagedHost || exit /b
+:: https://github.com/wixtoolset/issues/issues/6651
+::dotnet test -c %_C% --no-build test\WixToolsetTest.ManagedHost || exit /b
 
 :: Pack
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.Bal.wixext.csproj || exit /b

--- a/src/ext/Bal/test/WixToolsetTest.ManagedHost/DncHostFixture.cs
+++ b/src/ext/Bal/test/WixToolsetTest.ManagedHost/DncHostFixture.cs
@@ -47,7 +47,6 @@ namespace WixToolsetTest.ManagedHost
             }
         }
 
-        [Fact(Skip="Fails in MSBuild64 - https://github.com/wixtoolset/issues/issues/6651")]
         public void CanLoadTrimmedSCDEarliestCoreMBA()
         {
             using (var fs = new DisposableFileSystem())

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -42,7 +42,6 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.6.0" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="3.1.13" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="1.14.114" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
 

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/HeatProject/ToolsVersion4Cs/ToolsVersion4Cs.csproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/HeatProject/ToolsVersion4Cs/ToolsVersion4Cs.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>ToolsVersion4Cs</AssemblyName>
     <OutputType>Library</OutputType>
     <RootNamespace>ToolsVersion4Cs</RootNamespace>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I made these changes for the build machine, but I at least needed the v4.7.2 changes to build locally after trying to do a minimal install of VS2022 without any other dev products on the machine.

Update v4.0 projects to target v4.7.2.
Skip all Bal managed host tests for now.
Remove ToolsVersion from DTF test projects.
Remove Microsoft.NETFramework.ReferenceAssemblies from Directory.Packages.props.