### PR TITLE
6836 - Make the clean room process replace the splash screen with its own

### DIFF
--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -132,7 +132,7 @@ extern "C" HRESULT EngineRun(
 
     engineState.command.nCmdShow = nCmdShow;
 
-    if (BURN_MODE_ELEVATED != engineState.internalCommand.mode && BOOTSTRAPPER_DISPLAY_NONE < engineState.command.display && !engineState.command.hwndSplashScreen)
+    if (BURN_MODE_ELEVATED != engineState.internalCommand.mode && BOOTSTRAPPER_DISPLAY_NONE < engineState.command.display)
     {
         SplashScreenCreate(hInstance, NULL, &engineState.command.hwndSplashScreen);
     }

--- a/src/test/burn/WixToolsetTest.BurnE2E/WixIuiBaTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/WixIuiBaTests.cs
@@ -114,7 +114,7 @@ namespace WixToolsetTest.BurnE2E
         // Manual test for InternalUIBundle:
         //  1. Double click InternalUIBundle.exe on a machine that will prompt for elevation.
         //  2. Verify that the splash screen appeared but the prereq BA did not come up.
-        //  3. Verify that the elevation prompt came up immediately instead of flashing on the taskbar. (This is currently broken)
+        //  3. Verify that the elevation prompt came up immediately instead of flashing on the taskbar.
         //  4. Allow elevation.
         //  5. Verify that the MSI UI came up and the splash screen disappeared.
         //  6. Accept the two CA messages and click the install button.


### PR DESCRIPTION
This is required to get Windows to automatically transfer foreground focus so that the BA's window or the elevation prompt is automatically activated.

Fixes https://github.com/wixtoolset/issues/issues/6836