### PR TITLE
Add intermediate folder and output path to all contexts 

### DIFF
--- a/src/api/api.cmd
+++ b/src/api/api.cmd
@@ -3,25 +3,51 @@
 
 @set _C=Debug
 @set _L=%~dp0..\..\build\logs
+
 :parse_args
 @if /i "%1"=="release" set _C=Release
+@if /i "%1"=="inc" set _INCREMENTAL=1
+@if /i "%1"=="clean" set _INCREMENTAL= & set _CLEAN=1
 @if not "%1"=="" shift & goto parse_args
 
 @set _B=%~dp0..\..\build\api\%_C%
 
+:: Clean
+@if NOT "%_INCREMENTAL%"=="" call :clean
+@if NOT "%_CLEAN%"=="" goto :end
+
 @echo Building api %_C%
 
-:: restore
-:: build
-:: pack
+:: Restore
+:: Build
+:: Pack
 
 msbuild api_t.proj -p:Configuration=%_C% -nologo -m -warnaserror -bl:%_L%\api_build.binlog || exit /b
 
-:: test
+:: Test
 dotnet test burn\test\WixToolsetTest.Mba.Core -c %_C% --nologo --no-build -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.Mba.Core.trx" || exit /b
 dotnet test %_B%\x86\BalUtilUnitTest.dll --nologo -l "trx;LogFileName=%_L%\TestResults\BalUtilUnitTest.trx" || exit /b
 dotnet test %_B%\x86\BextUtilUnitTest.dll --nologo -l "trx;LogFileName=%_L%\TestResults\BextUtilUnitTest.trx" || exit /b
 dotnet test wix\api_wix.sln -c %_C% --nologo --no-build -l "trx;LogFileName=%_L%\TestResults\api_wix.trx" || exit /b
 
+@goto :end
+
+:clean
+@rd /s/q "..\..\build\api" 2> nul
+@del "..\..\build\artifacts\WixToolset.BalUtil.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.BextUtil.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.BootstrapperCore.Native.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.Data.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.Extensibility.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.Mba.Core.*.nupkg" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.balutil" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.bextutil" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.bootstrappercore.native" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.data" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.extensibility" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.mba.core" 2> nul
+@exit /b
+
+:end
 @popd
 @endlocal

--- a/src/api/wix/WixToolset.Extensibility/Data/ICommandLineContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ICommandLineContext.cs
@@ -5,13 +5,24 @@ namespace WixToolset.Extensibility.Data
     using System;
     using WixToolset.Extensibility.Services;
 
-#pragma warning disable 1591 // TODO: add documentation
+    /// <summary>
+    /// Command-line context.
+    /// </summary>
     public interface ICommandLineContext
     {
+        /// <summary>
+        /// Service provider.
+        /// </summary>
         IServiceProvider ServiceProvider { get; }
 
+        /// <summary>
+        /// Extension manager.
+        /// </summary>
         IExtensionManager ExtensionManager { get; set; }
 
+        /// <summary>
+        /// Command-line arguments.
+        /// </summary>
         ICommandLineArguments Arguments { get; set; }
     }
 }

--- a/src/api/wix/WixToolset.Extensibility/Data/ICompileContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ICompileContext.cs
@@ -29,6 +29,16 @@ namespace WixToolset.Extensibility.Data
         IReadOnlyCollection<ICompilerExtension> Extensions { get; set; }
 
         /// <summary>
+        /// Intermediate folder.
+        /// </summary>
+        string IntermediateFolder { get; set; }
+
+        /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the platform which the compiler will use when defaulting 64-bit attributes and elements.
         /// </summary>
         /// <value>The platform which the compiler will use when defaulting 64-bit attributes and elements.</value>

--- a/src/api/wix/WixToolset.Extensibility/Data/ILayoutContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ILayoutContext.cs
@@ -37,6 +37,11 @@ namespace WixToolset.Extensibility.Data
         string IntermediateFolder { get; set; }
 
         /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
