### PR TITLE
Better support for semantic versioning in WiX

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -1076,7 +1076,7 @@ namespace WixToolset.Data
 
         public static Message IllegalVersionValue(SourceLineNumber sourceLineNumbers, string elementName, string attributeName, string value)
         {
-            return Message(sourceLineNumbers, Ids.IllegalVersionValue, "The {0}/@{1} attribute's value, '{2}', is not a valid version.  Legal version values should look like 'x.x.x.x' where x is an integer from 0 to 65534.", elementName, attributeName, value);
+            return Message(sourceLineNumbers, Ids.IllegalVersionValue, "The {0}/@{1} attribute's value, '{2}', is not a valid version. Specify a four-part version or semantic version, such as '#.#.#.#' or '#.#.#-label.#'.", elementName, attributeName, value);
         }
 
         public static Message IllegalWarningIdAsError(string warningId)
@@ -1279,9 +1279,9 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.InvalidMergeLanguage, "The Merge element '{0}' specified an invalid language '{1}'.  Verify that localization tokens are being properly resolved to a numeric LCID.", mergeId, mergeLanguage);
         }
 
-        public static Message InvalidModuleOrBundleVersion(SourceLineNumber sourceLineNumbers, string moduleOrBundle, string version)
+        public static Message InvalidFourPartVersion(SourceLineNumber sourceLineNumbers, string elementName, string attributeName, string version)
         {
-            return Message(sourceLineNumbers, Ids.InvalidModuleOrBundleVersion, "Invalid {0}/@Version '{1}'. {0} version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", moduleOrBundle, version);
+            return Message(sourceLineNumbers, Ids.InvalidFourPartVersion, "Invalid {0}/@Version '{1}'. {0} version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", elementName, version);
         }
 
         public static Message InvalidPlatformValue(SourceLineNumber sourceLineNumbers, string value)
@@ -2678,7 +2678,7 @@ namespace WixToolset.Data
             SplitCabinetNameCollision = 377,
             SplitCabinetInsertionFailed = 378,
             InvalidPreprocessorFunctionAutoVersion = 379,
-            InvalidModuleOrBundleVersion = 380,
+            InvalidFourPartVersion = 380,
             UnsupportedPlatformForElement = 381,
             MissingMedia = 382,
             IllegalYesNoAlwaysValue = 384,

--- a/src/api/wix/WixToolset.Data/WarningMessages.cs
+++ b/src/api/wix/WixToolset.Data/WarningMessages.cs
@@ -367,9 +367,9 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.InvalidHigherInstallerVersionInModule, "Merge module '{0}' has an installer version of {1} which is greater than the product's installer version of {2}. Merging a module with a higher installer version than the product it is being merged into can result in invalid values in the resulting msi. You must set the Package/@InstallerVersion attribute to {1} or greater to merge this merge module into your product.", moduleId, moduleInstallerVersion, productInstallerVersion);
         }
 
-        public static Message InvalidModuleOrBundleVersion(SourceLineNumber sourceLineNumbers, string moduleOrBundle, string version)
+        public static Message InvalidFourPartVersion(SourceLineNumber sourceLineNumbers, string elementName, string version)
         {
-            return Message(sourceLineNumbers, Ids.InvalidModuleOrBundleVersion, "Invalid {0}/@Version '{1}'. {0} version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", moduleOrBundle, version);
+            return Message(sourceLineNumbers, Ids.InvalidFourPartVersion, "Invalid {0}/@Version '{1}'. {0} version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", elementName, version);
         }
 
         public static Message InvalidRemoveFile(SourceLineNumber sourceLineNumbers, string file, string component)
@@ -663,9 +663,9 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.VariableDeclarationCollision, "The variable '{0}' with value '{1}' was previously declared with value '{2}'.", variableName, variableValue, variableCollidingValue);
         }
 
-        public static Message VersionTruncated(SourceLineNumber sourceLineNumbers, string originalVersion, string package, string truncatedVersion)
+        public static Message InvalidMsiProductVersion(SourceLineNumber sourceLineNumbers, string version, string package)
         {
-            return Message(sourceLineNumbers, Ids.VersionTruncated, "Product version {0} in package '{1}' is not valid per the MSI SDK and cannot be represented in a bundle. It has been truncated to {2}.", originalVersion, package, truncatedVersion);
+            return Message(sourceLineNumbers, Ids.InvalidMsiProductVersion, "Invalid product version '{0}' in MSI package '{1}'. Product version should have a major version less than 256, a minor version less than 256, and a build version less than 65536. The bundle may incorrectly detect upgrades of this package.", version, package);
         }
 
         public static Message CollidingModularizationTypes(string tableName, string columnName, string foreignTableName, int foreignColumnNumber, string modularizationType, string foreignModularizationType)
@@ -764,7 +764,7 @@ namespace WixToolset.Data
             DeprecatedPackageCompressedAttribute = 1087,
             DeprecatedQuestionMarksGuid = 1090,
             PackageCodeSet = 1091,
-            InvalidModuleOrBundleVersion = 1093,
+            InvalidFourPartVersion = 1093,
             InvalidRemoveFile = 1095,
             PreprocessorWarning = 1096,
             UpdateOfNonKeyPathFile = 1097,
@@ -816,7 +816,7 @@ namespace WixToolset.Data
             AllChangesIncludedInPatch = 1145,
             RelatedAttributeConditionallyIgnored = 1146,
             BackslashTerminateInlineDirectorySyntax = 1147,
-            VersionTruncated = 1148,
+            InvalidMsiProductVersion = 1148,
             ServiceConfigFamilyNotSupported = 1149,
             SymbolNotTranslatedToOutput = 1150,
             MsiTransactionLimitations = 1151,

