### PR TITLE
Add two useful tools for debugging custom actions

### DIFF
--- a/src/libs/wcautil/WixToolset.WcaUtil/inc/wcautil.h
+++ b/src/libs/wcautil/WixToolset.WcaUtil/inc/wcautil.h
@@ -23,6 +23,32 @@ extern "C" {
 #define MessageExitOnFailure(x, e, s, ...) MessageExitOnFailureSource(DUTIL_SOURCE_DEFAULT, x, e, s, __VA_ARGS__)
 #define MessageExitOnNullWithLastError(p, x, e, s, ...) MessageExitOnNullWithLastErrorSource(DUTIL_SOURCE_DEFAULT, p, x, e, s, __VA_ARGS__)
 
+#define ANNOTATE
+
+#ifdef ANNOTATE
+#define WcaReadStringFromCaData(d, s) WcaReadAnnotatedStringFromCaData(__FILE__, __LINE__, #s, d, s)
+#define WcaReadIntegerFromCaData(d, i) WcaReadAnnotatedIntegerFromCaData(__FILE__, __LINE__, #i, d, i)
+#define WcaReadStreamFromCaData(d, c, b) WcaReadAnnotatedStreamFromCaData(__FILE__, __LINE__, #b, d, c, b)
+#define WcaWriteStringToCaData(s, d) WcaWriteAnnotatedStringToCaData(__FILE__, __LINE__, #s, s, d)
+#define WcaWriteIntegerToCaData(i, d) WcaWriteAnnotatedIntegerToCaData(__FILE__, __LINE__, #i, i, d)
+#define WcaWriteStreamToCaData(c, b, d) WcaWriteAnnotatedStreamToCaData(__FILE__, __LINE__, #b, c, b, d)
+#else
+#define WcaReadStringFromCaData(d, s) WcaReadStringFromCaDataImpl(d, s)
+#define WcaReadIntegerFromCaData(d, i) WcaReadIntegerFromCaDataImpl(d, i)
+#define WcaReadStreamFromCaData(d, c, b) WcaReadStreamFromCaDataImpl(d, c, b)
+#define WcaWriteStringToCaData(s, d) WcaWriteStringToCaDataImpl(s, d)
+#define WcaWriteIntegerToCaData(i, d) WcaWriteIntegerToCaDataImpl(i, d)
+#define WcaWriteStreamToCaData(c, b, d) WcaWriteStreamToCaDataImpl(c, b, d)
+#endif
+
+#define CHECKIN
+
+#ifdef CHECKIN
+#define WcaCheckIn() WcaCheckInImpl(__FILE__, __LINE__)
+#else
+#define WcaCheckIn()
+#endif
+
 // Generic action enum.
 typedef enum WCA_ACTION
 {
@@ -264,32 +290,86 @@ DWORD WIXAPI WcaCountOfCustomActionDataRecords(
     __in_z LPCWSTR wzData
     );
 
-HRESULT WIXAPI WcaReadStringFromCaData(
+HRESULT WIXAPI WcaReadStringFromCaDataImpl(
     __deref_in LPWSTR* ppwzCustomActionData,
     __deref_out_z LPWSTR* ppwzString
     );
-HRESULT WIXAPI WcaReadIntegerFromCaData(
+HRESULT WIXAPI WcaReadIntegerFromCaDataImpl(
     __deref_in LPWSTR* ppwzCustomActionData,
     __out int* piResult
     );
-HRESULT WIXAPI WcaReadStreamFromCaData(
+HRESULT WIXAPI WcaReadStreamFromCaDataImpl(
     __deref_in LPWSTR* ppwzCustomActionData,
     __deref_out_bcount(*pcbData) BYTE** ppbData,
     __out DWORD_PTR* pcbData
     );
-HRESULT WIXAPI WcaWriteStringToCaData(
+HRESULT WIXAPI WcaWriteStringToCaDataImpl(
     __in_z LPCWSTR wzString,
     __deref_inout_z LPWSTR* ppwzCustomActionData
     );
-HRESULT WIXAPI WcaWriteIntegerToCaData(
+HRESULT WIXAPI WcaWriteIntegerToCaDataImpl(
     __in int i,
     __deref_out_z_opt LPWSTR* ppwzCustomActionData
     );
-HRESULT WIXAPI WcaWriteStreamToCaData(
+HRESULT WIXAPI WcaWriteStreamToCaDataImpl(
     __in_bcount(cbData) const BYTE* pbData,
     __in SIZE_T cbData,
     __deref_inout_z_opt LPWSTR* ppwzCustomActionData
     );
+
+#ifdef ANNOTATE
+HRESULT WIXAPI WcaReadAnnotatedStringFromCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __deref_in LPWSTR* ppwzCustomActionData,
+    __deref_out_z LPWSTR* ppwzString
+);
+HRESULT WIXAPI WcaReadAnnotatedIntegerFromCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __deref_in LPWSTR* ppwzCustomActionData,
+    __out int* piResult
+);
+HRESULT WIXAPI WcaReadAnnotatedStreamFromCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __deref_in LPWSTR* ppwzCustomActionData,
+    __deref_out_bcount(*pcbData) BYTE** ppbData,
+    __out DWORD_PTR* pcbData
+);
+HRESULT WIXAPI WcaWriteAnnotatedStringToCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __in_z LPCWSTR wzString,
+    __deref_inout_z_opt LPWSTR* ppwzCustomActionData
+);
+HRESULT WIXAPI WcaWriteAnnotatedIntegerToCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __in int i,
+    __deref_out_z_opt LPWSTR* ppwzCustomActionData
+);
+HRESULT WIXAPI WcaWriteAnnotatedStreamToCaData(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __in_bcount(cbData) const BYTE* pbData,
+    __in SIZE_T cbData,
+    __deref_inout_z_opt LPWSTR* ppwzCustomActionData
+);
+#endif
+
+#ifdef CHECKIN
+VOID WIXAPI WcaCheckInImpl(
+    __in_z LPCSTR szFile,
+    __in int iLine
+);
+#endif
 
 HRESULT __cdecl WcaAddTempRecord(
     __inout MSIHANDLE* phTableView,

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcascript.cpp
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcascript.cpp
@@ -235,12 +235,69 @@ LExit:
     return hr;
 }
 
-
 /********************************************************************
- WcaCaScriptWriteString() - writes a string to the ca script.
+ WcaCaScriptWriteAnnotatedString() - writes an annotated string to the ca script.
 
 ********************************************************************/
-extern "C" HRESULT WIXAPI WcaCaScriptWriteString(
+extern "C" HRESULT WIXAPI WcaCaScriptWriteAnnotatedString(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __in WCA_CASCRIPT_HANDLE hScript,
+    __in_z LPCWSTR wzValue
+)
+{
+    WCHAR wzBuffer[512];
+    HRESULT hr = StringCchPrintfW(wzBuffer, countof(wzBuffer), L"%hs(%d) Write Script String (%hs) = \"%ls\"", szFile, iLine, szVar, wzValue);
+    ExitOnFailure(hr, "failed to write annotated string to ca scrippt");
+
+    WcaLog(LOGMSG_STANDARD, "%ls", wzBuffer);
+
+    hr = WcaCaScriptWriteStringImpl(hScript, wzBuffer);
+    ExitOnFailure(hr, "failed to write annotated string to ca script");
+
+    hr = WcaCaScriptWriteStringImpl(hScript, wzValue);
+    ExitOnFailure(hr, "failed to write annotated string to ca script");
+
+LExit:
+    return hr;
+}
+
+#ifdef ANNOTATE
+/********************************************************************
+ WcaCaScriptWriteAnnotatedNumber() - writes an annotated number to the ca script.
+
+********************************************************************/
+extern "C" HRESULT WIXAPI WcaCaScriptWriteAnnotatedNumber(
+    __in_z LPCSTR szFile,
+    __in int iLine,
+    __in_z LPCSTR szVar,
+    __in WCA_CASCRIPT_HANDLE hScript,
+    __in DWORD dwValue
+)
+{
+    WCHAR wzBuffer[512];
+    HRESULT hr = StringCchPrintfW(wzBuffer, countof(wzBuffer), L"%hs(%d) Write Script Number (%hs) = \"%u\"", szFile, iLine, szVar, dwValue);
+    ExitOnFailure(hr, "failed to write annotated number to ca script");
+
+    WcaLog(LOGMSG_STANDARD, "%ls", wzBuffer);
+
+    hr = WcaCaScriptWriteStringImpl(hScript, wzBuffer);
+    ExitOnFailure(hr, "failed to write annotated integer to ca data");
+
+    hr = WcaCaScriptWriteNumberImpl(hScript, dwValue);
+    ExitOnFailure(hr, "failed to write annotated number to ca script");
+
+LExit:
+    return hr;
+}
+#endif
+
+/********************************************************************
+ WcaCaScriptWriteStringImpl() - writes a string to the ca script.
+
+********************************************************************/
+extern "C" HRESULT WIXAPI WcaCaScriptWriteStringImpl(
     __in WCA_CASCRIPT_HANDLE hScript,
     __in_z LPCWSTR wzValue
     )
@@ -274,12 +331,11 @@ LExit:
     return hr;
 }
 
-
 /********************************************************************
- WcaCaScriptWriteNumber() - writes a number to the ca script.
+ WcaCaScriptWriteNumberImpl() - writes a number to the ca script.
 
 ********************************************************************/
-extern "C" HRESULT WIXAPI WcaCaScriptWriteNumber(
+extern "C" HRESULT WIXAPI WcaCaScriptWriteNumberImpl(
     __in WCA_CASCRIPT_HANDLE hScript,
     __in DWORD dwValue
     )
@@ -290,7 +346,7 @@ extern "C" HRESULT WIXAPI WcaCaScriptWriteNumber(
     hr = ::StringCchPrintfW(wzBuffer, countof(wzBuffer), L"%u", dwValue);
     ExitOnFailure(hr, "Failed to convert number into string.");
 
-    hr = WcaCaScriptWriteString(hScript, wzBuffer);
+    hr = WcaCaScriptWriteStringImpl(hScript, wzBuffer);
     ExitOnFailure(hr, "Failed to write number to script.");
 
 LExit:


### PR DESCRIPTION
This pull request includes two tools I have developed to aid in debugging
custom actions. The first tool provides a way to match up writes to and reads
from custom action data. The second tool is a simple, "Here I am!" that can be
pasted freely into custom action code to allow the analysis of code flow. It is especially useful when used inn conjunction with calls to WcaLog() to provide
data state in conjunction with the flow. There are a few comments in WcaUtil.h
to help with setting things up.