+
+        /// <summary>
         /// File to capture list of content, built output and copied output files.
         /// </summary>
         string TrackingFile { get; set; }

--- a/src/api/wix/WixToolset.Extensibility/Data/ILibraryContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ILibraryContext.cs
@@ -43,9 +43,19 @@ namespace WixToolset.Extensibility.Data
         IReadOnlyCollection<Localization> Localizations { get; set; }
 
         /// <summary>
+        /// Intermediate folder.
+        /// </summary>
+        string IntermediateFolder { get; set; }
+
+        /// <summary>
         /// Collection of intermediates to include in the library.
         /// </summary>
         IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
 
         /// <summary>
         /// Cancellation token.

--- a/src/api/wix/WixToolset.Extensibility/Data/ILinkContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ILinkContext.cs
@@ -33,9 +33,19 @@ namespace WixToolset.Extensibility.Data
         OutputType ExpectedOutputType { get; set; }
 
         /// <summary>
+        /// Intermediate folder.
+        /// </summary>
+        string IntermediateFolder { get; set; }
+
+        /// <summary>
         /// Collection of intermediates to link.
         /// </summary>
         IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
 
         /// <summary>
         /// Symbol definition creator used to load extension data.

--- a/src/api/wix/WixToolset.Extensibility/Data/IPreprocessContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IPreprocessContext.cs
@@ -28,6 +28,16 @@ namespace WixToolset.Extensibility.Data
         IReadOnlyCollection<string> IncludeSearchPaths { get; set; }
 
         /// <summary>
+        /// Intermediate folder.
+        /// </summary>
+        string IntermediateFolder { get; set; }
+
+        /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
+
+        /// <summary>
         /// Gets the platform which the compiler will use when defaulting 64-bit attributes and elements.
         /// </summary>
         /// <value>The platform which the compiler will use when defaulting 64-bit attributes and elements.</value>

--- a/src/api/wix/WixToolset.Extensibility/Data/IResolveContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IResolveContext.cs
@@ -58,6 +58,11 @@ namespace WixToolset.Extensibility.Data
         bool AllowUnresolvedVariables { get; set; }
 
         /// <summary>
+        /// Output path.
+        /// </summary>
+        string OutputPath { get; set; }
+
+        /// <summary>
         /// Cancellation token.
         /// </summary>
         CancellationToken CancellationToken { get; set; }

--- a/src/setup/ThmViewerPackage/ThmViewerPackage.wxs
+++ b/src/setup/ThmViewerPackage/ThmViewerPackage.wxs
@@ -2,7 +2,6 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="WiX Toolset Theme Viewer" Manufacturer="WiX Toolset" Language="1033" Version="!(bind.fileVersion.ThmViewerFile)" UpgradeCode="59c4b122-5167-445b-8fc4-09dcd4eced89">
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
-    <MediaTemplate />
 
     <Feature Id="Main">
       <ComponentGroupRef Id="Components" />

--- a/src/tools/tools.cmd
+++ b/src/tools/tools.cmd
@@ -17,7 +17,7 @@
 @echo Building tools %_C%
 
 :: Build
-msbuild -Restore tools.sln -p:Configuration=%_C% -nologo -m -warnaserror -bl:..\..\build\logs\tools_build.binlog || exit /b
+msbuild -Restore tools.sln -p:Configuration=%_C% -nologo -m -warnaserror -bl:%_L%\tools_build.binlog || exit /b
 
 :: Publish
 msbuild publish_t.proj -p:Configuration=%_C% -nologo -m -warnaserror -bl:%_L%\tools_publish.binlog || exit /b
@@ -26,7 +26,7 @@ msbuild publish_t.proj -p:Configuration=%_C% -nologo -m -warnaserror -bl:%_L%\to
 dotnet test -c %_C% --no-build --nologo test\WixToolsetTest.HeatTasks -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.HeatTasks.trx" || exit /b
 
 :: Pack
