### PR TITLE
Fix 32/64-bit bitness handling in Burn and BUtil.

### DIFF
--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -3299,7 +3299,6 @@ static HRESULT OnLaunchApprovedExe(
     SIZE_T iData = 0;
     BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe = NULL;
     BURN_APPROVED_EXE* pApprovedExe = NULL;
-    REGSAM samDesired = KEY_QUERY_VALUE;
     HKEY hKey = NULL;
     DWORD dwProcessId = 0;
     BYTE* pbSendData = NULL;
@@ -3323,12 +3322,7 @@ static HRESULT OnLaunchApprovedExe(
 
     LogId(REPORT_STANDARD, MSG_LAUNCH_APPROVED_EXE_SEARCH, pApprovedExe->sczKey, pApprovedExe->sczValueName ? pApprovedExe->sczValueName : L"", pApprovedExe->fWin64 ? L"yes" : L"no");
 
-    if (pApprovedExe->fWin64)
-    {
-        samDesired |= KEY_WOW64_64KEY;
-    }
-
-    hr = RegOpen(HKEY_LOCAL_MACHINE, pApprovedExe->sczKey, samDesired, &hKey);
+    hr = RegOpenEx(HKEY_LOCAL_MACHINE, pApprovedExe->sczKey, KEY_QUERY_VALUE, pApprovedExe->fWin64 ? REG_KEY_64BIT : REG_KEY_32BIT, &hKey);
     ExitOnFailure(hr, "Failed to open the registry key for the approved exe path.");
 
     hr = RegReadString(hKey, pApprovedExe->sczValueName, &pLaunchApprovedExe->sczExecutablePath);

--- a/src/burn/engine/search.cpp
+++ b/src/burn/engine/search.cpp
@@ -836,19 +836,13 @@ static HRESULT RegistrySearchExists(
     HKEY hKey = NULL;
     DWORD dwType = 0;
     BOOL fExists = FALSE;
-    REGSAM samDesired = KEY_QUERY_VALUE;
-
-    if (pSearch->RegistrySearch.fWin64)
-    {
-        samDesired = samDesired | KEY_WOW64_64KEY;
-    }
 
     // format key string
     hr = VariableFormatString(pVariables, pSearch->RegistrySearch.sczKey, &sczKey, NULL);
     ExitOnFailure(hr, "Failed to format key string.");
 
     // open key
-    hr = RegOpen(pSearch->RegistrySearch.hRoot, sczKey, samDesired, &hKey);
+    hr = RegOpenEx(pSearch->RegistrySearch.hRoot, sczKey, KEY_QUERY_VALUE, pSearch->RegistrySearch.fWin64 ? REG_KEY_64BIT : REG_KEY_32BIT, &hKey);
     if (SUCCEEDED(hr))
     {
         fExists = TRUE;
@@ -922,12 +916,6 @@ static HRESULT RegistrySearchValue(
     LPBYTE pData = NULL;
     DWORD cch = 0;
     BURN_VARIANT value = { };
-    REGSAM samDesired = KEY_QUERY_VALUE;
-
-    if (pSearch->RegistrySearch.fWin64)
-    {
-        samDesired = samDesired | KEY_WOW64_64KEY;
-    }
 
     // format key string
     hr = VariableFormatString(pVariables, pSearch->RegistrySearch.sczKey, &sczKey, NULL);
@@ -941,7 +929,7 @@ static HRESULT RegistrySearchValue(
     }
 
     // open key
-    hr = RegOpen(pSearch->RegistrySearch.hRoot, sczKey, samDesired, &hKey);
+    hr = RegOpenEx(pSearch->RegistrySearch.hRoot, sczKey, KEY_QUERY_VALUE, pSearch->RegistrySearch.fWin64 ? REG_KEY_64BIT : REG_KEY_32BIT, &hKey);
     if (E_FILENOTFOUND == hr)
     {
         // What if there is a hidden variable in sczKey?

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -2361,7 +2361,7 @@ static HRESULT Get64bitFolderFromRegistry(
     AssertSz(CSIDL_PROGRAM_FILES == nFolder || CSIDL_PROGRAM_FILES_COMMON == nFolder, "Unknown folder CSIDL.");
     LPCWSTR wzFolderValue = CSIDL_PROGRAM_FILES_COMMON == nFolder ? L"CommonFilesDir" : L"ProgramFilesDir";
 
-    hr = RegOpen(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion", KEY_READ | KEY_WOW64_64KEY, &hkFolders);
+    hr = RegOpenEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion", KEY_READ, REG_KEY_64BIT, &hkFolders);
     ExitOnFailure(hr, "Failed to open Windows folder key.");
 
     hr = RegReadString(hkFolders, wzFolderValue, psczPath);

--- a/src/burn/test/BurnUnitTest/RegistrationTest.cpp
+++ b/src/burn/test/BurnUnitTest/RegistrationTest.cpp
@@ -645,7 +645,7 @@ namespace Bootstrapper
                 NativeAssert::Succeeded(hr, "Failed to allocate buffer for related bundle id.");
 
                 // Verify we can find ourself via the UpgradeCode
-                hr = BundleEnumRelatedBundleFixed(TEST_BUNDLE_UPGRADE_CODE, BUNDLE_INSTALL_CONTEXT_USER, &dwRelatedBundleIndex, sczRelatedBundleId);
+                hr = BundleEnumRelatedBundleFixed(TEST_BUNDLE_UPGRADE_CODE, BUNDLE_INSTALL_CONTEXT_USER, REG_KEY_DEFAULT, &dwRelatedBundleIndex, sczRelatedBundleId);
                 TestThrowOnFailure(hr, L"Failed to enumerate related bundle.");
 
                 NativeAssert::StringEqual(TEST_BUNDLE_ID, sczRelatedBundleId);

--- a/src/libs/dutil/WixToolset.DUtil/inc/butil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/butil.h
@@ -60,7 +60,9 @@ HRESULT DAPI BundleGetBundleInfoFixed(
     );
 
 /********************************************************************
-BundleEnumRelatedBundle - Queries the bundle installation metadata for installs with the given upgrade code
+BundleEnumRelatedBundle - Queries the bundle installation metadata for installs with the given upgrade code.
+Enumerate 32-bit and 64-bit in two passes.
+
 RETURNS:
     E_INVALIDARG
         An invalid parameter was passed to the function.
@@ -74,12 +76,14 @@ RETURNS:
 HRESULT DAPI BundleEnumRelatedBundle(
     __in_z LPCWSTR wzUpgradeCode,
     __in BUNDLE_INSTALL_CONTEXT context,
+    __in REG_KEY_BITNESS kbKeyBitness,
     __inout PDWORD pdwStartIndex,
     __deref_out_z LPWSTR* psczBundleId
     );
 
 /********************************************************************
 BundleEnumRelatedBundleFixed - Queries the bundle installation metadata for installs with the given upgrade code
+Enumerate 32-bit and 64-bit in two passes.
 
 NOTE: lpBundleIdBuff is a buffer to receive the bundle GUID. This buffer must be 39 characters long.
         The first 38 characters are for the GUID, and the last character is for the terminating null character.
@@ -96,6 +100,7 @@ RETURNS:
 HRESULT DAPI BundleEnumRelatedBundleFixed(
     __in_z LPCWSTR wzUpgradeCode,
     __in BUNDLE_INSTALL_CONTEXT context,
+    __in REG_KEY_BITNESS kbKeyBitness,
     __inout PDWORD pdwStartIndex,
     __out_ecount(MAX_GUID_CHARS+1) LPWSTR wzBundleId
     );

--- a/src/libs/dutil/WixToolset.DUtil/inc/regutil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/regutil.h
@@ -408,6 +408,15 @@ BOOL DAPI RegValueExists(
     __in REG_KEY_BITNESS kbKeyBitness
     );
 
+/********************************************************************
+RegTranslateKeyBitness - Converts from REG_KEY_BITNESS values to
+REGSAM-compatible values.
+
+*********************************************************************/
+REGSAM DAPI RegTranslateKeyBitness(
+    __in REG_KEY_BITNESS kbKeyBitness
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libs/dutil/WixToolset.DUtil/monutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/monutil.cpp
@@ -1677,18 +1677,7 @@ static REGSAM GetRegKeyBitness(
     __in MON_REQUEST *pRequest
     )
 {
-    if (REG_KEY_32BIT == pRequest->regkey.kbKeyBitness)
-    {
-        return KEY_WOW64_32KEY;
-    }
-    else if (REG_KEY_64BIT == pRequest->regkey.kbKeyBitness)
-    {
-        return KEY_WOW64_64KEY;
-    }
-    else
-    {
-        return 0;
-    }
+    return RegTranslateKeyBitness(pRequest->regkey.kbKeyBitness);
 }
 
 static HRESULT DuplicateRemoveMessage(

--- a/src/libs/dutil/WixToolset.DUtil/precomp.h
+++ b/src/libs/dutil/WixToolset.DUtil/precomp.h
@@ -48,7 +48,6 @@
 #include "apputil.h"
 #include "atomutil.h"
 #include "buffutil.h"
-#include "butil.h"
 #include "cabcutil.h"
 #include "cabutil.h"
 #include "conutil.h"
@@ -76,6 +75,7 @@
 #include "polcutil.h"
 #include "procutil.h"
 #include "regutil.h"
+#include "butil.h"  // NOTE: Butil must come after Regutil.
 #include "resrutil.h"
 #include "reswutil.h"
 #include "rmutil.h"

--- a/src/test/burn/TestData/UpgradeRelatedBundleTests/BundleAv1x64/BundleAv1x64.wixproj
+++ b/src/test/burn/TestData/UpgradeRelatedBundleTests/BundleAv1x64/BundleAv1x64.wixproj
@@ -1,0 +1,16 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk="WixToolset.Sdk">
+  <Import Project="..\BundleAv1\BundleA.props" />
+  <PropertyGroup>
+    <BA>TestBA_x64</BA>
+    <InstallerPlatform>X64</InstallerPlatform>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PackageAv1\PackageAv1.wixproj" />
+    <ProjectReference Include="..\..\TestBA\TestBAWixlib_x64\testbawixlib_x64.wixproj" /> 
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Bal.wixext" />
+    <PackageReference Include="WixToolset.NetFx.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/burn/TestData/UpgradeRelatedBundleTests/BundleAv1x64/BundleAv1x64.wxs
+++ b/src/test/burn/TestData/UpgradeRelatedBundleTests/BundleAv1x64/BundleAv1x64.wxs
@@ -1,0 +1,10 @@
+﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <PackageGroup Id="BundlePackages">
+      <MsiPackage Id="PackageA" SourceFile="$(var.PackageAv1.TargetPath)" />
+    </PackageGroup>
+  </Fragment>
+</Wix>

--- a/src/test/burn/WixToolsetTest.BurnE2E/UpgradeRelatedBundleTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/UpgradeRelatedBundleTests.cs
@@ -49,5 +49,22 @@ namespace WixToolsetTest.BurnE2E
 
             bundleAv1.VerifyUnregisteredAndRemovedFromPackageCache();
         }
+
+        [Fact]
+        public void Bundle32UpgradesBundle64()
+        {
+            var packageAv1 = this.CreatePackageInstaller("PackageAv1");
+            var packageAv2 = this.CreatePackageInstaller("PackageAv2");
+            var bundleAv1x64 = this.CreateBundleInstaller("BundleAv1x64");
+            var bundleAv2 = this.CreateBundleInstaller("BundleAv2");
+
+            bundleAv1x64.Install();
+            bundleAv1x64.VerifyRegisteredAndInPackageCache();
+
+            bundleAv2.Install();
+            bundleAv2.VerifyRegisteredAndInPackageCache();
+             
+            bundleAv1x64.VerifyUnregisteredAndRemovedFromPackageCache();
+        }
     }
 }


### PR DESCRIPTION
- Take advantage of RegOpenEx.
- Always look for related bundles in both 32 and 64 hives.
- BundleEnumRelatedBundle requires caller to specify bitness.