### PR TITLE
Quality of life fixes plus prevent crash when Bundles use SWID tags

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/Services/IMessaging.cs
+++ b/src/api/wix/WixToolset.Extensibility/Services/IMessaging.cs
@@ -16,6 +16,12 @@ namespace WixToolset.Extensibility.Services
         bool EncounteredError { get; }
 
         /// <summary>
+        /// Gets the number of errors encountered thus far.
+        /// </summary>
+        /// <value>The number of errors encountered.</value>
+        int ErrorCount { get; }
+
+        /// <summary>
         /// Gets the last error code encountered during messaging.
         /// </summary>
         /// <value>The exit code for the process.</value>

--- a/src/ext/NetFx/wixlib/NetCoreShared.wxs
+++ b/src/ext/NetFx/wixlib/NetCoreShared.wxs
@@ -1,6 +1,5 @@
 ﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <?foreach PLATFORM in x86;x64?>

--- a/src/setup/WixAdditionalTools/WixAdditionalTools.wxs
+++ b/src/setup/WixAdditionalTools/WixAdditionalTools.wxs
@@ -13,8 +13,7 @@
     </BootstrapperApplication>
 
     <SetVariable Variable="InstallFolder" Value="[ProgramFilesFolder]WiX Toolset v$(SetupMajorMinorVersion)\" />
-    <!-- TODO: bring back SoftwareTag when #6854 fixed -->
-    <!-- <SoftwareTag Regid="!(loc.Regid)" InstallPath="[InstallFolder]" /> -->
+    <SoftwareTag Regid="!(loc.Regid)" InstallPath="[InstallFolder]" />
 
     <Update Location="!(loc.UpdateUrl)" />
 

--- a/src/wix/WixToolset.Core.Burn/Bind/ProcessBundleSoftwareTagsCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bind/ProcessBundleSoftwareTagsCommand.cs
@@ -71,11 +71,14 @@ namespace WixToolset.Core.Burn.Bind
 
                     using (var db = new Database(payload.SourceFile.Path, OpenDatabase.ReadOnly))
                     {
-                        using (var view = db.OpenExecuteView("SELECT `Regid`, `TagId` FROM `SoftwareIdentificationTag`"))
+                        if (db.TableExists("SoftwareIdentificationTag"))
                         {
-                            foreach (var record in view.Records)
+                            using (var view = db.OpenExecuteView("SELECT `Regid`, `TagId` FROM `SoftwareIdentificationTag`"))
                             {
-                                tags.Add(new SoftwareTag { Regid = record.GetString(1), Id = record.GetString(2) });
+                                foreach (var record in view.Records)
+                                {
+                                    tags.Add(new SoftwareTag { Regid = record.GetString(1), Id = record.GetString(2) });
+                                }
                             }
                         }
                     }

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -157,7 +157,7 @@ namespace WixToolset.Core.CommandLine
             {
                 var document = this.Preprocess(preprocessorVariables, sourceFile, includeSearchPaths, cancellationToken);
 
-                if (this.Messaging.EncounteredError)
+                if (document == null)
                 {
                     continue;
                 }
@@ -358,7 +358,7 @@ namespace WixToolset.Core.CommandLine
             {
                 var document = this.Preprocess(preprocessorVariables, loc, includeSearchPaths, cancellationToken);
 
-                if (this.Messaging.EncounteredError)
+                if (document == null)
                 {
                     continue;
                 }

--- a/src/wix/WixToolset.Core/Compile/CompilerPayload.cs
+++ b/src/wix/WixToolset.Core/Compile/CompilerPayload.cs
@@ -115,22 +115,22 @@ namespace WixToolset.Core
 
                     if (!String.IsNullOrEmpty(this.Description))
                     {
-                        this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(this.SourceLineNumbers, this.Element.Name.LocalName, "Description", "SourceFile"));
+                        this.Core.Write(ErrorMessages.IllegalAttributeWithoutOtherAttributes(this.SourceLineNumbers, this.Element.Name.LocalName, "Description", "Hash", "CertificatePublicKey"));
                     }
 
                     if (!String.IsNullOrEmpty(this.ProductName))
                     {
-                        this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(this.SourceLineNumbers, this.Element.Name.LocalName, "ProductName", "SourceFile"));
+                        this.Core.Write(ErrorMessages.IllegalAttributeWithoutOtherAttributes(this.SourceLineNumbers, this.Element.Name.LocalName, "ProductName", "Hash", "CertificatePublicKey"));
                     }
 
                     if (this.Size.HasValue)
                     {
-                        this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(this.SourceLineNumbers, this.Element.Name.LocalName, "Size", "SourceFile"));
+                        this.Core.Write(ErrorMessages.IllegalAttributeWithoutOtherAttributes(this.SourceLineNumbers, this.Element.Name.LocalName, "Size", "Hash", "CertificatePublicKey"));
                     }
 
                     if (!String.IsNullOrEmpty(this.Version))
                     {
-                        this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(this.SourceLineNumbers, this.Element.Name.LocalName, "Version", "SourceFile"));
+                        this.Core.Write(ErrorMessages.IllegalAttributeWithoutOtherAttributes(this.SourceLineNumbers, this.Element.Name.LocalName, "Version", "Hash", "CertificatePublicKey"));
                     }
                 }
                 else

