### PR TITLE
Fix NoWarn being overridden and use PackageReference for TestSupport

### DIFF
--- a/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.csproj
+++ b/src/api/burn/WixToolset.Mba.Core/WixToolset.Mba.Core.csproj
@@ -12,7 +12,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <!-- https://github.com/NuGet/Home/issues/10665 -->
-    <NoWarn>NU5128</NoWarn>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(NCrunch)'=='' ">

--- a/src/api/burn/test/WixToolsetTest.Mba.Core/WixToolsetTest.Mba.Core.csproj
+++ b/src/api/burn/test/WixToolsetTest.Mba.Core/WixToolsetTest.Mba.Core.csproj
@@ -15,8 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
-    <ProjectReference Include="..\..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/wix/WixToolset.Data/WixToolset.Data.csproj
+++ b/src/api/wix/WixToolset.Data/WixToolset.Data.csproj
@@ -11,7 +11,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <!-- TODO: This shouldn't be ignored because this is public-facing -->
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/api/wix/test/WixToolsetTest.Data/WixToolsetTest.Data.csproj
+++ b/src/api/wix/test/WixToolsetTest.Data/WixToolsetTest.Data.csproj
@@ -13,8 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
-    <ProjectReference Include="..\..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/ComPlus/test/WixToolsetTest.ComPlus/WixToolsetTest.ComPlus.csproj
+++ b/src/ext/ComPlus/test/WixToolsetTest.ComPlus/WixToolsetTest.ComPlus.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/Dependency/test/WixToolsetTest.Dependency/WixToolsetTest.Dependency.csproj
+++ b/src/ext/Dependency/test/WixToolsetTest.Dependency/WixToolsetTest.Dependency.csproj
@@ -9,10 +9,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/DifxApp/test/WixToolsetTest.DifxApp/WixToolsetTest.DifxApp.csproj
+++ b/src/ext/DifxApp/test/WixToolsetTest.DifxApp/WixToolsetTest.DifxApp.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\UsingDriver\example.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\UsingDriver\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />

--- a/src/ext/DirectX/test/WixToolsetTest.DirectX/WixToolsetTest.DirectX.csproj
+++ b/src/ext/DirectX/test/WixToolsetTest.DirectX/WixToolsetTest.DirectX.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\UsingPixelShaderVersion\example.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\UsingPixelShaderVersion\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />

--- a/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
+++ b/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/Http/test/WixToolsetTest.Http/WixToolsetTest.Http.csproj
+++ b/src/ext/Http/test/WixToolsetTest.Http/WixToolsetTest.Http.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/Iis/test/WixToolsetTest.Iis/WixToolsetTest.Iis.csproj
+++ b/src/ext/Iis/test/WixToolsetTest.Iis/WixToolsetTest.Iis.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\UsingIis\example.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\UsingIis\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\UsingMessageQueue\example.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\UsingMessageQueue\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />

--- a/src/ext/PowerShell/test/WixToolsetTest.PowerShell/WixToolsetTest.Powershell.csproj
+++ b/src/ext/PowerShell/test/WixToolsetTest.PowerShell/WixToolsetTest.Powershell.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/Sql/test/WixToolsetTest.Sql/WixToolsetTest.Sql.csproj
+++ b/src/ext/Sql/test/WixToolsetTest.Sql/WixToolsetTest.Sql.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
+++ b/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
+++ b/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/WixToolsetTest.VisualStudio.csproj
+++ b/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/WixToolsetTest.VisualStudio.csproj
@@ -8,10 +8,6 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/internal/WixBuildTools.MsgGen/WixBuildTools.MsgGen.csproj
+++ b/src/internal/WixBuildTools.MsgGen/WixBuildTools.MsgGen.csproj
@@ -7,7 +7,7 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <NoWarn>CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 

--- a/src/internal/WixBuildTools.TestSupport/WixBuildTools.TestSupport.csproj
+++ b/src/internal/WixBuildTools.TestSupport/WixBuildTools.TestSupport.csproj
@@ -9,7 +9,7 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <CreateDocumentationFile>true</CreateDocumentationFile>
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 

--- a/src/internal/WixBuildTools.XsdGen/WixBuildTools.XsdGen.csproj
+++ b/src/internal/WixBuildTools.XsdGen/WixBuildTools.XsdGen.csproj
@@ -9,7 +9,7 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <NoWarn>CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 

--- a/src/wix/WixToolset.Core.Native/WixToolset.Core.Native.csproj
+++ b/src/wix/WixToolset.Core.Native/WixToolset.Core.Native.csproj
@@ -9,7 +9,7 @@
     <Description>WiX Toolset Native Processing</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <!-- https://github.com/NuGet/Home/issues/10665 -->
-    <NoWarn>NU5128</NoWarn>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
+++ b/src/wix/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.Converters.Symbolizer/WixToolsetTest.Converters.Symbolizer.csproj
+++ b/src/wix/test/WixToolsetTest.Converters.Symbolizer/WixToolsetTest.Converters.Symbolizer.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="WixToolset.Data" />
-    <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
+++ b/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
@@ -24,8 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
-    <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.Core.Burn/WixToolsetTest.Core.Burn.csproj
+++ b/src/wix/test/WixToolsetTest.Core.Burn/WixToolsetTest.Core.Burn.csproj
@@ -9,17 +9,12 @@
     <SignOutput>false</SignOutput>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\WixToolset.Core.Burn\WixToolset.Core.Burn.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
-    <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/test/WixToolsetTest.Heat/WixToolsetTest.Heat.csproj
+++ b/src/wix/test/WixToolsetTest.Heat/WixToolsetTest.Heat.csproj
@@ -18,8 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="WixBuildTools.TestSupport" /> -->
-    <ProjectReference Include="..\..\..\internal\WixBuildTools.TestSupport\WixBuildTools.TestSupport.csproj" />
+    <PackageReference Include="WixBuildTools.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/wix/wix.csproj
+++ b/src/wix/wix/wix.csproj
@@ -16,10 +16,6 @@
     <NuspecBasePath>$(OutputPath)publish\wix\</NuspecBasePath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>NU1701</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\WixToolset.Converters\WixToolset.Converters.csproj" />
     <ProjectReference Include="..\WixToolset.Core\WixToolset.Core.csproj" />


### PR DESCRIPTION
Fixes build failing due to MSB3026 in the TestSupport project.