### PR TITLE
Change ARP property Installed to 0 when registrationType is InProgress

### DIFF
--- a/src/api/burn/WixToolset.BootstrapperCore.Native/inc/BootstrapperApplication.h
+++ b/src/api/burn/WixToolset.BootstrapperCore.Native/inc/BootstrapperApplication.h
@@ -642,7 +642,7 @@ struct BA_ONCOMMITMSITRANSACTIONCOMPLETE_RESULTS
 struct BA_ONDETECTBEGIN_ARGS
 {
     DWORD cbSize;
-    BOOL fInstalled;
+    BOOTSTRAPPER_REGISTRATION_TYPE registrationType;
     DWORD cPackages;
     BOOL fCached;
 };

--- a/src/api/burn/WixToolset.Mba.Core/BootstrapperApplication.cs
+++ b/src/api/burn/WixToolset.Mba.Core/BootstrapperApplication.cs
@@ -1378,9 +1378,9 @@ namespace WixToolset.Mba.Core
             return args.HResult;
         }
 
-        int IBootstrapperApplication.OnDetectBegin(bool fCached, bool fInstalled, int cPackages, ref bool fCancel)
+        int IBootstrapperApplication.OnDetectBegin(bool fCached, RegistrationType registrationType, int cPackages, ref bool fCancel)
         {
-            DetectBeginEventArgs args = new DetectBeginEventArgs(fCached, fInstalled, cPackages, fCancel);
+            DetectBeginEventArgs args = new DetectBeginEventArgs(fCached, registrationType, cPackages, fCancel);
             this.OnDetectBegin(args);
 
             fCancel = args.Cancel;

--- a/src/api/burn/WixToolset.Mba.Core/EventArgs.cs
+++ b/src/api/burn/WixToolset.Mba.Core/EventArgs.cs
@@ -249,11 +249,11 @@ namespace WixToolset.Mba.Core
     public class DetectBeginEventArgs : CancellableHResultEventArgs
     {
         /// <summary />
-        public DetectBeginEventArgs(bool cached, bool installed, int packageCount, bool cancelRecommendation)
+        public DetectBeginEventArgs(bool cached, RegistrationType registrationType, int packageCount, bool cancelRecommendation)
             : base(cancelRecommendation)
         {
             this.Cached = cached;
-            this.Installed = installed;
+            this.RegistrationType = registrationType;
             this.PackageCount = packageCount;
         }
 
@@ -263,9 +263,9 @@ namespace WixToolset.Mba.Core
         public bool Cached { get; private set; }
 
         /// <summary>
-        /// Gets whether the bundle is installed.
+        /// Gets the bundle's registration state.
         /// </summary>
-        public bool Installed { get; private set; }
+        public RegistrationType RegistrationType { get; private set; }
 
         /// <summary>
         /// Gets the number of packages to detect.

--- a/src/api/burn/WixToolset.Mba.Core/IBootstrapperApplication.cs
+++ b/src/api/burn/WixToolset.Mba.Core/IBootstrapperApplication.cs
@@ -70,7 +70,7 @@ namespace WixToolset.Mba.Core
         [return: MarshalAs(UnmanagedType.I4)]
         int OnDetectBegin(
             [MarshalAs(UnmanagedType.Bool)] bool fCached,
-            [MarshalAs(UnmanagedType.Bool)] bool fInstalled,
+            [MarshalAs(UnmanagedType.U4)] RegistrationType registrationType,
             [MarshalAs(UnmanagedType.U4)] int cPackages,
             [MarshalAs(UnmanagedType.Bool)] ref bool fCancel
             );

--- a/src/api/burn/balutil/inc/BalBaseBAFunctions.h
+++ b/src/api/burn/balutil/inc/BalBaseBAFunctions.h
@@ -108,7 +108,7 @@ public: // IBootstrapperApplication
 
     virtual STDMETHODIMP OnDetectBegin(
         __in BOOL /*fCached*/,
-        __in BOOL /*fInstalled*/,
+        __in BOOTSTRAPPER_REGISTRATION_TYPE /*registrationType*/,
         __in DWORD /*cPackages*/,
         __inout BOOL* /*pfCancel*/
         )

--- a/src/api/burn/balutil/inc/BalBaseBootstrapperApplication.h
+++ b/src/api/burn/balutil/inc/BalBaseBootstrapperApplication.h
@@ -109,7 +109,7 @@ public: // IBootstrapperApplication
 
     virtual STDMETHODIMP OnDetectBegin(
         __in BOOL /*fCached*/,
-        __in BOOL /*fInstalled*/,
+        __in BOOTSTRAPPER_REGISTRATION_TYPE /*registrationType*/,
         __in DWORD /*cPackages*/,
         __inout BOOL* pfCancel
         )

--- a/src/api/burn/balutil/inc/BalBaseBootstrapperApplicationProc.h
+++ b/src/api/burn/balutil/inc/BalBaseBootstrapperApplicationProc.h
@@ -15,7 +15,7 @@ static HRESULT BalBaseBAProcOnDetectBegin(
     __inout BA_ONDETECTBEGIN_RESULTS* pResults
     )
 {
-    return pBA->OnDetectBegin(pArgs->fCached, pArgs->fInstalled, pArgs->cPackages, &pResults->fCancel);
+    return pBA->OnDetectBegin(pArgs->fCached, pArgs->registrationType, pArgs->cPackages, &pResults->fCancel);
 }
 
 static HRESULT BalBaseBAProcOnDetectComplete(

--- a/src/api/burn/balutil/inc/IBootstrapperApplication.h
+++ b/src/api/burn/balutil/inc/IBootstrapperApplication.h
@@ -42,7 +42,7 @@ DECLARE_INTERFACE_IID_(IBootstrapperApplication, IUnknown, "53C31D56-49C0-426B-A
     // OnDetectBegin - called when the engine begins detection.
     STDMETHOD(OnDetectBegin)(
         __in BOOL fCached,
-        __in BOOL fInstalled,
+        __in BOOTSTRAPPER_REGISTRATION_TYPE registrationType,
         __in DWORD cPackages,
         __inout BOOL* pfCancel
         ) = 0;

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -264,10 +264,6 @@ extern "C" HRESULT CoreQueryRegistration(
     SIZE_T cbBuffer = 0;
     SIZE_T iBuffer = 0;
 
-    // Detect if bundle is already installed.
-    hr = RegistrationDetectInstalled(&pEngineState->registration);
-    ExitOnFailure(hr, "Failed to detect bundle install state.");
-
     // detect resume type
     hr = RegistrationDetectResumeType(&pEngineState->registration, &pEngineState->command.resumeType);
     ExitOnFailure(hr, "Failed to detect resume type.");
@@ -314,14 +310,6 @@ extern "C" HRESULT CoreDetect(
     pEngineState->fPlanned = FALSE;
     DetectReset(&pEngineState->registration, &pEngineState->packages);
     PlanReset(&pEngineState->plan, &pEngineState->containers, &pEngineState->packages, &pEngineState->layoutPayloads);
-
-    // Detect if bundle installed state has changed since start up.
-    // This only happens if Apply() changed the state of bundle (installed, in progress, or uninstalled).
-    // In that case, Detect() can be used here to reset the installed state.
-    // Of course, there's also cases outside of this bundle's control,
-    // like other processes messing with its registration.
-    hr = RegistrationDetectInstalled(&pEngineState->registration);
-    ExitOnFailure(hr, "Failed to detect bundle install state.");
 
     hr = RegistrationSetDynamicVariables(&pEngineState->registration, &pEngineState->variables);
     ExitOnFailure(hr, "Failed to reset the dynamic registration variables during detect.");

--- a/src/burn/engine/detect.cpp
+++ b/src/burn/engine/detect.cpp
@@ -165,7 +165,7 @@ extern "C" HRESULT DetectReportRelatedBundles(
 {
     HRESULT hr = S_OK;
     BOOTSTRAPPER_REQUEST_STATE uninstallRequestState = BOOTSTRAPPER_REQUEST_STATE_NONE;
-    *pfEligibleForCleanup = pRegistration->fInstalled || pRegistration->fCached;
+    *pfEligibleForCleanup = BOOTSTRAPPER_REGISTRATION_TYPE_NONE != pRegistration->detectedRegistrationType || pRegistration->fCached;
 
     for (DWORD iRelatedBundle = 0; iRelatedBundle < pRegistration->relatedBundles.cRelatedBundles; ++iRelatedBundle)
     {

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -178,6 +178,7 @@ static HRESULT OnApplyInitialize(
     );
 static HRESULT ElevatedProcessDetect(
     __in BURN_REGISTRATION* pRegistration,
+    __in BURN_VARIABLES* pVariables,
     __in BURN_PACKAGES* pPackages
     );
 static HRESULT OnApplyUninitialize(
@@ -2245,7 +2246,7 @@ static HRESULT OnApplyInitialize(
     ExitOnFailure(hr, "Failed to acquire lock due to setup in other session.");
 
     // Detect.
-    hr = ElevatedProcessDetect(pRegistration, pPackages);
+    hr = ElevatedProcessDetect(pRegistration, pVariables, pPackages);
     ExitOnFailure(hr, "Failed to run detection in elevated process.");
 
     // Attempt to pause AU with best effort.
@@ -2331,12 +2332,16 @@ LExit:
 
 static HRESULT ElevatedProcessDetect(
     __in BURN_REGISTRATION* pRegistration,
+    __in BURN_VARIABLES* pVariables,
     __in BURN_PACKAGES* pPackages
     )
 {
     HRESULT hr = S_OK;
 
     DetectReset(pRegistration, pPackages);
+
+    hr = RegistrationSetDynamicVariables(pRegistration, pVariables);
+    ExitOnFailure(hr, "Failed to reset the dynamic registration variables during elevated detect.");
 
     hr = RelatedBundlesInitializeForScope(TRUE, pRegistration, &pRegistration->relatedBundles);
     ExitOnFailure(hr, "Failed to initialize per-machine related bundles.");

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -335,7 +335,7 @@ MessageId=199
 Severity=Success
 SymbolicName=MSG_DETECT_COMPLETE
 Language=English
-Detect complete, result: 0x%1!x!, installed: %2!hs!, cached: %3!hs!, eligible for cleanup: %4!hs!
+Detect complete, result: 0x%1!x!, registration state: %2!hs!, cached: %3!hs!, eligible for cleanup: %4!hs!
 .
 
 MessageId=200

--- a/src/burn/engine/plan.cpp
+++ b/src/burn/engine/plan.cpp
@@ -1692,7 +1692,7 @@ extern "C" HRESULT PlanExecuteCacheSyncAndRollback(
     HRESULT hr = S_OK;
     BURN_EXECUTE_ACTION* pAction = NULL;
 
-    if (!pPlan->fBundleAlreadyRegistered)
+    if (pPlan->fPlanPackageCacheRollback)
     {
         hr = PlanAppendRollbackAction(pPlan, &pAction);
         ExitOnFailure(hr, "Failed to append rollback action.");
@@ -2241,7 +2241,7 @@ static HRESULT AddCachePackageHelper(
     pCacheAction->type = BURN_CACHE_ACTION_TYPE_CHECKPOINT;
     pCacheAction->checkpoint.dwId = dwCheckpoint;
 
-    if (!pPlan->fBundleAlreadyRegistered)
+    if (pPlan->fPlanPackageCacheRollback)
     {
         // Create a package cache rollback action *before* the checkpoint.
         hr = AppendRollbackCacheAction(pPlan, &pCacheAction);

--- a/src/burn/engine/plan.h
+++ b/src/burn/engine/plan.h
@@ -249,7 +249,7 @@ typedef struct _BURN_PLAN
     BOOL fDisableRollback;
     BOOL fAffectedMachineState;
     LPWSTR sczLayoutDirectory;
-    BOOL fBundleAlreadyRegistered;
+    BOOL fPlanPackageCacheRollback;
 
     DWORD64 qwCacheSizeTotal;
 

--- a/src/burn/engine/registration.cpp
+++ b/src/burn/engine/registration.cpp
@@ -484,7 +484,13 @@ extern "C" HRESULT RegistrationSetDynamicVariables(
     )
 {
     HRESULT hr = S_OK;
-    LONGLONG llInstalled = BOOTSTRAPPER_REGISTRATION_TYPE_FULL == pRegistration->detectedRegistrationType ? 1 : 0;
+    LONGLONG llInstalled = 0;
+
+    // Detect if bundle is already installed.
+    hr = RegistrationDetectInstalled(pRegistration);
+    ExitOnFailure(hr, "Failed to detect bundle install state.");
+
+    llInstalled = BOOTSTRAPPER_REGISTRATION_TYPE_FULL == pRegistration->detectedRegistrationType ? 1 : 0;
 
     hr = VariableSetNumeric(pVariables, BURN_BUNDLE_INSTALLED, llInstalled, TRUE);
     ExitOnFailure(hr, "Failed to set the bundle installed built-in variable.");

--- a/src/burn/engine/registration.h
+++ b/src/burn/engine/registration.h
@@ -93,7 +93,7 @@ typedef struct _BURN_REGISTRATION
     BOOL fRegisterArp;
     BOOL fDisableResume;
     BOOL fCached;
-    BOOL fInstalled;
+    BOOTSTRAPPER_REGISTRATION_TYPE detectedRegistrationType;
     LPWSTR sczId;
     LPWSTR sczTag;
 
@@ -168,6 +168,10 @@ void RegistrationUninitialize(
     __in BURN_REGISTRATION* pRegistration
     );
 HRESULT RegistrationSetVariables(
+    __in BURN_REGISTRATION* pRegistration,
+    __in BURN_VARIABLES* pVariables
+    );
+HRESULT RegistrationSetDynamicVariables(
     __in BURN_REGISTRATION* pRegistration,
     __in BURN_VARIABLES* pVariables
     );

--- a/src/burn/engine/userexperience.cpp
+++ b/src/burn/engine/userexperience.cpp
@@ -104,7 +104,7 @@ extern "C" HRESULT UserExperienceLoad(
     args.pCommand = pCommand;
     args.pfnBootstrapperEngineProc = EngineForApplicationProc;
     args.pvBootstrapperEngineProcContext = pEngineContext;
-    args.qwEngineAPIVersion = MAKEQWORDVERSION(2022, 2, 22, 0);
+    args.qwEngineAPIVersion = MAKEQWORDVERSION(2022, 3, 4, 0);
 
     results.cbSize = sizeof(BOOTSTRAPPER_CREATE_RESULTS);
 
@@ -988,7 +988,7 @@ LExit:
 EXTERN_C BAAPI UserExperienceOnDetectBegin(
     __in BURN_USER_EXPERIENCE* pUserExperience,
     __in BOOL fCached,
-    __in BOOL fInstalled,
+    __in BOOTSTRAPPER_REGISTRATION_TYPE registrationType,
     __in DWORD cPackages
     )
 {
@@ -998,7 +998,7 @@ EXTERN_C BAAPI UserExperienceOnDetectBegin(
 
     args.cbSize = sizeof(args);
     args.cPackages = cPackages;
-    args.fInstalled = fInstalled;
+    args.registrationType = registrationType;
     args.fCached = fCached;
 
     results.cbSize = sizeof(results);

--- a/src/burn/engine/userexperience.h
+++ b/src/burn/engine/userexperience.h
@@ -245,7 +245,7 @@ BAAPI UserExperienceOnCommitMsiTransactionComplete(
 BAAPI UserExperienceOnDetectBegin(
     __in BURN_USER_EXPERIENCE* pUserExperience,
     __in BOOL fCached,
-    __in BOOL fInstalled,
+    __in BOOTSTRAPPER_REGISTRATION_TYPE registrationType,
     __in DWORD cPackages
     );
 BAAPI UserExperienceOnDetectCompatibleMsiPackage(

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -271,7 +271,7 @@ extern "C" HRESULT VariableInitialize(
         {BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, InitializeVariableString, NULL, FALSE, TRUE},
         {BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, InitializeVariableString, NULL, FALSE, TRUE},
         {BURN_BUNDLE_FORCED_RESTART_PACKAGE, InitializeVariableString, NULL, TRUE, TRUE},
-        {BURN_BUNDLE_INSTALLED, InitializeVariableNumeric, 0, FALSE, TRUE},
+        {BURN_BUNDLE_INSTALLED, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_ELEVATED, InitializeVariableNumeric, 0, FALSE, TRUE},
         {BURN_BUNDLE_ACTIVE_PARENT, InitializeVariableString, NULL, FALSE, TRUE},
         {BURN_BUNDLE_PROVIDER_KEY, InitializeVariableString, (DWORD_PTR)L"", FALSE, TRUE},

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -248,6 +248,7 @@ extern "C" HRESULT VariableInitialize(
 #endif
         {L"ProgramFiles6432Folder", InitializeVariable6432Folder, CSIDL_PROGRAM_FILES},
         {L"ProgramMenuFolder", InitializeVariableCsidlFolder, CSIDL_PROGRAMS},
+        {L"RebootPending", InitializeVariableNumeric, 0},
         {L"SendToFolder", InitializeVariableCsidlFolder, CSIDL_SENDTO},
         {L"ServicePackLevel", InitializeVariableVersionNT, OS_INFO_VARIABLE_ServicePackLevel},
         {L"StartMenuFolder", InitializeVariableCsidlFolder, CSIDL_STARTMENU},
@@ -1571,6 +1572,9 @@ static HRESULT SetVariableValue(
     // Insert element if not found.
     if (S_FALSE == hr)
     {
+        // Not possible from external callers so just assert.
+        AssertSz(SET_VARIABLE_OVERRIDE_BUILTIN != setBuiltin, "Intent to set missing built-in variable.");
+
         hr = InsertVariable(pVariables, wzVariable, iVariable);
         ExitOnFailure(hr, "Failed to insert variable '%ls'.", wzVariable);
     }

--- a/src/burn/test/BurnUnitTest/PlanTest.cpp
+++ b/src/burn/test/BurnUnitTest/PlanTest.cpp
@@ -792,7 +792,7 @@ namespace Bootstrapper
             InitializeEngineStateForCorePlan(wzSingleMsiManifestFileName, pEngineState);
             DetectPackagesAsAbsent(pEngineState);
 
-            pEngineState->registration.fInstalled = TRUE;
+            pEngineState->registration.detectedRegistrationType = BOOTSTRAPPER_REGISTRATION_TYPE_FULL;
 
             hr = CorePlan(pEngineState, BOOTSTRAPPER_ACTION_MODIFY);
             NativeAssert::Succeeded(hr, "CorePlan failed");
@@ -1457,7 +1457,7 @@ namespace Bootstrapper
         {
             PlanTestDetect(pEngineState);
 
-            pEngineState->registration.fInstalled = TRUE;
+            pEngineState->registration.detectedRegistrationType = BOOTSTRAPPER_REGISTRATION_TYPE_FULL;
 
             for (DWORD i = 0; i < pEngineState->packages.cPackages; ++i)
             {
@@ -1486,7 +1486,7 @@ namespace Bootstrapper
         {
             PlanTestDetect(pEngineState);
 
-            pEngineState->registration.fInstalled = TRUE;
+            pEngineState->registration.detectedRegistrationType = BOOTSTRAPPER_REGISTRATION_TYPE_FULL;
 
             for (DWORD i = 0; i < pEngineState->packages.cPackages; ++i)
             {

--- a/src/burn/test/BurnUnitTest/RegistrationTest.cpp
+++ b/src/burn/test/BurnUnitTest/RegistrationTest.cpp
@@ -218,7 +218,7 @@ namespace Bootstrapper
 
                 // verify that registration was updated
                 this->ValidateUninstallKeyResume(Int32(BURN_RESUME_MODE_ARP));
-                this->ValidateUninstallKeyInstalled(1);
+                this->ValidateUninstallKeyInstalled(0);
                 this->ValidateRunOnceKeyString(TEST_BUNDLE_ID, nullptr);
 
                 //
@@ -231,7 +231,7 @@ namespace Bootstrapper
 
                 // verify that registration was updated
                 this->ValidateUninstallKeyResume(Int32(BURN_RESUME_MODE_ACTIVE));
-                this->ValidateUninstallKeyInstalled(1);
+                this->ValidateUninstallKeyInstalled(0);
                 this->ValidateRunOnceKeyEntry(cacheExePath);
 
                 // delete registration
@@ -337,7 +337,7 @@ namespace Bootstrapper
 
                 // verify that registration variables were updated
                 this->ValidateUninstallKeyDisplayName(L"Product1");
-                registration.fInstalled = TRUE;
+                registration.detectedRegistrationType = BOOTSTRAPPER_REGISTRATION_TYPE_FULL;
 
                 hr = RegistrationSetVariables(&registration, &variables);
                 TestThrowOnFailure(hr, L"Failed to set registration variables.");

--- a/src/ext/Bal/Samples/bafunctions/WixSampleBAFunctions.cpp
+++ b/src/ext/Bal/Samples/bafunctions/WixSampleBAFunctions.cpp
@@ -9,14 +9,14 @@ class CWixSampleBAFunctions : public CBalBaseBAFunctions
 public: // IBootstrapperApplication
     virtual STDMETHODIMP OnDetectBegin(
         __in BOOL fCached,
-        __in BOOL fInstalled,
+        __in BOOTSTRAPPER_REGISTRATION_TYPE registrationType,
         __in DWORD cPackages,
         __inout BOOL* pfCancel
         )
     {
         HRESULT hr = S_OK;
 
-        BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Running detect begin BA function. fCached=%d, fInstalled=%d, cPackages=%u, fCancel=%d", fCached, fInstalled, cPackages, *pfCancel);
+        BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Running detect begin BA function. fCached=%d, registrationType=%d, cPackages=%u, fCancel=%d", fCached, registrationType, cPackages, *pfCancel);
 
         //-------------------------------------------------------------------------------------------------
         // YOUR CODE GOES HERE

--- a/src/test/burn/WixToolset.WixBA/InstallationViewModel.cs
+++ b/src/test/burn/WixToolset.WixBA/InstallationViewModel.cs
@@ -53,9 +53,9 @@ namespace WixToolset.WixBA
     /// </summary>
     public class InstallationViewModel : PropertyNotifyBase
     {
-        private RootViewModel root;
+        private readonly RootViewModel root;
 
-        private Dictionary<string, int> downloadRetries;
+        private readonly Dictionary<string, int> downloadRetries;
         private bool downgrade;
         private string downgradeMessage;
 
@@ -407,7 +407,7 @@ namespace WixToolset.WixBA
 
         private void DetectBegin(object sender, DetectBeginEventArgs e)
         {
-            this.root.DetectState = e.Installed ? DetectionState.Present : DetectionState.Absent;
+            this.root.DetectState = RegistrationType.Full == e.RegistrationType ? DetectionState.Present : DetectionState.Absent;
             WixBA.Model.PlannedAction = LaunchAction.Unknown;
         }
 


### PR DESCRIPTION
Being registered in ARP and "installed" were always separate concepts, and some things like fEligibleForCleanup were looking at the wrong thing. This also allows the BA to tell the difference.