### PR TITLE
Improve error reporting wrt ExePackage and MsuPackage attributes

### DIFF
--- a/src/ext/Bal/test/examples/EarliestCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/EarliestCoreBundleSCD/SelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleSCD/SelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.EarliestCoreMBA.scd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  PerMachine="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe"  PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/EarliestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/EarliestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.EarliestCoreMBA.trimmedscd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/FullFramework2Bundle/Bundle.wxs
+++ b/src/ext/Bal/test/examples/FullFramework2Bundle/Bundle.wxs
@@ -8,7 +8,7 @@
             <bal:WixManagedBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe"  bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/FullFramework4Bundle/Bundle.wxs
+++ b/src/ext/Bal/test/examples/FullFramework4Bundle/Bundle.wxs
@@ -8,7 +8,7 @@
             <bal:WixManagedBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleSCD/SelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleSCD/SelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.LatestCoreMBA.scd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/LatestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
+++ b/src/ext/Bal/test/examples/LatestCoreBundleTrimmedSCD/TrimmedSelfContainedBundle.wxs
@@ -5,7 +5,7 @@
             <PayloadGroupRef Id="publish.Example.LatestCoreMBA.trimmedscd" />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" PerMachine="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/ext/Bal/test/examples/WPFCoreBundleFDD/FrameworkDependentBundle.wxs
+++ b/src/ext/Bal/test/examples/WPFCoreBundleFDD/FrameworkDependentBundle.wxs
@@ -9,7 +9,7 @@
             <bal:WixDotNetCoreBootstrapperApplicationHost />
         </BootstrapperApplication>
         <Chain>
-            <ExePackage DetectCondition="none" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
+            <ExePackage DetectCondition="none" UninstallArguments="-foo" SourceFile="..\.data\notanexe.exe" bal:PrereqPackage="yes" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/test/burn/TestData/DependencyTests/BundleE/BundleE.wxs
+++ b/src/test/burn/TestData/DependencyTests/BundleE/BundleE.wxs
@@ -9,7 +9,7 @@
     <PackageGroup Id="BundlePackages">
       <MsiPackage Id="PackageA" SourceFile="$(var.PackageAv1.TargetPath)" />
       <MsiPackage Id="PackageC" SourceFile="$(var.PackageC.TargetPath)" Vital="no" />
-      <ExePackage Id="ExeA" Cache="remove" Vital="no" PerMachine="yes" InstallArguments="/ec 1603"
+      <ExePackage Id="ExeA" Cache="remove" Vital="no" PerMachine="yes" InstallArguments="/ec 1603" UninstallArguments=""
                   DetectCondition="ExeA_Version AND ExeA_Version &gt;= v$(var.Version)">
         <Provides Key="$(var.TestGroupName)_ExeA,v1.0" Version="$(var.Version)" />
         <PayloadGroupRef Id="TestExePayloads" />

--- a/src/wix/test/WixToolsetTest.CoreIntegration/ExePackageFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/ExePackageFixture.cs
@@ -3,6 +3,7 @@
 namespace WixToolsetTest.CoreIntegration
 {
     using System.IO;
+    using System.Linq;
     using WixBuildTools.TestSupport;
     using WixToolset.Core.TestPackage;
     using Xunit;
@@ -25,6 +26,11 @@ namespace WixToolsetTest.CoreIntegration
                     "-o", Path.Combine(baseFolder, "test.wixlib")
                 });
 
+                WixAssert.CompareLineByLine(new[]
+                {
+                    "The ExePackage element's UninstallArguments attribute was not found; it is required without attribute Permanent present.",
+                    "The ExePackage/@DetectCondition attribute is recommended so the package is only installed when absent."
+                }, result.Messages.Select(m => m.ToString()).ToArray());
                 Assert.Equal(1153, result.ExitCode);
             }
         }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
@@ -2,13 +2,11 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Xml;
     using WixBuildTools.TestSupport;
-    using WixToolset.Core;
     using WixToolset.Core.TestPackage;
     using WixToolset.Data;
     using WixToolset.Data.Symbols;

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" DetectCondition="test" CacheId="!(wix.WixVariable1)" />
-            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" DetectCondition="test" CacheId="!(wix.WixVariable2)" />
+            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" DetectCondition="test" UninstallArguments="-u" CacheId="!(wix.WixVariable1)" />
+            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" DetectCondition="test" UninstallArguments="-u" CacheId="!(wix.WixVariable2)" />
         </PackageGroup>
 
         <WixVariable Id="WixVariable1" Value="CollidingCacheId" />

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicatePayloadNames.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicatePayloadNames.wxs
@@ -2,12 +2,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" />
-            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" />
-            <ExePackage Id="DuplicateCacheIds.wxs" SourceFile="$(sys.SOURCEFILEDIR)DuplicateCacheIds.wxs" Compressed="no" DetectCondition="none" Name="PayloadCollision">
+            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" UninstallArguments="-u" />
+            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" UninstallArguments="-u" />
+            <ExePackage Id="DuplicateCacheIds.wxs" SourceFile="$(sys.SOURCEFILEDIR)DuplicateCacheIds.wxs" Compressed="no" DetectCondition="none" UninstallArguments="-u" Name="PayloadCollision">
                 <Payload SourceFile="$(sys.SOURCEFILEDIR)BundleVariable.wxs" Compressed="no" Name="ContainerCollision" />
             </ExePackage>
