### PR TITLE
Fix a family of bugs related to, and including,  issue6847

### DIFF
--- a/src/wix/WixToolset.Converters/ConversionLab.cs
+++ b/src/wix/WixToolset.Converters/ConversionLab.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    internal class ConversionLab : IDisposable
+    {
+        private readonly XElement targetElement;
+        private readonly XElement parentElement;
+        private readonly List<XNode> siblingNodes;
+        private int index;
+
+        public ConversionLab(XElement targetElement)
+        {
+            this.targetElement = targetElement;
+            this.parentElement = this.targetElement.Parent;
+            this.siblingNodes = this.parentElement.Nodes().ToList();
+            foreach (var siblingNode in this.siblingNodes)
+            {
+                siblingNode.Remove();
+            }
+            this.index = this.siblingNodes.IndexOf(this.targetElement);
+        }
+
+        public void RemoveOrphanTextNodes()
+        {
+            if (!this.targetElement.HasElements)
+            {
+                var childNodes = this.targetElement.Nodes().ToList();
+                foreach (var childNode in childNodes)
+                {
+                    childNode.Remove();
+                }
+            }
+        }
+
+        public void RemoveTargetElement()
+        {
+            if (this.index + 1 < this.siblingNodes.Count
+             && this.siblingNodes[this.index + 1] is XText trailingText
+             && String.IsNullOrWhiteSpace(trailingText.Value))
+            {
+                this.siblingNodes.RemoveAt(this.index + 1);
+            }
+            this.siblingNodes.RemoveAt(this.index);
+            if (0 < this.index
+             && this.siblingNodes[this.index - 1] is XText leadingText
+             && String.IsNullOrWhiteSpace(leadingText.Value))
+            {
+                this.siblingNodes.RemoveAt(this.index - 1);
+            }
+        }
+
+        public void ReplaceTargetElement(XElement replacement)
+        {
+            this.siblingNodes[this.index] = replacement;
+        }
+
+        public void AddCommentsAsSiblings(IEnumerable<XNode> comments)
+        {
+            string leadingWhitespace = null;
+            if (0 < this.index
+             && this.siblingNodes[this.index - 1] is XText leadingText
+             && String.IsNullOrWhiteSpace(leadingText.Value))
+            {
+                leadingWhitespace = leadingText.Value;
+            }
+
+            foreach (var comment in comments)
+            {
+                if (null != leadingWhitespace)
+                {
+                    this.siblingNodes.Insert(++this.index, new XText(leadingWhitespace));
+                }
+                this.siblingNodes.Insert(++this.index, comment);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.parentElement.Add(this.siblingNodes);
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
@@ -78,6 +78,8 @@ namespace WixToolsetTest.Converters
                 "  <Fragment>",
                 "    <UI>",
                 "      <Dialog Id=\"Dlg1\">",
+                "        <!-- Comment 1 -->",
+                "        <!-- Comment 2 -->",
                 "        <Control Id=\"Control1\" DisableCondition=\"x=y\" HideCondition=\"a&lt;&gt;b\" />",
                 "      </Dialog>",
                 "    </UI>",
@@ -167,10 +169,10 @@ namespace WixToolsetTest.Converters
                 "    <UI>",
                 "      <Dialog Id=\"Dlg1\">",
                 "        <Control Id=\"Control1\">",
-                "          <Publish Value=\"abc\" Condition=\"1&lt;2\" />",
                 "          <!-- Comment 1 -->",
-                "          <Publish Value=\"gone\" />",
+                "          <Publish Value=\"abc\" Condition=\"1&lt;2\" />",
                 "          <!-- Comment 2 -->",
+                "          <Publish Value=\"gone\" />",
                 "        </Control>",
                 "      </Dialog>",
                 "    </UI>",
@@ -241,8 +243,8 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
-                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\" Condition=\"1&lt;2\" />",
                 "    <!-- Comment -->",
+                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\" Condition=\"1&lt;2\" />",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -311,8 +313,8 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
-                "    <Launch Condition=\"cdatacontent\" Message=\"commented cdata\" />",
                 "    <!-- commented conditional -->",
+                "    <Launch Condition=\"cdatacontent\" Message=\"commented cdata\" />",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -419,8 +421,8 @@ namespace WixToolsetTest.Converters
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
                 "    <Feature Id=\"Feature1\">",
-                "      <Level Value=\"0\" Condition=\"PROP = 1\" />",
                 "      <!-- Comment -->",
+                "      <Level Value=\"0\" Condition=\"PROP = 1\" />",
                 "    </Feature>",
                 "  </Fragment>",
                 "</Wix>"
@@ -496,10 +498,10 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
-                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <!-- Comment 1 -->",
-                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
+                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <!-- Comment 2 -->",
+                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -578,10 +580,10 @@ namespace WixToolsetTest.Converters
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Package Compressed=\"no\">",
                 "  ",
-                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <!-- Comment 1 -->",
-                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
+                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <!-- Comment 2 -->",
+                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
                 "  </Package>",
                 "</Wix>"
             };
@@ -658,8 +660,8 @@ namespace WixToolsetTest.Converters
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
                 "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\">",
-                "      <PermissionEx Sddl=\"sddl\" Condition=\"1&lt;2\" />",
                 "      <!-- Comment 2 -->",
+                "      <PermissionEx Sddl=\"sddl\" Condition=\"1&lt;2\" />",
                 "    </Component>",
                 "  </Fragment>",
                 "</Wix>"

--- a/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
@@ -35,10 +35,50 @@ namespace WixToolsetTest.Converters
                 "  <Fragment>",
                 "    <UI>",
                 "      <Dialog Id=\"Dlg1\">",
-                "        <Control Id=\"Control1\" DisableCondition=\"x=y\" HideCondition=\"a&lt;&gt;b\">",
-                "          ",
-                "          ",
+                "        <Control Id=\"Control1\" DisableCondition=\"x=y\" HideCondition=\"a&lt;&gt;b\" />",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(4, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixControlConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id='Dlg1'>",
+                "        <Control Id='Control1'>",
+                "          <Condition Action='disable'><!-- Comment 1 -->x=y</Condition>",
+                "          <Condition Action='hide'><!-- Comment 2 -->a&lt;>b</Condition>",
                 "        </Control>",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id=\"Dlg1\">",
+                "        <Control Id=\"Control1\" DisableCondition=\"x=y\" HideCondition=\"a&lt;&gt;b\" />",
                 "      </Dialog>",
                 "    </UI>",
                 "  </Fragment>",
@@ -102,6 +142,53 @@ namespace WixToolsetTest.Converters
             var actualLines = UnformattedDocumentLines(document);
             WixAssert.CompareLineByLine(expected, actualLines);
         }
+        [Fact]
+        public void FixPublishConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id='Dlg1'>",
+                "        <Control Id='Control1'>",
+                "          <Publish Value='abc'><!-- Comment 1 -->1&lt;2</Publish>",
+                "          <Publish Value='gone'><!-- Comment 2 -->1</Publish>",
+                "        </Control>",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id=\"Dlg1\">",
+                "        <Control Id=\"Control1\">",
+                "          <Publish Value=\"abc\" Condition=\"1&lt;2\" />",
+                "          <!-- Comment 1 -->",
+                "          <Publish Value=\"gone\" />",
+                "          <!-- Comment 2 -->",
+                "        </Control>",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(5, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
 
         [Fact]
         public void FixComponentCondition()
@@ -120,9 +207,42 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
-                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\" Condition=\"1&lt;2\">",
-                "      ",
+                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\" Condition=\"1&lt;2\" />",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixComponentConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <Component Id='Comp1' Directory='ApplicationFolder'>",
+                "      <Condition><!-- Comment -->1&lt;2</Condition>",
                 "    </Component>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\" Condition=\"1&lt;2\" />",
+                "    <!-- Comment -->",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -175,27 +295,24 @@ namespace WixToolsetTest.Converters
             Assert.Equal(4, errors);
         }
 
-        [Fact(Skip = "Test demonstrates failure")]
+        [Fact]
         public void FixConditionWithComment()
         {
             var parse = String.Join(Environment.NewLine,
                 "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
                 "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
                 "  <Fragment>",
-                "    <Condition Message='commented cdata'>",
-                "        <!-- commented condition -->",
-                "        <![CDATA[cdatacontent]]>",
-                "    </Condition>",
+                "    <Condition Message='commented cdata'><!-- commented conditional -->",
+                "<![CDATA[cdatacontent]]></Condition>",
                 "  </Fragment>",
                 "</Wix>");
 
-            //TODO: expected value is not set in stone but must have replaced Condition element with Launch and should have kept the comment.
             var expected = new[]
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
                 "    <Launch Condition=\"cdatacontent\" Message=\"commented cdata\" />",
-                "        <!-- commented condition -->",
+                "    <!-- commented conditional -->",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -210,7 +327,7 @@ namespace WixToolsetTest.Converters
             var actualLines = UnformattedDocumentLines(document);
             WixAssert.CompareLineByLine(expected, actualLines);
 
-            Assert.Equal(2, errors);
+            Assert.Equal(3, errors);
         }
 
         [Fact]
@@ -285,6 +402,43 @@ namespace WixToolsetTest.Converters
         }
 
         [Fact]
+        public void FixFeatureConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <Feature Id='Feature1'>",
+                "      <Condition Level='0'><!-- Comment -->PROP = 1</Condition>",
+                "    </Feature>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <Feature Id=\"Feature1\">",
+                "      <Level Value=\"0\" Condition=\"PROP = 1\" />",
+                "      <!-- Comment -->",
+                "    </Feature>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
         public void FixLaunchCondition()
         {
             var parse = String.Join(Environment.NewLine,
@@ -306,6 +460,46 @@ namespace WixToolsetTest.Converters
                 "  <Fragment>",
                 "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(4, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixLaunchConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <Condition Message='Stop the install'>",
+                "      <!-- Comment 1 -->1&lt;2",
+                "    </Condition>",
+                "    <Condition Message='Do not stop'>",
+                "      <!-- Comment 2 -->1=2",
+                "    </Condition>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
+                "    <!-- Comment 1 -->",
+                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
+                "    <!-- Comment 2 -->",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -363,6 +557,48 @@ namespace WixToolsetTest.Converters
         }
 
         [Fact]
+        public void FixLaunchConditionInProductWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Product>",
+                "  <Package />",
+                "    <Condition Message='Stop the install'>",
+                "      <!-- Comment 1 -->1&lt;2",
+                "    </Condition>",
+                "    <Condition Message='Do not stop'>",
+                "      <!-- Comment 2 -->1=2",
+                "    </Condition>",
+                "  </Product>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Package Compressed=\"no\">",
+                "  ",
+                "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
+                "    <!-- Comment 1 -->",
+                "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
+                "    <!-- Comment 2 -->",
+                "  </Package>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(6, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
         public void FixPermissionExCondition()
         {
             var parse = String.Join(Environment.NewLine,
@@ -383,9 +619,47 @@ namespace WixToolsetTest.Converters
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Fragment>",
                 "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\">",
-                "      <PermissionEx Sddl=\"sddl\" Condition=\"1&lt;2\">",
-                "        ",
+                "      <PermissionEx Sddl=\"sddl\" Condition=\"1&lt;2\" />",
+                "    </Component>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixPermissionExConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<!-- Comment 1 -->",
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <Component Id='Comp1' Guid='*' Directory='ApplicationFolder'>",
+                "      <PermissionEx Sddl='sddl'>",
+                "        <Condition><!-- Comment 2 -->1&lt;2</Condition>",
                 "      </PermissionEx>",
+                "    </Component>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<!-- Comment 1 -->",
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <Component Id=\"Comp1\" Directory=\"ApplicationFolder\">",
+                "      <PermissionEx Sddl=\"sddl\" Condition=\"1&lt;2\" />",
+                "      <!-- Comment 2 -->",
                 "    </Component>",
                 "  </Fragment>",
                 "</Wix>"

--- a/src/wix/test/WixToolsetTest.Converters/UtilExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/UtilExtensionFixture.cs
@@ -45,6 +45,40 @@ namespace WixToolsetTest.Converters
         }
 
         [Fact]
+        public void FixCloseAppsConditionWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util='http://schemas.microsoft.com/wix/UtilExtension'>",
+                "  <Fragment>",
+                "    <util:CloseApplication Id='EndApp' Target='example.exe'>",
+                "      <!-- Comment -->a&lt;>b",
+                "    </util:CloseApplication>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:util=\"http://wixtoolset.org/schemas/v4/wxs/util\">",
+                "  <Fragment>",
+                "    <util:CloseApplication Id=\"EndApp\" Target=\"example.exe\" Condition=\"a&lt;&gt;b\" />",
+                "    <!-- Comment -->",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
         public void FixXmlConfigValue()
         {
             var parse = String.Join(Environment.NewLine,
@@ -61,6 +95,40 @@ namespace WixToolsetTest.Converters
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:util=\"http://wixtoolset.org/schemas/v4/wxs/util\">",
                 "  <Fragment>",
                 "    <util:XmlConfig Id=\"Change\" ElementPath=\"book\" Value=\"a&lt;&gt;b\" />",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixXmlConfigValueWithComment()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util='http://schemas.microsoft.com/wix/UtilExtension'>",
+                "  <Fragment>",
+                "    <util:XmlConfig Id='Change' ElementPath='book'>",
+                "      <!-- Comment -->a&lt;>b",
+                "    </util:XmlConfig>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:util=\"http://wixtoolset.org/schemas/v4/wxs/util\">",
+                "  <Fragment>",
+                "    <util:XmlConfig Id=\"Change\" ElementPath=\"book\" Value=\"a&lt;&gt;b\" />",
+                "    <!-- Comment -->",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -111,7 +179,6 @@ namespace WixToolsetTest.Converters
             var actualLines = UnformattedDocumentLines(document);
             WixAssert.CompareLineByLine(expected, actualLines);
         }
-
 
         [Fact]
         public void FixXmlConfigValueCData()

--- a/src/wix/test/WixToolsetTest.Converters/UtilExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/UtilExtensionFixture.cs
@@ -60,8 +60,8 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:util=\"http://wixtoolset.org/schemas/v4/wxs/util\">",
                 "  <Fragment>",
-                "    <util:CloseApplication Id=\"EndApp\" Target=\"example.exe\" Condition=\"a&lt;&gt;b\" />",
                 "    <!-- Comment -->",
+                "    <util:CloseApplication Id=\"EndApp\" Target=\"example.exe\" Condition=\"a&lt;&gt;b\" />",
                 "  </Fragment>",
                 "</Wix>"
             };
@@ -127,8 +127,8 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:util=\"http://wixtoolset.org/schemas/v4/wxs/util\">",
                 "  <Fragment>",
-                "    <util:XmlConfig Id=\"Change\" ElementPath=\"book\" Value=\"a&lt;&gt;b\" />",
                 "    <!-- Comment -->",
+                "    <util:XmlConfig Id=\"Change\" ElementPath=\"book\" Value=\"a&lt;&gt;b\" />",
                 "  </Fragment>",
                 "</Wix>"
             };


### PR DESCRIPTION
An arbitrary number of comments may be embedded anywhere in inner text.

This pull request attempts to address most, if not all, issues related such
comments when they occur in deprecated contexts. Leading whitespace
has been handled with considerable care. Closing tags associated with
empty elements resulting from their transformation are removed and
absorbed into their corresponding opening tags.

A significant number of test cases has been added to the test suite.