### PR TITLE
Pass `/xlog` to elevated engine.

### DIFF
--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -1644,6 +1644,12 @@ static HRESULT LaunchElevatedProcess(
     hr = StrAllocFormatted(&sczParameters, L"-q -%ls %ls %ls %u", BURN_COMMANDLINE_SWITCH_ELEVATED, pConnection->sczName, pConnection->sczSecret, dwCurrentProcessId);
     ExitOnFailure(hr, "Failed to allocate parameters for elevated process.");
 
+    if (BURN_LOGGING_ATTRIBUTE_EXTRADEBUG & pEngineState->internalCommand.dwLoggingAttributes)
+    {
+        hr = StrAllocConcatFormatted(&sczParameters, L" -%ls=%ls", BURN_COMMANDLINE_SWITCH_LOG_MODE, L"x");
+        ExitOnFailure(hr, "Failed to set log mode in elevated process command-line.");
+    }
+
     // Since ShellExecuteEx doesn't support passing inherited handles, don't bother with CoreAppendFileHandleSelfToCommandLine.
     // We could fallback to using ::DuplicateHandle to inject the file handle later if necessary.
     hr = ShelExec(pEngineState->sczBundleEngineWorkingPath, sczParameters, L"runas", NULL, SW_SHOWNA, hwndParent, &hProcess);


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/6534.