### PR TITLE
Added Dutch translation of Util extension.

### DIFF
--- a/src/ext/Util/wixlib/nl-nl.wxl
+++ b/src/ext/Util/wixlib/nl-nl.wxl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<WixLocalization Culture="nl-nl" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+    <String Id="msierrUSRFailedUserCreate" Overridable="yes">De gebruiker kon niet worden aangemaakt.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes">De gebruiker kon niet worden aangemaakt vanwege een ongeldig wachtwoord.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes">De gebruikersgroep kon niet worden toegevoegd.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrUSRFailedUserCreateExists" Overridable="yes">De gebruiker kon niet worden aangemaakt omdat hij al bestond.  ([2]   [3]   [4]   [5])</String>
+
+    <String Id="msierrSMBFailedCreate" Overridable="yes">Netwerk delen kon niet worden aangemaakt.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrSMBFailedDrop" Overridable="yes">Netwerk delen kon niet worden verwijderd.  ([2]   [3]   [4]   [5])</String>
+
+    <String Id="msierrPERFMONFailedRegisterDLL" Overridable="yes">De DLL kon niet worden geregistreerd bij PerfMon.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrPERFMONFailedUnregisterDLL" Overridable="yes">De DLL kon niet worden gederegistreerd bij PerfMon.  ([2]   [3]   [4]   [5])</String>
+
+    <String Id="msierrInstallPerfCounterData" Overridable="yes">De performance tellers konden niet worden geïnstalleerd.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrUninstallPerfCounterData" Overridable="yes">De performance tellers konden niet worden gedeïnstalleerd.  ([2]   [3]   [4]   [5])</String>
+
+    <String Id="msierrSecureObjectsFailedCreateSD" Overridable="yes">De beveiligingsbeschrijver voor [3]\[4] kon niet worden gecreëerd, systeemfout: [2]</String>
+    <String Id="msierrSecureObjectsFailedSet" Overridable="yes">De beveiligingsbeschrijver voor object [3] kon niet worden ingesteld, systeemfout: [2]</String>
+    <String Id="msierrSecureObjectsUnknownType" Overridable="yes">Onbekend Objectstype [3], systeemfout: [2]</String>
+
+    <String Id="msierrXmlFileFailedRead" Overridable="yes">Er trad een fout op bij het lezen van XML-bestanden.</String>
+    <String Id="msierrXmlFileFailedOpen" Overridable="yes">XML-bestand [3] kon niet worden geopend, systeemfout: [2]</String>
+    <String Id="msierrXmlFileFailedSelect" Overridable="yes">Node [3] kon niet worden gevonden in XML-bestand: [4], systeemfout: [2]</String>
+    <String Id="msierrXmlFileFailedSave" Overridable="yes">Bij het opslaan van veranderingen in XML-bestand [3] trad een fout op, systeemfout: [2]</String>
+
+    <String Id="msierrXmlConfigFailedRead" Overridable="yes">Bij het configureren van XML-bestanden trad een fout op.</String>
+    <String Id="msierrXmlConfigFailedOpen" Overridable="yes">XML-bestand [3] kon niet worden geopend, systeemfout: [2]</String>
+    <String Id="msierrXmlConfigFailedSelect" Overridable="yes">Node [3] kon niet worden gevonden in XML-bestand: [4], systeemfout: [2]</String>
+    <String Id="msierrXmlConfigFailedSave" Overridable="yes">Bij het opslaan van veranderingen in XML-bestand [3] trad een fout op, systeemfout: [2]</String>
+</WixLocalization>


### PR DESCRIPTION
Adding a Dutch translation for the Util extension. Without this translation, using Util extension elements in wix projects with culture "nl-nl" will fail out of the box.

Issue for both v3 and v4 of the Wix toolset: https://github.com/wixtoolset/issues/issues/6678


[issue]: https://github.com/wixtoolset/issues/issues/6678