### PR TITLE
Trim patch baseline identifiers when they get too long

### DIFF
--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/GetFileFacadesFromTransforms.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/GetFileFacadesFromTransforms.cs
@@ -40,10 +40,10 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             //var patchActualFileTable = this.Output.EnsureTable(this.TableDefinitions["File"]);
 
             // Index paired transforms by name without their "#" prefix.
-            var pairedTransforms = this.SubStorages.Where(s => s.Name.StartsWith("#")).ToDictionary(s => s.Name, s => s.Data);
+            var pairedTransforms = this.SubStorages.Where(s => s.Name.StartsWith(PatchConstants.PairedPatchTransformPrefix)).ToDictionary(s => s.Name, s => s.Data);
 
             // Enumerate through main transforms.
-            foreach (var substorage in this.SubStorages.Where(s => !s.Name.StartsWith("#")))
+            foreach (var substorage in this.SubStorages.Where(s => !s.Name.StartsWith(PatchConstants.PairedPatchTransformPrefix)))
             {
                 var mainTransform = substorage.Data;
                 var mainFileTable = mainTransform.Tables["File"];
@@ -54,7 +54,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 }
 
                 // Index File table of pairedTransform
-                var pairedTransform = pairedTransforms["#" + substorage.Name];
+                var pairedTransform = pairedTransforms[PatchConstants.PairedPatchTransformPrefix + substorage.Name];
                 var pairedFileRows = new RowDictionary<FileRow>(pairedTransform.Tables["File"]);
 
                 foreach (FileRow mainFileRow in mainFileTable.Rows.Where(f => f.Operation != RowOperation.Delete))

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/PatchConstants.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/PatchConstants.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core.WindowsInstaller.Bind
+{
+    internal static class PatchConstants
+    {
+        public const int MaxPatchTransformName = 31;
+
+        public static readonly string PairedPatchTransformPrefix = "#";
+    }
+}

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateTransformsWithFileFacades.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateTransformsWithFileFacades.cs
@@ -52,16 +52,16 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             var patchMediaRows = new RowDictionary<MediaRow>(this.Output.Tables["Media"]);
 
             // Index paired transforms by name without the "#" prefix.
-            var pairedTransforms = this.SubStorages.Where(s => s.Name.StartsWith("#")).ToDictionary(s => s.Name, s => s.Data);
+            var pairedTransforms = this.SubStorages.Where(s => s.Name.StartsWith(PatchConstants.PairedPatchTransformPrefix)).ToDictionary(s => s.Name, s => s.Data);
 
             // Copy File bind data into substorages