--- a/src/wix/WixToolset.Core/ExtensibilityServices/Messaging.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/Messaging.cs
@@ -13,7 +13,9 @@ namespace WixToolset.Core.ExtensibilityServices
         private readonly HashSet<int> suppressedWarnings = new HashSet<int>();
         private readonly HashSet<int> warningsAsErrors = new HashSet<int>();
 
-        public bool EncounteredError { get; private set; }
+        public bool EncounteredError => this.ErrorCount > 0;
+
+        public int ErrorCount { get; private set; }
 
         public int LastErrorNumber { get; private set; }
 
@@ -49,7 +51,7 @@ namespace WixToolset.Core.ExtensibilityServices
 
             if (level == MessageLevel.Error)
             {
-                this.EncounteredError = true;
+                ++this.ErrorCount;
                 this.LastErrorNumber = message.Id;
             }
 

--- a/src/wix/WixToolset.Core/Preprocessor.cs
+++ b/src/wix/WixToolset.Core/Preprocessor.cs
@@ -141,6 +141,8 @@ namespace WixToolset.Core
         {
             state.CurrentFileStack.Push(state.Helper.GetVariableValue(state.Context, "sys", "SOURCEFILEDIR"));
 
+            var beforeErrorCount = this.Messaging.ErrorCount;
+
             // Process the reader into the output.
             IPreprocessResult result = null;
             try
@@ -150,7 +152,7 @@ namespace WixToolset.Core
                 // Fire event with post-processed document.
                 this.ProcessedStream?.Invoke(this, new ProcessedStreamEventArgs(state.Context.SourcePath, state.Output));
 
-                if (!this.Messaging.EncounteredError)
+                if (beforeErrorCount == this.Messaging.ErrorCount)
                 {
                     result = this.ServiceProvider.GetService<IPreprocessResult>();
                     result.Document = state.Output;
@@ -292,7 +294,7 @@ namespace WixToolset.Core
                 if (XmlNodeType.ProcessingInstruction == reader.NodeType)
                 {
                     var ignore = false;
-                    string name = null;
+                    string name;
 
                     switch (reader.LocalName)
                     {
@@ -423,7 +425,6 @@ namespace WixToolset.Core
                                 break;
                             }
                         }
-
                     }
                     //else
                     //{
@@ -826,7 +827,7 @@ namespace WixToolset.Core
         private string GetNextToken(ProcessingState state, string originalExpression, ref string expression, out bool stringLiteral)
         {
             stringLiteral = false;
-            var token = String.Empty;
+            string token;
             expression = expression.Trim();
             if (0 == expression.Length)
             {
@@ -1280,7 +1281,7 @@ namespace WixToolset.Core
         /// <returns>Boolean to indicate if the expression is true or false</returns>
         private bool EvaluateExpressionRecurse(ProcessingState state, string originalExpression, ref string expression, PreprocessorOperation prevResultOperation, bool prevResult)
         {
-            var expressionValue = false;
+            bool expressionValue;
             expression = expression.Trim();
             if (expression.Length == 0)
             {

--- a/src/wix/test/WixToolsetTest.Converters/Mocks/MockMessaging.cs
+++ b/src/wix/test/WixToolsetTest.Converters/Mocks/MockMessaging.cs
@@ -12,7 +12,9 @@ namespace WixToolsetTest.Converters.Mocks
     {
         public List<Message> Messages { get; } = new List<Message>();
 
-        public bool EncounteredError { get; private set; }
+        public bool EncounteredError => this.ErrorCount > 0;
+
+        public int ErrorCount { get; private set; }
 
         public int LastErrorNumber { get; }
 
@@ -22,18 +24,33 @@ namespace WixToolsetTest.Converters.Mocks
 
         public bool WarningsAsError { get; set; }
 
-        public void ElevateWarningMessage(int warningNumber) => throw new NotImplementedException();
+        public void ElevateWarningMessage(int warningNumber)
+        {
+            throw new NotImplementedException();
+        }
 
-        public void SetListener(IMessageListener listener) => throw new NotImplementedException();
+        public void SetListener(IMessageListener listener)
+        {
+            throw new NotImplementedException();
+        }
 
-        public void SuppressWarningMessage(int warningNumber) => throw new NotImplementedException();
+        public void SuppressWarningMessage(int warningNumber)
+        {
+            throw new NotImplementedException();
+        }
 
         public void Write(Message message)
         {
             this.Messages.Add(message);
-            this.EncounteredError |= message.Level == MessageLevel.Error;
+            if (message.Level == MessageLevel.Error)
+            {
+                ++this.ErrorCount;
+            }
         }
 
-        public void Write(string message, bool verbose = false) => throw new NotImplementedException();
+        public void Write(string message, bool verbose = false)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/ExePackageFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/ExePackageFixture.cs
@@ -469,5 +469,35 @@ namespace WixToolsetTest.CoreIntegration
                 Assert.Equal(10, result.ExitCode);
             }
         }
+
+        [Fact]
+        public void CannotBuildBundleWithExePackageWithoutSourceOrHashOrCertificate()
+        {
+            var dotDatafolder = TestData.Get(@"TestData", ".Data");
+            var folder = TestData.Get(@"TestData", "ExePackage");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "ExePackageWithoutSourceHashOrCertificate.wxs"),
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-bindpath", dotDatafolder,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, "bin", "test.exe")
+                });
+
+                WixAssert.CompareLineByLine(new[]
+                {
+                    "The ExePackagePayload/@Description attribute can only be specified with one of the following attributes: Hash or CertificatePublicKey present.",
+                    "The ExePackagePayload/@Size attribute can only be specified with one of the following attributes: Hash or CertificatePublicKey present.",
+                    "The ExePackagePayload/@Version attribute can only be specified with one of the following attributes: Hash or CertificatePublicKey present.",
+                }, result.Messages.Select(m => m.ToString()).ToArray());
+            }
+        }
     }
 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExePackage/ExePackageWithoutSourceHashOrCertificate.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExePackage/ExePackageWithoutSourceHashOrCertificate.wxs
@@ -1,0 +1,13 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Bundle Name="BurnBundle" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="B94478B1-E1F3-4700-9CE8-6AA090854AEC">
+        <BootstrapperApplication>
+            <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+        </BootstrapperApplication>
+        
+        <Chain>
+            <ExePackage DetectCondition="DetectedTheMsu" UninstallArguments="-uninstall">
+              <ExePackagePayload Name='foo.exe' DownloadUrl='http://wixtoolset.org' Description='Some description' Size='10' Version="1.2" />
+            </ExePackage>
+        </Chain>
+    </Bundle>
+</Wix>


### PR DESCRIPTION
* Preprocessor only fails if the current document does not parse
* Improve error messages for remote payloads
* Prevent crash when Bundle has SWID Tag but child MSI does not - fixes wixtoolset/issues#6854