-            <ExePackage Id="HiddenPersistedBundleVariable.wxs" SourceFile="$(sys.SOURCEFILEDIR)HiddenPersistedBundleVariable.wxs" Compressed="no" DetectCondition="none" Name="PayloadCollision" />
+            <ExePackage Id="HiddenPersistedBundleVariable.wxs" SourceFile="$(sys.SOURCEFILEDIR)HiddenPersistedBundleVariable.wxs" Compressed="no" DetectCondition="none" UninstallArguments="-u" Name="PayloadCollision" />
             <PackageGroupRef Id="MsiPackages" />
         </PackageGroup>
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/UnscheduledPackage.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/UnscheduledPackage.wxs
@@ -2,15 +2,15 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" />
-            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" />
+            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" UninstallArguments="-u" />
+            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" UninstallArguments="-u" />
         </PackageGroup>
         <SetVariableRef Id="Dummy" />
     </Fragment>
     <Fragment>
         <SetVariable Id="Dummy" Variable="Dummy" />
         <PackageGroup Id="Unscheduled">
-            <ExePackage Id="Unscheduled1" SourceFile="burn.exe" CacheId="Unscheduled1" DetectCondition="none" />
+            <ExePackage Id="Unscheduled1" SourceFile="burn.exe" CacheId="Unscheduled1" DetectCondition="none" UninstallArguments="-u" />
         </PackageGroup>
     </Fragment>
 </Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/UnscheduledRollbackBoundary.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BadInput/UnscheduledRollbackBoundary.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" />
-            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" />
+            <ExePackage Id="Auto1" SourceFile="burn.exe" CacheId="Auto1" DetectCondition="none" UninstallArguments="-u" />
+            <ExePackage Id="Auto2" SourceFile="burn.exe" CacheId="Auto2" DetectCondition="none" UninstallArguments="-u" />
         </PackageGroup>
         <SetVariableRef Id="Dummy" />
     </Fragment>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Dependency/ExePackageProvidesBundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Dependency/ExePackageProvidesBundle.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage DetectCondition="DetectedSomething" SourceFile="burn.exe">
+            <ExePackage DetectCondition="DetectedSomething" UninstallArguments="-u" SourceFile="burn.exe">
                 <Provides Key="DependencyTests_ExeA,v1.0" Version="1.0.0.0" />
             </ExePackage>
         </PackageGroup>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/MsuPackage/Bundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/MsuPackage/Bundle.wxs
@@ -5,7 +5,7 @@
         </BootstrapperApplication>
         
         <Chain>
-            <MsuPackage DetectCondition="DetectedTheMsu" SourceFile="test.msu" />
+            <MsuPackage DetectCondition="DetectedTheMsu" KB="xyz" SourceFile="test.msu" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Payload/DownloadUrlPlaceholdersBundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Payload/DownloadUrlPlaceholdersBundle.wxs
@@ -14,7 +14,7 @@
     </Bundle>
     <Fragment>
         <PackageGroup Id="ContainerPackages">
-            <ExePackage SourceFile="burn.exe" DetectCondition="none" Compressed="no" />
+            <ExePackage SourceFile="burn.exe" DetectCondition="none" UninstallArguments="-u" Compressed="no" />
         </PackageGroup>
     </Fragment>
     <Fragment>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Payload/SharedBAAndPackagePayloadBundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Payload/SharedBAAndPackagePayloadBundle.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage SourceFile="burn.exe" DetectCondition="none">
+            <ExePackage SourceFile="burn.exe" DetectCondition="none" UninstallArguments="-u">
                 <PayloadGroupRef Id="Shared" />
             </ExePackage>
         </PackageGroup>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleExeBundle/SingleExePackageGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleExeBundle/SingleExePackageGroup.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage DetectCondition="DetectedSomething" SourceFile="burn.exe" />
+            <ExePackage DetectCondition="DetectedSomething" UninstallArguments="-uninstall" SourceFile="burn.exe" />
         </PackageGroup>
     </Fragment>
 </Wix>


### PR DESCRIPTION
For example, DetectCondition is required when RepairArguments or UninstallArguments present and always recommended. Also, non-permanent ExePackages need UninstallArguments. The code was refactored to make it easier to reason over the different requirements for different package types.

Fixes wixtoolset/issues#6458
Fixes wixtoolset/issues#6459
