### PR TITLE
DUtilTraceErrorSourceFiltersOnTraceLevel is still flaky

### DIFF
--- a/src/libs/dutil/test/DUtilUnitTest/DUtilTests.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/DUtilTests.cpp
@@ -11,7 +11,7 @@ namespace DutilTests
     public ref class DUtil
     {
     public:
-        [Fact]
+        [Fact(Skip="Flaky")]
         void DUtilTraceErrorSourceFiltersOnTraceLevel()
         {
             DutilInitialize(&DutilTestTraceError);


### PR DESCRIPTION
It failed for me locally in Debug.

```
Test:
  xUnit.net MSBuild Runner v2.4.1 (32-bit Desktop .NET 4.0.30319.42000)
    Discovering: DUtilUnitTest
    Discovered:  DUtilUnitTest
    Starting:    DUtilUnitTest
C:\src\wix4\src\internal\WixBuildTools.TestSupport.Native\build\WixBuildTools.TestSupport.Native.targets(50,5): warning : DutilTests.FileUtil.FileUtilTest [SKIP] [C:\src\wix4\src\libs\dutil\test\DutilUnitTest\DUtilUnitTest.vcxproj]
        Skipped until we have a good way to reference ANSI.txt.
C:\src\wix4\src\internal\WixBuildTools.TestSupport.Native\build\WixBuildTools.TestSupport.Native.targets(50,5): warning : DutilTests.MonUtil.MonUtilTest [SKIP] [C:\src\wix4\src\libs\dutil\test\DutilUnitTest\DUtilUnitTest.vcxproj]
        Test demonstrates failure
C:\src\wix4\src\internal\WixBuildTools.TestSupport\WixAssert.cs(121): error : DutilTests.DUtil.DUtilTraceErrorSourceFiltersOnTraceLevel [FAIL] [C:\src\wix4\src\libs\dutil\test\DutilUnitTest\DUtilUnitTest.vcxproj]
        Assert.Throws() Failure
        Expected: typeof(System.Exception)
        Actual:   (No exception was thrown)
        Stack Trace:
          C:\src\wix4\src\internal\WixBuildTools.TestSupport\WixAssert.cs(121,0): at WixBuildTools.TestSupport.WixAssert.Throws[T](Action testCode)
          DUtilTests.cpp(25,0): at DutilTests.DUtil.DUtilTraceErrorSourceFiltersOnTraceLevel()
    Finished:    DUtilUnitTest
  === TEST EXECUTION SUMMARY ===
     DUtilUnitTest  Total: 32, Errors: 0, Failed: 1, Skipped: 2, Time: 2.443s
```