### PR TITLE
6848 - Handle case where bundle is already cached in package cache

### DIFF
--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -2547,6 +2547,11 @@ static HRESULT DoExecuteAction(
     } while (fRetry && *pRestart < BOOTSTRAPPER_APPLY_RESTART_INITIATED);
 
 LExit:
+    if (*pRestart < restart)
+    {
+        *pRestart = restart;
+    }
+
     return hr;
 }
 
@@ -2561,6 +2566,7 @@ static HRESULT DoRollbackActions(
     DWORD iCheckpoint = 0;
     BOOL fRetryIgnored = FALSE;
     BOOL fSuspendIgnored = FALSE;
+    BOOTSTRAPPER_APPLY_RESTART restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
 
     pContext->fRollback = TRUE;
 
@@ -2598,7 +2604,8 @@ static HRESULT DoRollbackActions(
                 continue;
             }
 
-            BOOTSTRAPPER_APPLY_RESTART restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
+            restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
+
             switch (pRollbackAction->type)
             {
             case BURN_EXECUTE_ACTION_TYPE_CHECKPOINT:
@@ -2674,6 +2681,11 @@ static HRESULT DoRollbackActions(
     }
 
 LExit:
+    if (*pRestart < restart)
+    {
+        *pRestart = restart;
+    }
+
     return hr;
 }
 
@@ -2791,6 +2803,7 @@ static HRESULT DoRestoreRelatedBundleActions(
     HRESULT hr = S_OK;
     BOOL fRetryIgnored = FALSE;
     BOOL fSuspendIgnored = FALSE;
+    BOOTSTRAPPER_APPLY_RESTART restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
 
     // execute restore related bundle actions
     for (DWORD i = 0; i < pEngineState->plan.cRestoreRelatedBundleActions; ++i)
@@ -2804,7 +2817,8 @@ static HRESULT DoRestoreRelatedBundleActions(
         pContext->wzExecutingPackageId = NULL;
         pContext->fAbandonedProcess = FALSE;
 
-        BOOTSTRAPPER_APPLY_RESTART restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
+        restart = BOOTSTRAPPER_APPLY_RESTART_NONE;
+
         switch (pRestoreRelatedBundleAction->type)
         {
         case BURN_EXECUTE_ACTION_TYPE_RELATED_BUNDLE:
@@ -2824,6 +2838,11 @@ static HRESULT DoRestoreRelatedBundleActions(
     }
 
 LExit:
+    if (*pRestart < restart)
+    {
+        *pRestart = restart;
+    }
+
     return hr;
 }
 

--- a/src/burn/engine/detect.cpp
+++ b/src/burn/engine/detect.cpp
@@ -399,18 +399,23 @@ static HRESULT DetectAtomFeedUpdate(
         {
             APPLICATION_UPDATE_ENTRY* pAppUpdateEntry = &pApupChain->rgEntries[i];
             APPLICATION_UPDATE_ENCLOSURE* pEnclosure = pAppUpdateEntry->rgEnclosures;
+            LPCWSTR wzHash = L"";
+            BOOTSTRAPPER_UPDATE_HASH_TYPE hashType = BOOTSTRAPPER_UPDATE_HASH_TYPE_NONE;
 
-            if (pEnclosure && pEnclosure->rgbDigest && *pEnclosure->rgbDigest)
+            if (pEnclosure && pEnclosure->rgbDigest && APUP_HASH_ALGORITHM_SHA512 == pEnclosure->digestAlgorithm)
             {
                 hr = StrAllocHexEncode(pEnclosure->rgbDigest, pEnclosure->cbDigest, &sczHash);
                 ExitOnFailure(hr, "Failed to encode hash as string.");
+
+                wzHash = sczHash;
+                hashType = BOOTSTRAPPER_UPDATE_HASH_TYPE_SHA512;
             }
 
             hr = UserExperienceOnDetectUpdate(pUX,
                 pEnclosure ? pEnclosure->wzUrl : NULL,
                 pEnclosure ? pEnclosure->dw64Size : 0,
-                sczHash ? sczHash : L"",
-                pEnclosure ? pEnclosure->digestAlgorithm == APUP_HASH_ALGORITHM_SHA512 ? BOOTSTRAPPER_UPDATE_HASH_TYPE_SHA512 : BOOTSTRAPPER_UPDATE_HASH_TYPE_NONE : BOOTSTRAPPER_UPDATE_HASH_TYPE_NONE,
+                wzHash,
+                hashType,
                 pAppUpdateEntry->pVersion,
                 pAppUpdateEntry->wzTitle,
                 pAppUpdateEntry->wzSummary,

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -862,6 +862,13 @@ Language=English
 Cached non-vital package: %1!ls!, encountered error: 0x%2!x!. Continuing...
 .
 
+MessageId=345
+Severity=Warning
+SymbolicName=MSG_IGNORING_CACHE_BUNDLE_FAILURE
+Language=English
+Ignoring failure to cache bundle because the file already exists, encountered error: 0x%1!x!. Continuing...
+.
+
 MessageId=346
 Severity=Warning
 SymbolicName=MSG_CACHE_RETRYING_PACKAGE

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -1006,7 +1006,7 @@ MessageId=366
 Severity=Success
 SymbolicName=MSG_EXECUTE_PACKAGE_PROCESS_EXITED
 Language=English
-The process for package: %1!ls! exited with code: %2!u!. The exit code has been translated to type: %3!hs! and restart: %4!hs!.
+The process for package: %1!ls! exited with code: 0x%2!x!. The exit code has been translated to type: %3!hs! and restart: %4!hs!.
 .
 
 MessageId=370

--- a/src/burn/engine/externalengine.cpp
+++ b/src/burn/engine/externalengine.cpp
@@ -296,7 +296,7 @@ HRESULT ExternalEngineSetUpdate(
         {
             ExitFunction1(hr = E_INVALIDARG);
         }
-        else if (BOOTSTRAPPER_UPDATE_HASH_TYPE_SHA512 == hashType && (!wzHash || !*wzHash || SHA512_HASH_LEN != lstrlenW(wzHash)))
+        else if (BOOTSTRAPPER_UPDATE_HASH_TYPE_SHA512 == hashType && (!wzHash || !*wzHash || SHA512_HASH_LEN * 2 != lstrlenW(wzHash)))
         {
             ExitFunction1(hr = E_INVALIDARG);
         }

--- a/src/burn/engine/splashscreen.cpp
+++ b/src/burn/engine/splashscreen.cpp
@@ -221,6 +221,11 @@ LExit:
         ::DeleteObject(splashScreenInfo.hBitmap);
     }
 
+    if (splashScreenInfo.hwndPrevious)
+    {
+        ::PostMessageW(splashScreenInfo.hwndPrevious, WM_CLOSE, 0, 0);
+    }
+
     return hr;
 }
 
@@ -261,6 +266,7 @@ static LRESULT CALLBACK WndProc(
         return 1;
 
     case WM_ENTERIDLE:
+    case WM_MOVING:
         lres = ::DefWindowProcW(hWnd, uMsg, wParam, lParam);
 
         // We had to create our own splash screen so that Windows would automatically transfer focus from the other process's splash screen.

--- a/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
@@ -4287,8 +4287,6 @@ static HRESULT StopBillboard(
 
     if (THEME_CONTROL_TYPE_BILLBOARD == pControl->type)
     {
-        ThemeControlEnable(pControl, FALSE);
-
         if (::KillTimer(pTheme->hwndParent, idEvent))
         {
             hr = S_OK;

--- a/src/test/burn/TestData/ExePackageTests/CustomExitCodeExePackage/CustomExitCodeExePackage.wixproj
+++ b/src/test/burn/TestData/ExePackageTests/CustomExitCodeExePackage/CustomExitCodeExePackage.wixproj
@@ -1,0 +1,17 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <OutputType>Bundle</OutputType>
+    <UpgradeCode>{9BB4F6D3-4EE3-40BF-879F-90E78440EAE8}</UpgradeCode>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Templates\Bundle.wxs" Link="Bundle.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\TestBA\TestBAWixlib\testbawixlib.wixproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Bal.wixext" />
+    <PackageReference Include="WixToolset.NetFx.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/burn/TestData/ExePackageTests/CustomExitCodeExePackage/CustomExitCodeExePackage.wxs
+++ b/src/test/burn/TestData/ExePackageTests/CustomExitCodeExePackage/CustomExitCodeExePackage.wxs
@@ -1,0 +1,34 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+  <Fragment>
+    <PackageGroup Id="BundlePackages">
+      <ExePackage Id="TestExe" Cache="remove" PerMachine="yes"
+                  DetectCondition="" Permanent="yes" InstallArguments="/ec [EXEEXITCODE]">
+        <PayloadGroupRef Id="TestExePayloads" />
+
+        <ExitCode Value="0" Behavior="error" />
+        <ExitCode Value="3" Behavior="scheduleReboot" />
+        <ExitCode Value="4" Behavior="forceReboot" />
+        <ExitCode Value="5" Behavior="errorScheduleReboot" />
+        <ExitCode Value="-2147024891" Behavior="errorScheduleReboot" />
+        <ExitCode Value="6" Behavior="errorForceReboot" />
+        <ExitCode Value="-2147024890" Behavior="errorForceReboot" />
+        <ExitCode Value="3010" Behavior="error" />
+        <ExitCode Value="-2147021886" Behavior="error" />
+        <ExitCode Value="3011" Behavior="error" />
+        <ExitCode Value="-2147021885" Behavior="error" />
+        <ExitCode Value="1641" Behavior="error" />
+        <ExitCode Value="-2147023255" Behavior="error" />
+        <ExitCode Value="3017" Behavior="error" />
+        <ExitCode Value="-2147021879" Behavior="error" />
+        <ExitCode Value="3018" Behavior="error" />
+        <ExitCode Value="-2147021878" Behavior="error" />
+        <ExitCode Value="-2147483647" Behavior="error" />
+        <ExitCode Value="-2147483648" Behavior="error" />
+        <ExitCode Behavior="success" />
+      </ExePackage>
+    </PackageGroup>
+    <Variable Name="EXEEXITCODE" bal:Overridable="yes" Value="1" />
+  </Fragment>
+</Wix>

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingTheme.xml
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingTheme.xml
@@ -132,7 +132,7 @@ There are currently four states for a button: default, focus, hover, and selecte
         </Page>
         <Page Name="Billboard">
             <Label X="6" Y="6" Width="-6" Height="43" FontId="Default">
-                This page has a billboard. It loops between two panels every 1.5 seconds.
+                This page has a billboard. It loops between two panels every 1.5 seconds. Press Back to go to another page, and then come back and make sure it still loops.
             </Label>
             <Billboard Name="FirstBillboard" X="11" Y="59" Width="-11" Height="-39" Interval="1500" Loop="yes">
                 <Panel>

--- a/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingThemeLoose.xml
+++ b/src/test/burn/TestData/Manual/BafThmutilTesting/theme/BafThmUtilTestingThemeLoose.xml
@@ -132,7 +132,7 @@ There are currently four states for a button: default, focus, hover, and selecte
         </Page>
         <Page Name="Billboard">
             <Label X="6" Y="6" Width="-6" Height="43" FontId="Default">
-                This page has a billboard. It loops between two panels every 1.5 seconds.
+                This page has a billboard. It loops between two panels every 1.5 seconds. Press Back to go to another page, and then come back and make sure it still loops.
             </Label>
             <Billboard Name="FirstBillboard" X="11" Y="59" Width="-11" Height="-39" Interval="1500" Loop="yes">
                 <Panel>

--- a/src/test/burn/TestData/Manual/BundleA/ManualTests.txt
+++ b/src/test/burn/TestData/Manual/BundleA/ManualTests.txt
@@ -152,3 +152,13 @@ CanRestartFromUnelevatedPerUserBundleWithShutdownPrivilege
 =======================================
 
 (10. Uninstall the bundle)
+
+CanShowSplashScreenQuicklyAndCacheThousandsOfFilesInLinearTime
+
+1. Run BundleB.exe.
+2. The splash screen should come up immediately (less than 1 second).
+3. After the wixstdba UI comes up, make sure the splash screen was closed (it might be hiding underneath windows).
+4. Click Install (accept elevation).
+5. This bundle contains 10000 loose files which needs to be cached, which used to take over 30 minutes. The exact timing can be different on different machines, but it should be closer to 30 seconds.
+6. Click Close.
+(7. Uninstall the bundle)

--- a/src/test/burn/TestData/UpdateBundleTests/BundleBv1/FeedBv2.0_wronghash.xml
+++ b/src/test/burn/TestData/UpdateBundleTests/BundleBv1/FeedBv2.0_wronghash.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:as="http://appsyndication.org/2006/appsyn">
+  <title type="text">BundleB v2.0</title>
+  <subtitle type="text">Bundle Subtitle.</subtitle>
+  <as:application type="application/exe">1116353B-7C6E-4C29-BFA1-D4A972CD421D</as:application>
+  <updated>2014-07-14T12:39:00.000Z</updated>
+  <id>http://localhost:9999/e2e/BundleB/feed</id>
+  <link rel="self" type="application/atom+xml" href="http://localhost:9999/e2e/BundleB/feed"/>
+  <generator version="0.1">manual build</generator>
+  <entry>
+    <title>Bundle v2.0</title>
+    <id>v2.0</id>
+    <author>
+      <name>Bundle_Author</name>
+      <uri>http://mycompany.com/software</uri>
+      <email>Bundle_Author@mycompany.com</email>
+    </author>
+    <link rel="alternate" href="http://www.mycompany.com/content/view/software"/>
+    <link rel="enclosure" href="http://localhost:9999/e2e/BundleB/2.0/BundleB.exe" length="0" type="application/octet-stream">
+      <as:name>this hash is supposed to be wrong but has a tiny chance of actually being right</as:name>
+      <as:digest algorithm="sha512">00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</as:digest>
+    </link>
+    <content type="html">
+      &lt;p&gt;Change list:&lt;/p&gt;&lt;ul&gt;
+      &lt;li&gt;Updated release.&lt;/li&gt;
+      &lt;/ul&gt;
+    </content>
+    <as:upgrade version="1.0" />
+    <as:version>2.0.0.0</as:version>
+    <updated>2014-11-10T12:39:00.000Z</updated>
+  </entry>
+  <entry>
+    <title>Bundle v1.0</title>
+    <id>v1.0</id>
+    <author>
+      <name>Bundle_Author</name>
+      <uri>http://mycompany.com/software</uri>
+      <email>Bundle_Author@mycompany.com</email>
+    </author>
+    <link rel="alternate" href="http://www.mycompany.com/content/view/software"/>
+    <link rel="enclosure" href="http://localhost:9999/e2e/BundleB/1.0/BundleB.exe" length="0" type="application/octet-stream"/>
+    <content type="html">
+      &lt;p&gt;Change list:&lt;/p&gt;&lt;ul&gt;
+      &lt;li&gt;Initial release.&lt;/li&gt;
+      &lt;/ul&gt;
+    </content>
+    <as:upgrade version="1.0.0.0-preview" />
+    <as:version>1.0.0.0</as:version>
+    <updated>2014-11-09T12:39:00.000Z</updated>
+  </entry>  
+</feed>

--- a/src/test/burn/WixTestTools/MSIExec.cs
+++ b/src/test/burn/WixTestTools/MSIExec.cs
@@ -666,7 +666,13 @@ namespace WixTestTools
             /// A restart is required to complete the install. This message is indicative of a success. 
             /// This does not include installs where the ForceReboot action is run. 
             /// </summary> 
-            ERROR_SUCCESS_REBOOT_REQUIRED = 3010
+            ERROR_SUCCESS_REBOOT_REQUIRED = 3010,
+
+            /// <summary>
+            /// ERROR_SUCCESS_REBOOT_REQUIRED           3017
+            /// The requested operation failed. A system reboot is required to roll back changes made.
+            /// </summary>
+            ERROR_FAIL_REBOOT_REQUIRED = 3017,
         }
 
         /// <summary>

--- a/src/test/burn/WixToolsetTest.BurnE2E/ExePackageTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/ExePackageTests.cs
@@ -143,6 +143,32 @@ namespace WixToolsetTest.BurnE2E
         }
 
         [RuntimeFact]
+        public void CanUseLargeCustomExitCode()
+        {
+            var customExitCodeExePackageBundle = this.CreateBundleInstaller(@"CustomExitCodeExePackage");
+
+            var installLogPath = customExitCodeExePackageBundle.Install(5, "EXEEXITCODE=-2147024891");
+            customExitCodeExePackageBundle.VerifyUnregisteredAndRemovedFromPackageCache();
+
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "TestExe.exe\" /ec -2147024891"));
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "The process for package: TestExe exited with code: 0x80070005. The exit code has been translated to type: ErrorScheduleReboot and restart: Required."));
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "Applied execute package: TestExe, result: 0x80070005, restart: Required"));
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "Apply complete, result: 0x80070005, restart: Required, ba requested restart:  No"));
+        }
+
+        [RuntimeFact]
+        public void CanUseWildcardCustomExitCode()
+        {
+            var customExitCodeExePackageBundle = this.CreateBundleInstaller(@"CustomExitCodeExePackage");
+
+            var installLogPath = customExitCodeExePackageBundle.Install((int)MSIExec.MSIExecReturnCode.SUCCESS, "EXEEXITCODE=1");
+            customExitCodeExePackageBundle.VerifyUnregisteredAndRemovedFromPackageCache();
+
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "TestExe.exe\" /ec 1"));
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, "The process for package: TestExe exited with code: 0x1. The exit code has been translated to type: Success and restart: None."));
+        }
+
+        [RuntimeFact]
         public void CanInstallAndUninstallPerUserArpEntryExePackage()
         {
             var perUserArpEntryExePackageBundle = this.CreateBundleInstaller(@"PerUserArpEntryExePackage");


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/6848.

Add more burn E2E tests.

Fix bug where first splash screen wasn't closed.
Fix bug where billboard only started the first time.
Fix bug where the restart status was lost when the exit code was an error.
Fix bug where the hash byte array length was compared to the hash string length (string is twice as long).
Fix bug where Burn didn't give update hash if the first byte was 0.