### PR TITLE
Fix converting empty inner text.

### DIFF
--- a/src/wix/WixToolset.Converters/WixConverter.cs
+++ b/src/wix/WixToolset.Converters/WixConverter.cs
@@ -2274,15 +2274,17 @@ namespace WixToolset.Converters
         private static bool TryGetInnerText(XElement element, out string value)
         {
             value = null;
+            var found = false;
 
-            var nodes = element.Nodes();
+            var nodes = element.Nodes().ToList();
 
-            if (nodes.All(e => e.NodeType == XmlNodeType.Text || e.NodeType == XmlNodeType.CDATA))
+            if (nodes.Any() && nodes.All(e => e.NodeType == XmlNodeType.Text || e.NodeType == XmlNodeType.CDATA))
             {
                 value = String.Join(String.Empty, nodes.Cast<XText>().Select(TrimTextValue));
+                found = true;
             }
 
-            return !String.IsNullOrEmpty(value);
+            return found;
         }
 
         private static bool IsTextNode(XNode node, out XText text)

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
@@ -535,6 +535,9 @@ namespace WixToolsetTest.CoreIntegration
                 var fileSymbol = section.Symbols.OfType<FileSymbol>().Single();
                 WixAssert.StringEqual(Path.Combine(folder, @"data\test.txt"), fileSymbol[FileSymbolFields.Source].AsPath().Path);
                 WixAssert.StringEqual(@"test.txt", fileSymbol[FileSymbolFields.Source].PreviousValue.AsPath().Path);
+
+                var featureSymbol = Assert.Single(section.Symbols.OfType<FeatureSymbol>());
+                WixAssert.StringEqual("MsiPackage", featureSymbol.Title);
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Bundle.en-us.wxl
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Bundle.en-us.wxl
@@ -1,0 +1,6 @@
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="BundleName">~IncludeTestBundle</String>
+  <String Id="BundleInProgressName">~InProgressTestBundle</String>
+
+</WixLocalization>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Bundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Bundle.wxs
@@ -1,0 +1,13 @@
+<?include data\Bundle.wxi ?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Bundle Name="$(var.BundleLocName)" InProgressName="!(loc.BundleInProgressName)" Version="!(bind.packageVersion.test.msi)" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <BootstrapperApplication>
+      <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+    </BootstrapperApplication>
+    <Chain>
+      <MsiPackage SourceFile="test.msi">
+        <MsiProperty Name="TEST" Value="1" />
+      </MsiPackage>
+    </Chain>
+  </Bundle>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Package.wxs
@@ -5,7 +5,7 @@
 
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
-    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+    <Feature Id="ProductFeature" Title="$(var.FeatureTitleName)">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
   </Package>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/data/Bundle.wxi
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/data/Bundle.wxi
@@ -1,0 +1,3 @@
+<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <?define BundleLocName = "!(loc.BundleName)" ?>
+</Include>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/data/Package.wxi
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/data/Package.wxi
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <?define ProductVersion = "1.2.3" ?>
+  <?define FeatureTitleName = "!(loc.FeatureTitle)" ?>
 </Include>


### PR DESCRIPTION
Add failing test for commented inner text (https://github.com/wixtoolset/issues/issues/6847).

Closes https://github.com/wixtoolset/issues/issues/6846.