--- a/src/api/wix/WixToolset.Data/WixVersion.cs
+++ b/src/api/wix/WixToolset.Data/WixVersion.cs
@@ -1,0 +1,275 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Data
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// WiX Toolset's representation of a version designed to support
+    /// a different version types including 4-part versions with very
+    /// large numbers and semantic versions with 4-part versions with
+    /// or without leading "v" indicators.
+    /// </summary>
+    [CLSCompliant(false)]
+    public class WixVersion
+    {
+        /// <summary>
+        /// Gets the prefix of the version if present when parsed. Usually, 'v' or 'V'.
+        /// </summary>
+        public char? Prefix { get; set; } 
+
+        /// <summary>
+        /// Gets or sets the major version.
+        /// </summary>
+        public uint? Major { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minor version.
+        /// </summary>
+        public uint? Minor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the patch version.
+        /// </summary>
+        public uint? Patch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revision version.
+        /// </summary>
+        public uint? Revision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the labels in the version.
+        /// </summary>
+        public WixVersionLabel[] Labels { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata in the version.
+        /// </summary>
+        public string Metadata { get; set; }
+
+        /// <summary>
+        /// Tries to parse a string value into a valid <c>WixVersion</c>.
+        /// </summary>
+        /// <param name="parse">String value to parse into a version.</param>
+        /// <param name="version">Parsed version.</param>
+        /// <returns>True if the version was successfully parsed, or false otherwise.</returns>
+        public static bool TryParse(string parse, out WixVersion version)
+        {
+            version = new WixVersion();
+
+            var labels = new List<WixVersionLabel>();
+            var start = 0;
+            var end = parse.Length;
+
+            if (end > 0 && (parse[0] == 'v' || parse[0] == 'V'))
+            {
+                version.Prefix = parse[0];
+
+                ++start;
+            }
+
+            var partBegin = start;
+            var partEnd = start;
+            var lastPart = false;
+            var trailingDot = false;
+            var invalid = false;
+            var currentPart = 0;
+            var parsedVersionNumber = false;
+            var expectedReleaseLabels = false;
+
+            // Parse version number
+            while (start < end)
+            {
+                trailingDot = false;
+
+                // Find end of part.
+                for (; ; )
+                {
+                    if (partEnd >= end)
+                    {
+                        lastPart = true;
+                        break;
+                    }
+
+                    var ch = parse[partEnd];
+
+                    switch (ch)
+                    {
+                        case '0':
+                        case '1':
+                        case '2':
+                        case '3':
+                        case '4':
+                        case '5':
+                        case '6':
+                        case '7':
+                        case '8':
+                        case '9':
+                            ++partEnd;
+                            continue;
+                        case '.':
+                            trailingDot = true;
+                            break;
+                        case '-':
+                        case '+':
+                            lastPart = true;
+                            break;
+                        default:
+                            invalid = true;
+                            break;
+                    }
+
+                    break;
+                }
+
+                var partLength = partEnd - partBegin;
+                if (invalid || partLength <= 0)
+                {
+                    invalid = true;
+                    break;
+                }
+
+                // Parse version part.
+                var s = parse.Substring(partBegin, partLength);
+                if (!UInt32.TryParse(s, out var part))
+                {
+                    invalid = true;
+                    break;
+                }
+
+                switch (currentPart)
+                {
+                    case 0:
+                        version.Major = part;
+                        break;
+                    case 1:
+                        version.Minor = part;
+                        break;
+                    case 2:
+                        version.Patch = part;
+                        break;
+                    case 3:
+                        version.Revision = part;
+                        break;
+                }
+
+                if (trailingDot)
+                {
+                    ++partEnd;
+                }
+                partBegin = partEnd;
+                ++currentPart;
+
+                if (4 <= currentPart || lastPart)
+                {
+                    parsedVersionNumber = true;
+                    break;
+                }
+            }
+
+            invalid |= !parsedVersionNumber || trailingDot;
+
+            if (!invalid && partBegin < end && parse[partBegin] == '-')
+            {
+                partBegin = partEnd = partBegin + 1;
+                expectedReleaseLabels = true;
+                lastPart = false;
+            }
+
+            while (expectedReleaseLabels && partBegin < end)
+            {
+                trailingDot = false;
+
+                // Find end of part.
+                for (; ; )
+                {
+                    if (partEnd >= end)
+                    {
+                        lastPart = true;
+                        break;
+                    }
+
+                    var ch = parse[partEnd];
+                    if (ch >= '0' && ch <= '9' ||
+                        ch >= 'A' && ch <= 'Z' ||
+                        ch >= 'a' && ch <= 'z' ||
+                        ch == '-')
+                    {
+                        ++partEnd;
+                        continue;
+                    }
+                    else if (ch == '+')
+                    {
+                        lastPart = true;
+                    }
+                    else if (ch == '.')
+                    {
+                        trailingDot = true;
+                    }
+                    else
+                    {
+                        invalid = true;
+                    }
+
+                    break;
+                }
+
+                var partLength = partEnd - partBegin;
+                if (invalid || partLength <= 0)
+                {
+                    invalid = true;
+                    break;
+                }
+
+                WixVersionLabel label;
+                var partString = parse.Substring(partBegin, partLength);
+                if (UInt32.TryParse(partString, out var numericPart))
+                {
+                    label = new WixVersionLabel(partString, numericPart);
+                }
+                else
+                {
+                    label = new WixVersionLabel(partString);
+                }
+
+                labels.Add(label);
+
+                if (trailingDot)
+                {
+                    ++partEnd;
+                }
+                partBegin = partEnd;
+
+                if (lastPart)
+                {
+                    break;
+                }
+            }
+
+            invalid |= expectedReleaseLabels && (labels.Count == 0 || trailingDot);
+
+            if (!invalid && partBegin < end)
+            {
+                if (parse[partBegin] == '+')
+                {
+                    version.Metadata = parse.Substring(partBegin + 1);
+                }
+                else
+                {
+                    invalid = true;
+                }
+            }
+
+            if (invalid)
+            {
+                return false;
+            }
+
+            version.Labels = labels.Count == 0 ? null : labels.ToArray();
+
+            return true;
+        }
+    }
+}

--- a/src/api/wix/WixToolset.Data/WixVersionLabel.cs
+++ b/src/api/wix/WixToolset.Data/WixVersionLabel.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Data
+{
+    using System;
+
+    /// <summary>
+    /// Label in a <c>WixVersion</c>.
+    /// </summary>
+    [CLSCompliant(false)]
+    public class WixVersionLabel
+    {
+        /// <summary>
+        /// Creates a string only version label.
+        /// </summary>
+        /// <param name="label">String value for version label.</param>
+        public WixVersionLabel(string label)
+        {
+            this.Label = label;
+        }
+
+        /// <summary>
+        /// Creates a string version label with numeric value.
+        /// </summary>
+        /// <param name="label">String value for version label.</param>
+        /// <param name="numeric">Numeric value for the version label.</param>
+        public WixVersionLabel(string label, uint? numeric)
+        {
+            this.Label = label;
+            this.Numeric = numeric;
+        }
+
+        /// <summary>
+        /// Gets the string label value.
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Gets the optional numeric label value.
+        /// </summary>
+        public uint? Numeric { get; set; }
+    }
+}

--- a/src/api/wix/WixToolset.Extensibility/Services/IBackendHelper.cs
+++ b/src/api/wix/WixToolset.Extensibility/Services/IBackendHelper.cs
@@ -104,11 +104,25 @@ namespace WixToolset.Extensibility.Services
         bool IsValidBinderVariable(string variable);
 
         /// <summary>
-        /// Verifies the given string is a valid 4-part version module or bundle version.
+        /// Verifies the given string is a valid 4-part version.
         /// </summary>
         /// <param name="version">The version to verify.</param>
-        /// <returns>True if version is a valid module or bundle version.</returns>
+        /// <returns>True if version is a valid 4-part version.</returns>
         bool IsValidFourPartVersion(string version);
+
+        /// <summary>
+        /// Verifies the given string is a valid MSI product version.
+        /// </summary>
+        /// <param name="version">The MSI product version to verify.</param>
+        /// <returns>True if version is a valid MSI product version</returns>
+        bool IsValidMsiProductVersion(string version);
+
+        /// <summary>
+        /// Verifies the given string is a valid WiX version.
+        /// </summary>
+        /// <param name="version">The version to verify.</param>
+        /// <returns>True if version is a valid WiX version.</returns>
+        bool IsValidWixVersion(string version);
 
         /// <summary>
         /// Determines if value is a valid identifier.

--- a/src/api/wix/test/WixToolsetTest.Data/WixVerFixture.cs
+++ b/src/api/wix/test/WixToolsetTest.Data/WixVerFixture.cs
@@ -1,0 +1,204 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.Data
+{
+    using System;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class WixVerFixture
+    {
+        [Fact]
+        public void CannotParseEmptyStringAsVersion()
+        {
+            Assert.False(WixVersion.TryParse(String.Empty, out var _));
+        }
+
+        [Fact]
+        public void CannotParseInvalidStringAsVersion()
+        {
+            Assert.False(WixVersion.TryParse("invalid", out var _));
+        }
+
+        [Fact]
+        public void CanParseFourPartVersion()
+        {
+            Assert.True(WixVersion.TryParse("1.2.3.4", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Equal((uint)3, version.Patch);
+            Assert.Equal((uint)4, version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseThreePartVersion()
+        {
+            Assert.True(WixVersion.TryParse("1.2.3", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Equal((uint)3, version.Patch);
+            Assert.Null(version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseFourPartVersionWithTrailingZero()
+        {
+            Assert.True(WixVersion.TryParse("1.2.3.0", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Equal((uint)3, version.Patch);
+            Assert.Equal((uint)0, version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseNumericReleaseLabels()
+        {
+            Assert.True(WixVersion.TryParse("1.2-19", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Null(version.Patch);
+            Assert.Null(version.Revision);
+            Assert.Equal("19", version.Labels[0].Label);
+            Assert.Equal((uint)19, version.Labels[0].Numeric);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseDottedNumericReleaseLabels()
+        {
+            Assert.True(WixVersion.TryParse("1.2-2.0", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Null(version.Patch);
+            Assert.Null(version.Revision);
+            Assert.Equal("2", version.Labels[0].Label);
+            Assert.Equal((uint)2, version.Labels[0].Numeric);
+            Assert.Equal("0", version.Labels[1].Label);
+            Assert.Equal((uint)0, version.Labels[1].Numeric);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseHyphenAsVersionSeparator()
+        {
+            Assert.True(WixVersion.TryParse("0.0.1-a", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)0, version.Major);
+            Assert.Equal((uint)0, version.Minor);
+            Assert.Equal((uint)1, version.Patch);
+            Assert.Equal("a", version.Labels[0].Label);
+            Assert.Null(version.Labels[0].Numeric);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseIgnoringLeadingZeros()
+        {
+            Assert.True(WixVersion.TryParse("0.01-a.000", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)0, version.Major);
+            Assert.Equal((uint)1, version.Minor);
+            Assert.Null(version.Patch);
+            Assert.Null(version.Revision);
+            Assert.Equal("a", version.Labels[0].Label);
+            Assert.Null(version.Labels[0].Numeric);
+            Assert.Equal("000", version.Labels[1].Label);
+            Assert.Equal((uint)0, version.Labels[1].Numeric);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CanParseMetadata()
+        {
+            Assert.True(WixVersion.TryParse("1.2.3+abcd", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Equal((uint)3, version.Patch);
+            Assert.Null(version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Equal("abcd", version.Metadata);
+        }
+
+        [Fact]
+        public void CannotParseUnexpectedContentAsMetadata()
+        {
+            Assert.False(WixVersion.TryParse("1.2.3.abcd", out var _));
+            Assert.False(WixVersion.TryParse("1.2.3.-abcd", out var _));
+        }
+
+        [Fact]
+        public void CanParseLeadingPrefix()
+        {
+            Assert.True(WixVersion.TryParse("v10.20.30.40", out var version));
+            Assert.Equal('v', version.Prefix);
+            Assert.Equal((uint)10, version.Major);
+            Assert.Equal((uint)20, version.Minor);
+            Assert.Equal((uint)30, version.Patch);
+            Assert.Equal((uint)40, version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Null(version.Metadata);
+
+            Assert.True(WixVersion.TryParse("V100.200.300.400", out var version2));
+            Assert.Equal('V', version2.Prefix);
+            Assert.Equal((uint)100, version2.Major);
+            Assert.Equal((uint)200, version2.Minor);
+            Assert.Equal((uint)300, version2.Patch);
+            Assert.Equal((uint)400, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Null(version2.Metadata);
+        }
+
+        [Fact]
+        public void CanParseVeryLargeNumbers()
+        {
+            Assert.True(WixVersion.TryParse("4294967295.4294967295.4294967295.4294967295", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal(4294967295, version.Major);
+            Assert.Equal(4294967295, version.Minor);
+            Assert.Equal(4294967295, version.Patch);
+            Assert.Equal(4294967295, version.Revision);
+            Assert.Null(version.Labels);
+            Assert.Null(version.Metadata);
+        }
+
+        [Fact]
+        public void CannotParseTooLargeNumbers()
+        {
+            Assert.False(WixVersion.TryParse("4294967296.4294967296.4294967296.4294967296", out var _));
+        }
+
+        [Fact]
+        public void CanParseLabelsWithMetadata()
+        {
+            Assert.True(WixVersion.TryParse("1.2.3.4-a.b.c.d.5+abc123", out var version));
+            Assert.Null(version.Prefix);
+            Assert.Equal((uint)1, version.Major);
+            Assert.Equal((uint)2, version.Minor);
+            Assert.Equal((uint)3, version.Patch);
+            Assert.Equal((uint)4, version.Revision);
+            Assert.Equal("a", version.Labels[0].Label);
+            Assert.Null(version.Labels[0].Numeric);
+            Assert.Equal("b", version.Labels[1].Label);
+            Assert.Null(version.Labels[1].Numeric);
+            Assert.Equal("c", version.Labels[2].Label);
+            Assert.Null(version.Labels[2].Numeric);
+            Assert.Equal("d", version.Labels[3].Label);
+            Assert.Null(version.Labels[3].Numeric);
+            Assert.Equal("5", version.Labels[4].Label);
+            Assert.Equal((uint)5, version.Labels[4].Numeric);
+            Assert.Equal("abc123", version.Metadata);
+        }
+    }
+}

--- a/src/ext/Dependency/Dependency.wixext.v3.ncrunchsolution
+++ b/src/ext/Dependency/Dependency.wixext.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/ext/Dependency/test/WixToolsetTest.Dependency/DependencyExtensionFixture.cs
+++ b/src/ext/Dependency/test/WixToolsetTest.Dependency/DependencyExtensionFixture.cs
@@ -17,13 +17,14 @@ namespace WixToolsetTest.Dependency
             var folder = TestData.Get(@"TestData\UsingProvides");
             var build = new Builder(folder, typeof(DependencyExtensionFactory), new[] { folder });
 
-            var results = build.BuildAndQuery(Build, "CustomAction", "Wix4DependencyProvider")
+            var results = build.BuildAndQuery(Build, "CustomAction", "Wix4DependencyProvider", "Wix4Dependency")
                                .Select(r => Regex.Replace(r, "{[^}]*}", "{*}"))
                                .ToArray();
             WixAssert.CompareLineByLine(new[]
             {
                 "CustomAction:Wix4DependencyCheck_X86\t1\tDependencyCA_X86\tWixDependencyCheck\t",
                 "CustomAction:Wix4DependencyRequire_X86\t1\tDependencyCA_X86\tWixDependencyRequire\t",
+                "Wix4Dependency:depL8BNflcqZaN5CQEWh2U3SBHFDdg\tUsingRequires\t1.0.0-beta.9\t\t0",
                 "Wix4DependencyProvider:dep74OfIcniaqxA7EprRGBw4Oyy3r8\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\tUsingProvides\t\t\t",
                 "Wix4DependencyProvider:depTpv28q7slcxvXPWmU4Z0GfbiI.4\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\t{*}\t\t\t",
             }, results);

--- a/src/ext/Dependency/test/WixToolsetTest.Dependency/TestData/UsingProvides/Package.wxs
+++ b/src/ext/Dependency/test/WixToolsetTest.Dependency/TestData/UsingProvides/Package.wxs
@@ -12,7 +12,7 @@
         <File Name="example.txt" Source="Package.wxs" />
         <Provides Key="UsingProvides" dep:Check="yes" />
         <Provides>
-          <Requires ProviderKey="UsingRequires" Minimum="1.0.0.0" dep:Enforce="yes" />
+          <Requires ProviderKey="UsingRequires" Minimum="1.0.0-beta.9" dep:Enforce="yes" />
         </Provides>
       </Component>
     </Feature>

--- a/src/libs/dutil/WixToolset.DUtil/inc/regutil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/regutil.h
@@ -1,6 +1,7 @@
 #pragma once
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
+#include "verutil.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -258,6 +259,16 @@ HRESULT DAPI RegReadVersion(
     __in HKEY hk,
     __in_z_opt LPCWSTR wzName,
     __out DWORD64* pdw64Version
+    );
+
+/********************************************************************
+ RegReadWixVersion - reads a registry key value as a WiX version.
+
+*********************************************************************/
+HRESULT DAPI RegReadWixVersion(
+    __in HKEY hk,
+    __in_z_opt LPCWSTR wzName,
+    __out VERUTIL_VERSION** ppVersion
     );
 
 /********************************************************************

--- a/src/test/burn/TestData/DependencyTests/PackageB/ProductComponents.wxs
+++ b/src/test/burn/TestData/DependencyTests/PackageB/ProductComponents.wxs
@@ -11,7 +11,7 @@
     <Component Id="FileComponent2" Guid="A1866388-65B4-4215-A8FB-9A7AADBE4E8E" Directory="INSTALLFOLDER">
       <File Source="$(sys.SOURCEFILEPATH)" />
       <Provides>
-        <Requires ProviderKey="WiX.$(var.TestGroupName).A,v1.0" Minimum="1.0.0.0" IncludeMinimum="yes" dep:Enforce="yes" />
+        <Requires ProviderKey="WiX.$(var.TestGroupName).A,v1.0" Minimum="1.0.0-alpha.420" IncludeMinimum="yes" dep:Enforce="yes" />
       </Provides>
     </Component>
   </Fragment>

--- a/src/wix/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
@@ -118,30 +118,9 @@ namespace WixToolset.Core.Burn.Bundles
                 this.ChainPackage.Version = this.MsiPackage.ProductVersion;
             }
 
-            if (!this.BackendHelper.IsValidFourPartVersion(this.MsiPackage.ProductVersion))
+            if (!this.BackendHelper.IsValidMsiProductVersion(this.MsiPackage.ProductVersion))
             {
-                // not a proper .NET version (e.g., five fields); can we get a valid four-part version number?
-                string version = null;
-                var versionParts = this.MsiPackage.ProductVersion.Split('.');
-                var count = versionParts.Length;
-                if (0 < count)
-                {
-                    version = versionParts[0];
-                    for (var i = 1; i < 4 && i < count; ++i)
-                    {
-                        version = String.Concat(version, ".", versionParts[i]);
-                    }
-                }
-
-                if (!String.IsNullOrEmpty(version) && this.BackendHelper.IsValidFourPartVersion(version))
-                {
-                    this.Messaging.Write(WarningMessages.VersionTruncated(this.PackagePayload.SourceLineNumbers, this.MsiPackage.ProductVersion, this.PackageId, version));
-                    this.MsiPackage.ProductVersion = version;
-                }
-                else
-                {
-                    this.Messaging.Write(ErrorMessages.InvalidProductVersion(this.PackagePayload.SourceLineNumbers, this.MsiPackage.ProductVersion, this.PackageId));
-                }
+                this.Messaging.Write(WarningMessages.InvalidMsiProductVersion(this.PackagePayload.SourceLineNumbers, this.MsiPackage.ProductVersion, this.PackageId));
             }
 
             this.SetPerMachineAppropriately(harvestedMsiPackage.AllUsers);

--- a/src/wix/WixToolset.Core.Burn/BurnBackendWarnings.cs
+++ b/src/wix/WixToolset.Core.Burn/BurnBackendWarnings.cs
@@ -16,6 +16,11 @@ namespace WixToolset.Core.Burn
             return Message(sourceLineNumbers, Ids.AttachedContainerPayloadCollision2, "The location of the payload related to the previous error.");
         }
 
+        public static Message CannotParseBundleVersionAsFourPartVersion(SourceLineNumber originalLineNumber, string version)
+        {
+            return Message(originalLineNumber, Ids.CannotParseBundleVersionAsFourPartVersion, "The Bundle/@Version was not be able to be used as a four-part version. A valid four-part version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", version);
+        }
+
         public static Message EmptyContainer(SourceLineNumber sourceLineNumbers, string containerId)
         {
             return Message(sourceLineNumbers, Ids.EmptyContainer, "The Container '{0}' is being ignored because it doesn't have any payloads.", containerId);
@@ -61,6 +66,7 @@ namespace WixToolset.Core.Burn
             UnknownBundleRelationAction = 8505,
             HiddenBundleNotSupported = 8506,
             UnknownMsiPackagePlatform = 8507,
+            CannotParseBundleVersionAsFourPartVersion = 8508,
         } // last available is 8999. 9000 is VerboseMessages.
     }
 }

--- a/src/wix/WixToolset.Core.Burn/ExtensibilityServices/BurnBackendHelper.cs
+++ b/src/wix/WixToolset.Core.Burn/ExtensibilityServices/BurnBackendHelper.cs
@@ -104,6 +104,16 @@ namespace WixToolset.Core.Burn.ExtensibilityServices
             return this.backendHelper.IsValidIdentifier(id);
         }
 
+        public bool IsValidMsiProductVersion(string version)
+        {
+            return this.backendHelper.IsValidMsiProductVersion(version);
+        }
+
+        public bool IsValidWixVersion(string version)
+        {
+            return this.backendHelper.IsValidWixVersion(version);
+        }
+
         public bool IsValidLongFilename(string filename, bool allowWildcards, bool allowRelative)
         {
             return this.backendHelper.IsValidLongFilename(filename, allowWildcards, allowRelative);

--- a/src/wix/WixToolset.Core.Burn/ExtensibilityServices/PayloadHarvester.cs
+++ b/src/wix/WixToolset.Core.Burn/ExtensibilityServices/PayloadHarvester.cs
@@ -52,16 +52,27 @@ namespace WixToolset.Core.Burn.ExtensibilityServices
 
             if (null != versionInfo)
             {
-                // Use the fixed version info block for the file since the resource text may not be a dotted quad.
-                var version = new Version(versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
+                var version = versionInfo.ProductVersion;
 
-                if (PayloadHarvester.EmptyVersion != version)
+                if (String.IsNullOrEmpty(version))
                 {
-                    payload.Version = version.ToString();
+                    version = versionInfo.FileVersion;
+                }
+
+                if (String.IsNullOrEmpty(version))
+                {
+                    // Fallback to fixed version info block for the file.
+                    var fixedVersion = new Version(versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
+
+                    if (PayloadHarvester.EmptyVersion != fixedVersion)
+                    {
+                        version = fixedVersion.ToString();
+                    }
                 }
 
                 payload.Description = versionInfo.FileDescription;
                 payload.DisplayName = versionInfo.ProductName;
+                payload.Version = version;
             }
         }
     }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -298,6 +298,9 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 command.Execute();
             }
 
+            // Now that delayed fields are processed, validate the package/module version.
+            this.VerifyVersion(packageSymbol, moduleSymbol);
+
             // Process dependency references.
             if (SectionType.Product == section.Type || SectionType.Module == section.Type)
             {
@@ -535,6 +538,24 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             result.Wixout = this.CreateWixout(trackedFiles, this.Intermediate, data);
 
             return result;
+        }
+
+        private void VerifyVersion(WixPackageSymbol packageSymbol, WixModuleSymbol moduleSymbol)
+        {
+            if (packageSymbol != null)
+            {
+                if (!this.WindowsInstallerBackendHelper.IsValidMsiProductVersion(packageSymbol.Version))
+                {
+                    this.Messaging.Write(ErrorMessages.InvalidProductVersion(packageSymbol.SourceLineNumbers, packageSymbol.Version));
+                }
+            }
+            else if (moduleSymbol != null)
+            {
+                if (!this.WindowsInstallerBackendHelper.IsValidFourPartVersion(moduleSymbol.Version))
+                {
+                    this.Messaging.Write(WindowsInstallerBackendErrors.InvalidModuleVersion(moduleSymbol.SourceLineNumbers, moduleSymbol.Version));
+                }
+            }
         }
 
         private int CalculateCodepage(WixPackageSymbol packageSymbol, WixModuleSymbol moduleSymbol, WixPatchSymbol patchSymbol)

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -1033,6 +1033,16 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
         private void AddUpgradeSymbol(UpgradeSymbol symbol)
         {
+            if (!String.IsNullOrEmpty(symbol.VersionMin) && !this.BackendHelper.IsValidMsiProductVersion(symbol.VersionMin))
+            {
+                this.Messaging.Write(ErrorMessages.InvalidProductVersion(symbol.SourceLineNumbers, symbol.VersionMin));
+            }
+
+            if (!String.IsNullOrEmpty(symbol.VersionMax) && !this.BackendHelper.IsValidMsiProductVersion(symbol.VersionMax))
+            {
+                this.Messaging.Write(ErrorMessages.InvalidProductVersion(symbol.SourceLineNumbers, symbol.VersionMax));
+            }
+
             var row = (UpgradeRow)this.CreateRow(symbol, "Upgrade");
             row.UpgradeCode = symbol.UpgradeCode;
             row.VersionMin = symbol.VersionMin;

--- a/src/wix/WixToolset.Core.WindowsInstaller/ExtensibilityServices/WindowsInstallerBackendHelper.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/ExtensibilityServices/WindowsInstallerBackendHelper.cs
@@ -93,6 +93,16 @@ namespace WixToolset.Core.WindowsInstaller.ExtensibilityServices
             return this.backendHelper.IsValidIdentifier(id);
         }
 
+        public bool IsValidMsiProductVersion(string version)
+        {
+            return this.backendHelper.IsValidMsiProductVersion(version);
+        }
+
+        public bool IsValidWixVersion(string version)
+        {
+            return this.backendHelper.IsValidWixVersion(version);
+        }
+
         public bool IsValidLongFilename(string filename, bool allowWildcards, bool allowRelative)
         {
             return this.backendHelper.IsValidLongFilename(filename, allowWildcards, allowRelative);

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendErrors.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendErrors.cs
@@ -14,6 +14,11 @@ namespace WixToolset.Core.WindowsInstaller
             return Message(sourceLineNumbers, Ids.CannotLoadWixoutAsTransform, "Could not load wixout file as a transform{1}", additionalDetail);
         }
 
+        public static Message InvalidModuleVersion(SourceLineNumber originalLineNumber, string version)
+        {
+            return Message(originalLineNumber, Ids.InvalidModuleVersion, "The Module/@Version was not be able to be used as a four-part version. A valid four-part version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", version);
+        }
+
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
             return new Message(sourceLineNumber, MessageLevel.Error, (int)id, format, args);
@@ -22,6 +27,7 @@ namespace WixToolset.Core.WindowsInstaller
         public enum Ids
         {
             CannotLoadWixoutAsTransform = 7500,
+            InvalidModuleVersion = 7501,
         } // last available is 7999. 8000 is BurnBackendErrors.
     }
 }

--- a/src/wix/WixToolset.Core/Common.cs
+++ b/src/wix/WixToolset.Core/Common.cs
@@ -132,6 +132,11 @@ namespace WixToolset.Core
             return true;
         }
 
+        public static bool IsValidMsiProductVersion(string version)
+        {
+            return Version.TryParse(version, out var ver) && ver.Major < 256 && ver.Minor < 256 && ver.Build < 65536;
+        }
+
         public static bool IsValidLongFilename(string filename, bool allowWildcards, bool allowRelative)
         {
             if (String.IsNullOrEmpty(filename))

--- a/src/wix/WixToolset.Core/CompilerCore.cs
+++ b/src/wix/WixToolset.Core/CompilerCore.cs
@@ -221,27 +221,7 @@ namespace WixToolset.Core
         /// <returns>True if version is a valid product version</returns>
         public static bool IsValidProductVersion(string version)
         {
-            if (!Common.IsValidBinderVariable(version))
-            {
-                Version ver = new Version(version);
-
-                if (255 < ver.Major || 255 < ver.Minor || 65535 < ver.Build)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Verifies the given string is a valid module or bundle version.
-        /// </summary>
-        /// <param name="version">The version to verify.</param>
-        /// <returns>True if version is a valid module or bundle version.</returns>
-        public static bool IsValidModuleOrBundleVersion(string version)
-        {
-            return Common.IsValidFourPartVersion(version);
+            return Common.IsValidBinderVariable(version) || Common.IsValidMsiProductVersion(version);
         }
 
         /// <summary>

--- a/src/wix/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/wix/WixToolset.Core/Compiler_Bundle.cs
@@ -246,10 +246,6 @@ namespace WixToolset.Core
             {
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Version"));
             }
-            else if (!CompilerCore.IsValidModuleOrBundleVersion(version))
-            {
-                this.Core.Write(WarningMessages.InvalidModuleOrBundleVersion(sourceLineNumbers, "Bundle", version));
-            }
 
             if (String.IsNullOrEmpty(upgradeCode))
             {

--- a/src/wix/WixToolset.Core/Compiler_Module.cs
+++ b/src/wix/WixToolset.Core/Compiler_Module.cs
@@ -96,10 +96,6 @@ namespace WixToolset.Core
             {
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Version"));
             }
-            else if (!CompilerCore.IsValidModuleOrBundleVersion(version))
-            {
-                this.Core.Write(WarningMessages.InvalidModuleOrBundleVersion(sourceLineNumbers, "Module", version));
-            }
 
             try
             {

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -105,12 +105,8 @@ namespace WixToolset.Core
                     case "UpgradeCode":
                         upgradeCode = this.Core.GetAttributeGuidValue(sourceLineNumbers, attrib, false);
                         break;
-                    case "Version": // if the attribute is valid version, use the attribute value as is (so "1.0000.01.01" would *not* get translated to "1.0.1.1").
-                        var verifiedVersion = this.Core.GetAttributeVersionValue(sourceLineNumbers, attrib);
-                        if (!String.IsNullOrEmpty(verifiedVersion))
-                        {
-                            version = attrib.Value;
-                        }
+                    case "Version":
+                        version = this.Core.GetAttributeVersionValue(sourceLineNumbers, attrib);
                         break;
                     default:
                         this.Core.UnexpectedAttribute(node, attrib);
@@ -146,10 +142,6 @@ namespace WixToolset.Core
             if (null == version)
             {
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Version"));
-            }
-            else if (!CompilerCore.IsValidProductVersion(version))
-            {
-                this.Core.Write(ErrorMessages.InvalidProductVersion(sourceLineNumbers, version));
             }
 
             if (compressed != YesNoDefaultType.No)

--- a/src/wix/WixToolset.Core/ExtensibilityServices/BackendHelper.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/BackendHelper.cs
@@ -95,6 +95,16 @@ namespace WixToolset.Core.ExtensibilityServices
             return Common.IsValidFourPartVersion(version);
         }
 
+        public bool IsValidMsiProductVersion(string version)
+        {
+            return Common.IsValidMsiProductVersion(version);
+        }
+
+        public bool IsValidWixVersion(string version)
+        {
+            return WixVersion.TryParse(version, out _);
+        }
+
         public bool IsValidIdentifier(string id)
         {
             return Common.IsIdentifier(id);

--- a/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
@@ -552,9 +552,10 @@ namespace WixToolset.Core.ExtensibilityServices
 
             if (!String.IsNullOrEmpty(value))
             {
-                if (Version.TryParse(value, out var version))
+                if (WixVersion.TryParse(value, out var version))
                 {
-                    return version.ToString();
+                    // Return the attribute value sans-prefix, if present.
+                    return version.Prefix.HasValue ? value.Substring(1) : value;
                 }
 
                 // Allow versions to contain binder variables.

--- a/src/wix/test/WixToolsetTest.Core/ParserHelperFixture.cs
+++ b/src/wix/test/WixToolsetTest.Core/ParserHelperFixture.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.Core
+{
+    using System;
+    using System.Xml.Linq;
+    using WixToolset.Core;
+    using WixToolset.Data;
+    using WixToolset.Extensibility.Services;
+    using Xunit;
+
+    public class ParserHelperFixture
+    {
+        [Fact]
+        public void CanParseFourPartAttributeVersion()
+        {
+            var helper = GetParserHelper();
+
+            var attribute = CreateAttribute("1.2.3.4");
+            var result = helper.GetAttributeVersionValue(null, attribute);
+
+            Assert.Equal("1.2.3.4", result);
+        }
+
+        [Fact]
+        public void CannotParseFivePartAttributeVersion()
+        {
+            var helper = GetParserHelper();
+
+            var attribute = CreateAttribute("1.2.3.4.5");
+            var exception = Assert.Throws<WixException>(() => { helper.GetAttributeVersionValue(null, attribute); });
+            Assert.Equal("The Test/@Value attribute's value, '1.2.3.4.5', is not a valid version. Specify a four-part version or semantic version, such as '#.#.#.#' or '#.#.#-label.#'.", exception.Message);
+        }
+
+        [Fact]
+        public void CannotParseVersionTooLargeAttributeVersion()
+        {
+            var version = "4294967296.2.3.4";
+            AssertVersion(version);
+        }
+
+        private static void AssertVersion(string version)
+        {
+            var helper = GetParserHelper();
+            var attribute = CreateAttribute(version);
+            var exception = Assert.Throws<WixException>(() => { helper.GetAttributeVersionValue(null, attribute); });
+            Assert.Equal($"The Test/@Value attribute's value, '{version}', is not a valid version. Specify a four-part version or semantic version, such as '#.#.#.#' or '#.#.#-label.#'.", exception.Message);
+        }
+
+        [Fact]
+        public void CanParseSemverAttributeVersion()
+        {
+            var helper = GetParserHelper();
+
+            var attribute = CreateAttribute("10.99.444-preview.0");
+            var result = helper.GetAttributeVersionValue(null, attribute);
+
+            Assert.Equal("10.99.444-preview.0", result);
+        }
+
+        [Fact]
+        public void CanParseFourPartSemverAttributeVersion()
+        {
+            var helper = GetParserHelper();
+
+            var attribute = CreateAttribute("1.2.3.4-meta.123-other.456");
+            var result = helper.GetAttributeVersionValue(null, attribute);
+
+            Assert.Equal("1.2.3.4-meta.123-other.456", result);
+        }
+
+        [Fact]
+        public void CanParseVersionWithLeadingV()
+        {
+            var helper = GetParserHelper();
+
+            var attribute = CreateAttribute("v1.2.3.4");
+            var result = helper.GetAttributeVersionValue(null, attribute);
+
+            Assert.Equal("1.2.3.4", result);
+        }
+
+
+        private static IParseHelper GetParserHelper()
+        {
+            var sp = WixToolsetServiceProviderFactory.CreateServiceProvider();
+            var helper = sp.GetService<IParseHelper>();
+            return helper;
+        }
+
+        private static XAttribute CreateAttribute(string value)
+        {
+            var attribute = new XAttribute("Value", value);
+            _ = new XElement("Test", attribute);
+
+            return attribute;
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundlePackageFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundlePackageFixture.cs
@@ -274,8 +274,8 @@ namespace WixToolsetTest.CoreIntegration
                                                   .ToArray();
                 WixAssert.CompareLineByLine(new string[]
                 {
-                    $"<BundlePackage Id='chain.exe' Cache='keep' CacheId='{chainBundleId}v1.0.0.0' InstallSize='34' Size='*' PerMachine='yes' Permanent='yes' Vital='yes' RollbackBoundaryForward='WixDefaultBoundary' RollbackBoundaryBackward='WixDefaultBoundary' LogPathVariable='WixBundleLog_chain.exe' RollbackLogPathVariable='WixBundleRollbackLog_chain.exe' BundleId='{chainBundleId}' Version='1.0.0.0' InstallArguments='' UninstallArguments='' RepairArguments='' SupportsBurnProtocol='yes' Win64='no'>" +
-                    "<Provides Key='MyProviderKey,v1.0' Version='1.0.0.0' DisplayName='BurnBundle' Imported='yes' />" +
+                    $"<BundlePackage Id='chain.exe' Cache='keep' CacheId='{chainBundleId}v1.0.0-foo.55' InstallSize='34' Size='*' PerMachine='yes' Permanent='yes' Vital='yes' RollbackBoundaryForward='WixDefaultBoundary' RollbackBoundaryBackward='WixDefaultBoundary' LogPathVariable='WixBundleLog_chain.exe' RollbackLogPathVariable='WixBundleRollbackLog_chain.exe' BundleId='{chainBundleId}' Version='1.0.0-foo.55' InstallArguments='' UninstallArguments='' RepairArguments='' SupportsBurnProtocol='yes' Win64='no'>" +
+                    "<Provides Key='MyProviderKey,v1.0' Version='1.0.0-foo.55' DisplayName='BurnBundle' Imported='yes' />" +
                     "<RelatedBundle Id='{B94478B1-E1F3-4700-9CE8-6AA090854AEC}' Action='Upgrade' />" +
                     "<PayloadRef Id='chain.exe' />" +
                     "</BundlePackage>",
@@ -302,7 +302,7 @@ namespace WixToolsetTest.CoreIntegration
                                                    .ToArray();
                 WixAssert.CompareLineByLine(new string[]
                 {
-                    "<WixPackageProperties Package='chain.exe' Vital='yes' DisplayName='BurnBundle' Description='BurnBundleDescription' DownloadSize='*' PackageSize='*' InstalledSize='34' PackageType='Bundle' Permanent='yes' LogPathVariable='WixBundleLog_chain.exe' RollbackLogPathVariable='WixBundleRollbackLog_chain.exe' Compressed='no' Version='1.0.0.0' Cache='keep' />",
+                    "<WixPackageProperties Package='chain.exe' Vital='yes' DisplayName='BurnBundle' Description='BurnBundleDescription' DownloadSize='*' PackageSize='*' InstalledSize='34' PackageType='Bundle' Permanent='yes' LogPathVariable='WixBundleLog_chain.exe' RollbackLogPathVariable='WixBundleRollbackLog_chain.exe' Compressed='no' Version='1.0.0-foo.55' Cache='keep' />",
                 }, packageElements);
             }
         }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/RemotePayloadFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/RemotePayloadFixture.cs
@@ -205,7 +205,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' DownloadUrl='https://www.example.com/files/burn.exe' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.1703.0' />",
+                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' DownloadUrl='https://www.example.com/files/burn.exe' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.0.1703' />",
                 }, elements);
             }
         }
@@ -265,7 +265,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.1703.0' />",
+                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.0.1703' />",
                     @"<Payload Name='signed_cab1.cab' CertificatePublicKey='BBD1B48A37503767C71F455624967D406A5D66C3' CertificateThumbprint='DE13B4CE635E3F63AA2394E66F95C460267BC82F' Hash='D8D3842403710E1F6036A62543224855CADF546853933C2B17BA99D789D4347B36717687C022678A9D3DE749DFC1482DAAB92B997B62BB32A8A6828B9D04C414' Size='1585' />",
                 }, elements);
             }
@@ -296,7 +296,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.1703.0' />",
+                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.0.1703' />",
                     @"<Payload Name='signed_cab1.cab' Hash='D8D3842403710E1F6036A62543224855CADF546853933C2B17BA99D789D4347B36717687C022678A9D3DE749DFC1482DAAB92B997B62BB32A8A6828B9D04C414' Size='1585' />",
                 }, elements);
             }
@@ -331,7 +331,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' DownloadUrl='https://www.example.com/files/burn.exe' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.1703.0' />",
+                    @"<ExePackagePayload Name='burn.exe' ProductName='Windows Installer XML Toolset' Description='WiX Toolset Bootstrapper' DownloadUrl='https://www.example.com/files/burn.exe' Hash='F6E722518AC3AB7E31C70099368D5770788C179AA23226110DCF07319B1E1964E246A1E8AE72E2CF23E0138AFC281BAFDE45969204405E114EB20C8195DA7E5E' Size='463360' Version='3.14.0.1703' />",
                     @"<Payload Name='a.dat' DownloadUrl='https://www.example.com/files/RemotePayload/recurse/a.dat' Hash='D13926E5CBE5ED8B46133F9199FAF2FF25B25981C67A31AE2BC3F6C20390FACBFADCD89BD22D3445D95B989C8EACFB1E68DB634BECB5C9624865BA453BCE362A' Size='16' />",
                     @"<Payload Name='b.dat' DownloadUrl='https://www.example.com/files/RemotePayload/recurse/subfolder/b.dat' Hash='5F94707BC29ADFE3B9615E6753388707FD0B8F5FD9EEEC2B17E21E72F1635FF7D7A101E7D14F614E111F263CB9AC4D0940BE1247881A7844F226D6C400293D8E' Size='37' />",
                     @"<Payload Name='c.dat' DownloadUrl='https://www.example.com/files/RemotePayload/recurse/subfolder/c.dat' Hash='97D6209A5571E05E4F72F9C6BF0987651FA03E63F971F9B53C2B3D798A666D9864F232D4E2D6442E47D9D72B282309B6EEFF4EE017B43B706FA92A0F5EF74734' Size='42' />",

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundlePackage/RemoteBundlePackage.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundlePackage/RemoteBundlePackage.wxs
@@ -18,7 +18,7 @@
                           ProtocolVersion="1"
                           ProviderKey="MyProviderKey,v1.0"
                           UpgradeCode="{B94478B1-E1F3-4700-9CE8-6AA090854AEC}"
-                          Version="1.0.0.0"
+                          Version="1.0.0-foo.55"
                           Win64="no"
                           />
         </BundlePackagePayload>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Upgrade/UpgradeInvalidMinVersion.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Upgrade/UpgradeInvalidMinVersion.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <ComponentGroupRef Id="MinimalComponentGroup"></ComponentGroupRef>
+        </ComponentGroup>
+
+        <Upgrade Id="B05772EA-82B8-4DE0-B7EB-45B5F0CCFE6D">
+            <UpgradeVersion Minimum="1.256.0" Property="RELPRODFOUND"></UpgradeVersion>
+        </Upgrade>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Version/Bundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Version/Bundle.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Bundle Name="MsiPackage-Bundle" Version="$(Version)" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <BootstrapperApplication>
+      <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+    </BootstrapperApplication>
+
+    <Chain>
+      <MsiPackage SourceFile="test1.msi" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Version/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Version/Package.wxs
@@ -1,0 +1,31 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Version="$(Version)"
+           Name="MsiPackage"
+           Manufacturer="Example Corporation"
+           UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a"
+           Scope="perUser">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade not allowed" />
+    <MediaTemplate EmbedCab="true" />
+
+    <Feature Id="ProductFeature" Title="Feature title">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="DesktopFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage $(Version)v" />
+    </StandardDirectory>
+  </Fragment>
+
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="test.txt" />
+            </Component>
+            <Component Id="Shared.dll" Shared="yes">
+                <File Name="Shared.dll" Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class UpgradeFixture
+    {
+
+        [Fact]
+        public void PopulatesInstallExecuteSequenceTable()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Upgrade", "UpgradeInvalidMinVersion.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "MinimalComponentGroup.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                var message = result.Messages.Single(m => m.Level == MessageLevel.Error);
+                Assert.Equal("Invalid product version '1.256.0'. Product version must have a major version less than 256, a minor version less than 256, and a build version less than 65536.", message.ToString());
+                Assert.Equal(242, result.ExitCode);
+            }
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/VersionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/VersionFixture.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class VersionFixture
+    {
+        [Fact]
+        public void CannotBuildMsiWithInvalidMajorVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test1.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Version", "Package.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-d", "Version=257.0.0",
+                    "-o", msiPath
+                });
+
+                var message = result.Messages.Single(m => m.Level == MessageLevel.Error);
+                Assert.Equal("Invalid product version '257.0.0'. Product version must have a major version less than 256, a minor version less than 256, and a build version less than 65536.", message.ToString());
+                Assert.Equal(242, result.ExitCode);
+            }
+        }
+
+        [Fact]
+        public void CanBuildBundleWithSemanticVersion()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test1.msi");
+                var msi2Path = Path.Combine(baseFolder, @"bin\test2.msi");
+                var bundlePath = Path.Combine(baseFolder, @"bin\bundle.exe");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Version", "Package.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-d", "Version=255.255.65535",
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+
+                var result3 = WixRunner.Execute(new[]
+{
+                    "build",
+                    Path.Combine(folder, "Version", "Bundle.wxs"),
+                    "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
+                    "-bindpath", Path.Combine(baseFolder, "bin"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-d", "Version=2022.3.9-preview.0-build.5+0987654321abcdef1234567890",
+                    "-o", bundlePath
+                });
+
+                result3.AssertSuccess();
+
+                var propertyTable = Query.QueryDatabase(msiPath, new[] { "Property" }).Select(r => r.Split('\t')).ToDictionary(r => r[0].Substring("Property:".Length), r => r[1]);
+                Assert.True(propertyTable.TryGetValue("ProductVersion", out var productVersion));
+                Assert.Equal("255.255.65535", productVersion);
+
+                var extractResult = BundleExtractor.ExtractAllContainers(null, bundlePath, Path.Combine(baseFolder, "ba"), Path.Combine(baseFolder, "attached"), Path.Combine(baseFolder, "extract"));
+                extractResult.AssertSuccess();
+
+                var bundleVersion = extractResult.SelectManifestNodes("/burn:BurnManifest/burn:Registration/@Version")
+                                                 .Cast<XmlAttribute>()
+                                                 .Single();
+                Assert.Equal("2022.3.9-preview.0-build.5+0987654321abcdef1234567890", bundleVersion.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for semver in bundles and dependencies

Take advantage of WixVersion/verutil functionality to support wider
range of version numbers were possible in the WiX Toolset

Closes wixtoolset/issues#4666