### PR TITLE
Centralize cache locations in IExtensionManager

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/Data/IExtensionCacheLocation.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IExtensionCacheLocation.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Extensibility.Data
+{
+    /// <summary>
+    /// Extension cache location scope.
+    /// </summary>
+    public enum ExtensionCacheLocationScope
+    {
+        /// <summary>
+        /// Project extension cache location.
+        /// </summary>
+        Project,
+
+        /// <summary>
+        /// User extension cache location.
+        /// </summary>
+        User,
+
+        /// <summary>
+        /// Machine extension cache location.
+        /// </summary>
+        Machine,
+    }
+
+    /// <summary>
+    /// Location where extensions may be cached.
+    /// </summary>
+    public interface IExtensionCacheLocation
+    {
+        /// <summary>
+        /// Path for  the extension cache location.
+        /// </summary>
+        string Path { get; }
+
+        /// <summary>
+        /// Scope for the extension cache location.
+        /// </summary>
+        ExtensionCacheLocationScope Scope { get; }
+    }
+}

--- a/src/api/wix/WixToolset.Extensibility/Services/IExtensionManager.cs
+++ b/src/api/wix/WixToolset.Extensibility/Services/IExtensionManager.cs
@@ -4,6 +4,7 @@ namespace WixToolset.Extensibility.Services
 {
     using System.Collections.Generic;
     using System.Reflection;
+    using WixToolset.Extensibility.Data;
 
     /// <summary>
     /// Loads extensions and uses the extensions' factories to provide services.
@@ -31,6 +32,12 @@ namespace WixToolset.Extensibility.Services
         /// </list>
         /// </remarks>
         void Load(string extensionReference);
+
+        /// <summary>
+        /// Gets extensions cache locations.
+        /// </summary>
+        /// <returns>List of cache locations where extensions may be found.</returns>
+        IReadOnlyCollection<IExtensionCacheLocation> GetCacheLocations();
 
         /// <summary>
         /// Gets extensions of specified type from factories loaded into the extension manager.

--- a/src/wix/WixToolset.Core.ExtensionCache/ExtensionCacheManagerCommand.cs
+++ b/src/wix/WixToolset.Core.ExtensionCache/ExtensionCacheManagerCommand.cs
@@ -25,16 +25,19 @@ namespace WixToolset.Core.ExtensionCache
         public ExtensionCacheManagerCommand(IServiceProvider serviceProvider)
         {
             this.Messaging = serviceProvider.GetService<IMessaging>();
+            this.ExtensionManager = serviceProvider.GetService<IExtensionManager>();
             this.ExtensionReferences = new List<string>();
         }
-
-        private IMessaging Messaging { get; }
 
         public bool ShowHelp { get; set; }
 
         public bool ShowLogo { get; set; }
 
         public bool StopParsing { get; set; }
+
+        private IMessaging Messaging { get; }
+
+        private IExtensionManager ExtensionManager { get; }
 
         private bool Global { get; set; }
 
@@ -51,7 +54,7 @@ namespace WixToolset.Core.ExtensionCache
             }
 
             var success = false;
-            var cacheManager = new ExtensionCacheManager();
+            var cacheManager = new ExtensionCacheManager(this.Messaging, this.ExtensionManager);
 
             switch (this.Subcommand)
             {

--- a/src/wix/WixToolset.Core.ExtensionCache/ExtensionCacheWarnings.cs
+++ b/src/wix/WixToolset.Core.ExtensionCache/ExtensionCacheWarnings.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core.ExtensionCache
+{
+    using WixToolset.Data;
+
+    internal static class ExtensionCacheWarnings
+    {
+        public static Message NugetException(string extensionId, string exceptionMessage)
+        {
+            return Message(new SourceLineNumber(extensionId), Ids.NugetException, "{0}", exceptionMessage);
+        }
+
+        private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
+        {
+            return new Message(sourceLineNumber, MessageLevel.Warning, (int)id, format, args);
+        }
+
+        public enum Ids
+        {
+            NugetException = 6100,
+        } // last available is 6499. 6500 is ExtensionCacheErrors.
+    }
+}

--- a/src/wix/WixToolset.Core.ExtensionCache/WixToolsetCoreServiceProviderExtensions.cs
+++ b/src/wix/WixToolset.Core.ExtensionCache/WixToolsetCoreServiceProviderExtensions.cs
@@ -27,7 +27,10 @@ namespace WixToolset.Core.ExtensionCache
 
         private static ExtensionCacheManager CreateExtensionCacheManager(IWixToolsetCoreServiceProvider coreProvider, Dictionary<Type, object> singletons)
         {
-            var extensionCacheManager = new ExtensionCacheManager();
+            var messaging = coreProvider.GetService<IMessaging>();
+            var extensionManager = coreProvider.GetService<IExtensionManager>();
+
+            var extensionCacheManager = new ExtensionCacheManager(messaging, extensionManager);
             singletons.Add(typeof(ExtensionCacheManager), extensionCacheManager);
 
             return extensionCacheManager;

--- a/src/wix/WixToolset.Core.TestPackage/WixRunner.cs
+++ b/src/wix/WixToolset.Core.TestPackage/WixRunner.cs
@@ -7,6 +7,7 @@ namespace WixToolset.Core.TestPackage
     using System.Threading;
     using System.Threading.Tasks;
     using WixToolset.Core.Burn;
+    using WixToolset.Core.ExtensionCache;
     using WixToolset.Core.WindowsInstaller;
     using WixToolset.Data;
     using WixToolset.Extensibility.Services;
@@ -65,7 +66,8 @@ namespace WixToolset.Core.TestPackage
         public static Task<int> Execute(string[] args, IWixToolsetCoreServiceProvider coreProvider, out List<Message> messages, bool warningsAsErrors = true)
         {
             coreProvider.AddWindowsInstallerBackend()
-                        .AddBundleBackend();
+                        .AddBundleBackend()
+                        .AddExtensionCacheManager();
 
             var listener = new TestMessageListener();
 

--- a/src/wix/WixToolset.Core.TestPackage/WixToolset.Core.TestPackage.csproj
+++ b/src/wix/WixToolset.Core.TestPackage/WixToolset.Core.TestPackage.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\WixToolset.Core.Native\WixToolset.Core.Native.csproj" PrivateAssets="true" />
     <ProjectReference Include="..\WixToolset.Core\WixToolset.Core.csproj" PrivateAssets="true" />
     <ProjectReference Include="..\WixToolset.Core.Burn\WixToolset.Core.Burn.csproj" PrivateAssets="true" />
+    <ProjectReference Include="..\WixToolset.Core.ExtensionCache\WixToolset.Core.ExtensionCache.csproj" PrivateAssets="true" />
     <ProjectReference Include="..\WixToolset.Core.WindowsInstaller\WixToolset.Core.WindowsInstaller.csproj" PrivateAssets="true" />
   </ItemGroup>
 

--- a/src/wix/WixToolset.Core/ExtensibilityServices/ExtensionCacheLocation.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/ExtensionCacheLocation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core.ExtensibilityServices
+{
+    using WixToolset.Extensibility.Data;
+
+    internal class ExtensionCacheLocation : IExtensionCacheLocation
+    {
+        public ExtensionCacheLocation(string path, ExtensionCacheLocationScope scope)
+        {
+            this.Path = path;
+            this.Scope = scope;
+        }
+
+        public string Path { get; }
+
+        public ExtensionCacheLocationScope Scope { get; }
+    }
+}


### PR DESCRIPTION
This removes the duplication of cache location definitions between
IExtensionManager and extension cache command. Also, adds an
extension cache test.

Fixes wixtoolset/issues#6536