-msbuild -t:Pack WixToolset.Heat -p:Configuration=%_C% -p:NoBuild=true -nologo -m -warnaserror -bl:..\..\build\logs\tools_pack.binlog || exit /b
+msbuild -t:Pack WixToolset.Heat -p:Configuration=%_C% -p:NoBuild=true -nologo -m -warnaserror -bl:%_L%\tools_pack.binlog || exit /b
 
 @goto :end
 

--- a/src/wix/WixToolset.Core/CompileContext.cs
+++ b/src/wix/WixToolset.Core/CompileContext.cs
@@ -23,6 +23,10 @@ namespace WixToolset.Core
 
         public IReadOnlyCollection<ICompilerExtension> Extensions { get; set; }
 
+        public string IntermediateFolder { get; set; }
+
+        public string OutputPath { get; set; }
+
         public Platform Platform { get; set; }
 
         public bool IsCurrentPlatform64Bit => this.Platform == Platform.ARM64 || this.Platform == Platform.X64;

--- a/src/wix/WixToolset.Core/LayoutContext.cs
+++ b/src/wix/WixToolset.Core/LayoutContext.cs
@@ -31,6 +31,8 @@ namespace WixToolset.Core
 
         public bool ResetAcls { get; set; }
 
+        public string OutputPath { get; set; }
+
         public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/wix/WixToolset.Core/LibraryContext.cs
+++ b/src/wix/WixToolset.Core/LibraryContext.cs
@@ -31,7 +31,11 @@ namespace WixToolset.Core
 
         public IReadOnlyCollection<Localization> Localizations { get; set; }
 
+        public string IntermediateFolder { get; set; }
+
         public IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        public string OutputPath { get; set; }
 
         public CancellationToken CancellationToken { get; set; }
     }

--- a/src/wix/WixToolset.Core/LinkContext.cs
+++ b/src/wix/WixToolset.Core/LinkContext.cs
@@ -24,7 +24,11 @@ namespace WixToolset.Core
 
         public OutputType ExpectedOutputType { get; set; }
 
+        public string IntermediateFolder { get; set; }
+
         public IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        public string OutputPath { get; set; }
 
         public ISymbolDefinitionCreator SymbolDefinitionCreator { get; set; }
 

--- a/src/wix/WixToolset.Core/PreprocessContext.cs
+++ b/src/wix/WixToolset.Core/PreprocessContext.cs
@@ -24,6 +24,10 @@ namespace WixToolset.Core
 
         public IReadOnlyCollection<string> IncludeSearchPaths { get; set; }
 
+        public string IntermediateFolder { get; set; }
+
+        public string OutputPath { get; set; }
+
         public string SourcePath { get; set; }
 
         public IDictionary<string, string> Variables { get; set; }

--- a/src/wix/WixToolset.Core/ResolveContext.cs
+++ b/src/wix/WixToolset.Core/ResolveContext.cs
@@ -37,6 +37,8 @@ namespace WixToolset.Core
 
         public bool AllowUnresolvedVariables { get; set; }
 
+        public string OutputPath { get; set; }
+
         public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
@@ -32,7 +32,9 @@ namespace WixToolsetTest.CoreIntegration
             var context = serviceProvider.GetService<ILinkContext>();
             context.Extensions = Array.Empty<WixToolset.Extensibility.ILinkerExtension>();
             context.ExtensionData = Array.Empty<WixToolset.Extensibility.IExtensionData>();
+            context.IntermediateFolder = Path.GetTempPath();
             context.Intermediates = new[] { intermediate1, intermediate2 };
+            context.OutputPath = Path.Combine(context.IntermediateFolder, "test.msi");
             context.SymbolDefinitionCreator = creator;
 
             var linker = serviceProvider.GetService<ILinker>();


### PR DESCRIPTION
Extensions sometimes need to generate files and lay them out relative to the final output path. Provide that context to all extensions so they can use the correct intermediate folder and output path.