### PR TITLE
Some build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,16 @@ jobs:
         shell: cmd
         run: 7z a "build\logs\test_burn_%GITHUB_RUN_ID%.zip" "%TEMP%\*.log" "%TEMP%\..\*.log"
 
+      - name: Export Application event log
+        if: always()
+        shell: cmd
+        run: wevtutil epl Application build\logs\Application.evtx /q:"Event/System/TimeCreated[timediff(@SystemTime) <= 86400000]"
+
+      - name: Export System event log
+        if: always()
+        shell: cmd
+        run: wevtutil epl System build\logs\System.evtx /q:"Event/System/TimeCreated[timediff(@SystemTime) <= 86400000]"
+
       - name: Save logs
         if: always()
         uses: actions/upload-artifact@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,8 @@ after_build:
   - 7z a "build\testresults.zip" @src\testresultfilelist.txt
 
 on_finish:
+  - wevtutil epl Application build\logs\Application.evtx /q:"Event/System/TimeCreated[timediff(@SystemTime) <= 86400000]"
+  - wevtutil epl System build\logs\System.evtx /q:"Event/System/TimeCreated[timediff(@SystemTime) <= 86400000]"
   - ps: 7z a ('temp_logs_' + (Get-Date).tostring("yyyyMMddHHmmss") + '.zip') $env:TEMP\*.log $env:TEMP\..\*.log
   - ps: 7z a ('build_logs_' + (Get-Date).tostring("yyyyMMddHHmmss") + '.zip') build\logs\ build\logs\TestResults\
   - ps: Push-AppveyorArtifact temp_logs_*.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ image: Visual Studio 2022
 version: 0.0.0.{build}
 configuration: Release
 
+init:
+  - git config --global core.autocrlf true
+
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
Export event logs to try to diagnose https://github.com/wixtoolset/issues/issues/6695, since it always fails with that specific test.
Force Appveyor to checkout using CRLF.

Might need to disable the event log export and the MSBuild .binlogs for release builds to avoid exposing secrets.