-            foreach (var substorage in this.SubStorages.Where(s => !s.Name.StartsWith("#")))
+            foreach (var substorage in this.SubStorages.Where(s => !s.Name.StartsWith(PatchConstants.PairedPatchTransformPrefix)))
             {
                 var mainTransform = substorage.Data;
 
                 var mainMsiFileHashIndex = new RowDictionary<Row>(mainTransform.Tables["MsiFileHash"]);
 
-                var pairedTransform = pairedTransforms["#" + substorage.Name];
+                var pairedTransform = pairedTransforms[PatchConstants.PairedPatchTransformPrefix + substorage.Name];
 
                 // Copy Media.LastSequence.
                 var pairedMediaTable = pairedTransform.Tables["Media"];

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
@@ -67,7 +67,6 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
 
             // create a schema msi which hopefully matches the table schemas in the transform
             var schemaOutput = new WindowsInstallerData(null);
-            var msiDatabaseFile = Path.Combine(this.IntermediateFolder, "schema.msi");
             foreach (var tableDefinition in this.TableDefinitions)
             {
                 // skip unreal tables and the Patch table
@@ -81,9 +80,10 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             Table transformViewTable;
 
             // Bind the schema msi.
+            var msiDatabaseFile = Path.Combine(this.IntermediateFolder, "schema.msi");
             this.GenerateDatabase(schemaOutput, msiDatabaseFile);
 
-            // apply the transform to the database and retrieve the modifications
+            // Apply the transform to the database and retrieve the modifications.
             using (var msiDatabase = new Database(msiDatabaseFile, OpenDatabase.Transact))
             {
                 // apply the transform with the ViewTransform option to collect all the modifications

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendWarnings.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendWarnings.cs
@@ -6,10 +6,10 @@ namespace WixToolset.Core.WindowsInstaller
 
     internal static class WindowsInstallerBackendWarnings
     {
-        //public static Message ReplaceThisWithTheFirstWarning(SourceLineNumber sourceLineNumbers)
-        //{
-        //    return Message(sourceLineNumbers, Ids.ReplaceThisWithTheFirstWarning, "format string", arg1, arg2);
-        //}
+        internal static Message LongPatchBaselineIdTrimmed(SourceLineNumber sourceLineNumbers, string baseTransformName, string trimmedTransformName)
+        {
+            return Message(sourceLineNumbers, Ids.LongPatchBaselineIdTrimmed, "The PatchBaseline/@Id='{0}' is too long. It is recommended to use short identifiers like 'RTM' and 'SP1'. The identifier has been trimmed to '{1}' so the patch can be created.", baseTransformName, trimmedTransformName);
+        }
 
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
@@ -18,7 +18,7 @@ namespace WixToolset.Core.WindowsInstaller
 
         public enum Ids
         {
-            // ReplaceThisWithTheFirstWarning = 7100,
+            LongPatchBaselineIdTrimmed = 7100,
         } // last available is 7499. 7500 is WindowsInstallerBackendErrors.
     }
 }

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -7745,10 +7745,6 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Id"));
                 id = Identifier.Invalid;
             }
-            else if (27 < id.Id.Length)
-            {
-                this.Core.Write(ErrorMessages.IdentifierTooLongError(sourceLineNumbers, node.Name.LocalName, "Id", id.Id, 27));
-            }
 
             if (!String.IsNullOrEmpty(baselineFile) || !String.IsNullOrEmpty(updateFile))
             {

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/PatchBaselineIdTooLong/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/PatchBaselineIdTooLong/Package.wxs
@@ -1,0 +1,28 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="~Test Package" Version="$(var.V)" Manufacturer="Example Corporation" Language="1033" UpgradeCode="{6B8097B9-A5D0-4BDE-B21E-AF6622DDCA01}" Scope="perMachine" ProductCode="{11111111-2222-3333-4444-555555555555}">
+    <MajorUpgrade DowngradeErrorMessage="Newer version already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <CustomAction Id="CAFromExtension" DllEntry="DoesntExist" BinaryRef="BinFromWir" />
+
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="~Test App" />
+    </StandardDirectory>
+
+    <Feature Id="Main">
+      <ComponentGroupRef Id="Components" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <ComponentGroup Id="Components" Directory="INSTALLFOLDER">
+      <Component>
+        <File Source="$(sys.SOURCEFILEPATH)" />
+      </Component>
+
+      <Component>
+        <RegistryValue Root="HKLM" Key="SOFTWARE\!(bind.property.ProductName)\Patch" Name="Version" Value="$(var.V)" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/PatchBaselineIdTooLong/Patch.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/PatchBaselineIdTooLong/Patch.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns='http://wixtoolset.org/schemas/v4/wxs'>
+    <Patch
+    AllowRemoval="yes"
+    DisplayName="~Test Patch v$(var.V)"
+    Description="~Test Small Update Patch v$(var.V)"
+    MoreInfoURL="http://www.example.com/"
+    Manufacturer="Example Corporation"
+    Classification="Update">
+
+    <Media Id="1" Cabinet="foo.cab">
+      <PatchBaseline Id="ThisBaseLineIdIsTooLongAndGetsTrimmed" BaselineFile="Baseline.wixpdb" UpdateFile="Update.wixpdb" />
+    </Media>
+
+    <PatchFamily Id='SequenceFamily' Version='$(var.V)' />
+  </Patch>
+</Wix>


### PR DESCRIPTION
The PatchBaseline/@id value is used as part of the name for the
patch transforms that get stored as substorages. Substorage name
length are very limited. Rather than error, we'll now trim the value
and let the user know via a warning.

Fixes wixtoolset/issues#4434