### PR TITLE
Move WixVersion to a new WixToolset.Versioning

### DIFF
--- a/src/Directory.vcxproj.props
+++ b/src/Directory.vcxproj.props
@@ -19,6 +19,9 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <NuGetTargetMoniker>native,Version=v0.0</NuGetTargetMoniker>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(CLRSupport)'=='true' ">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CustomizedNativeRecommendedRules.ruleset</CodeAnalysisRuleSet>

--- a/src/api/api.cmd
+++ b/src/api/api.cmd
@@ -41,6 +41,10 @@ dotnet test wix\api_wix.sln -c %_C% --nologo --no-build -l "trx;LogFileName=%_L%
 @del "..\..\build\artifacts\WixToolset.Data.*.nupkg" 2> nul
 @del "..\..\build\artifacts\WixToolset.Extensibility.*.nupkg" 2> nul
 @del "..\..\build\artifacts\WixToolset.Mba.Core.*.nupkg" 2> nul
+@del "%_L%\TestResults\WixToolsetTest.Mba.Core.trx" 2> nul
+@del "%_L%\TestResults\BalUtilUnitTest.trx" 2> nul
+@del "%_L%\TestResults\BextUtilUnitTest.trx" 2> nul
+@del "%_L%\TestResults\api_wix.trx" 2> nul
 @rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.balutil" 2> nul
 @rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.bextutil" 2> nul
 @rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.bootstrappercore.native" 2> nul

--- a/src/api/api.sln
+++ b/src/api/api.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Data", "wix\WixToolset.Data\WixToolset.Data.csproj", "{6B7C6F7F-4E0F-47D4-8E1E-A3A2E7C7AC60}"
 EndProject

--- a/src/api/wix/api_wix.sln
+++ b/src/api/wix/api_wix.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Data", "WixToolset.Data\WixToolset.Data.csproj", "{73ADBD3A-8FB2-47DB-BC79-9BC61C40F2E0}"
 EndProject

--- a/src/api/wix/api_wix_t.proj
+++ b/src/api/wix/api_wix_t.proj
@@ -1,12 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <!-- Build -->
-    <ProjectReference Include="WixToolset.Data\WixToolset.Data.csproj" />
-    <ProjectReference Include="WixToolset.Extensibility\WixToolset.Extensibility.csproj" />
-    <ProjectReference Include="test\WixToolsetTest.Data\WixToolsetTest.Data.csproj" />
-
-    <!-- Pack -->
     <ProjectReference Include="WixToolset.Data\WixToolset.Data.csproj" Targets="Pack" />
     <ProjectReference Include="WixToolset.Extensibility\WixToolset.Extensibility.csproj" Targets="Pack" />
+    <ProjectReference Include="test\WixToolsetTest.Data\WixToolsetTest.Data.csproj" />
   </ItemGroup>
 </Project>

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -19,6 +19,7 @@
 
     <PackageVersion Include="WixToolset.Data" Version="{packageversion}" />
     <PackageVersion Include="WixToolset.Extensibility" Version="{packageversion}" />
+    <PackageVersion Include="WixToolset.Versioning" Version="{packageversion}" />
 
     <PackageVersion Include="WixToolset.Burn" Version="{packageversion}" />
     <PackageVersion Include="WixToolset.Dnc.HostGenerator" Version="{packageversion}" />

--- a/src/libs/WixToolset.Versioning/WixToolset.Versioning.csproj
+++ b/src/libs/WixToolset.Versioning/WixToolset.Versioning.csproj
@@ -5,25 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(Configuration)'=='Release' ">$(TargetFrameworks);net472</TargetFrameworks>
-    <Description>Core Windows Installer</Description>
-    <Title>WiX Toolset Core Windows Installer</Title>
+    <LangVersion>7.3</LangVersion>
+    <Description>WiX Toolset Versioning</Description>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\WixToolset.Core.Native\WixToolset.Core.Native.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="WixToolset.Data" />
-    <PackageReference Include="WixToolset.Extensibility" />
-    <PackageReference Include="WixToolset.Versioning" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" />
-    <PackageReference Include="System.Text.Encoding.CodePages" />
-  </ItemGroup>
 </Project>

--- a/src/libs/WixToolset.Versioning/WixVersion.cs
+++ b/src/libs/WixToolset.Versioning/WixVersion.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
-namespace WixToolset.Data
+namespace WixToolset.Versioning
 {
     using System;
     using System.Collections.Generic;
@@ -11,13 +11,12 @@ namespace WixToolset.Data
     /// large numbers and semantic versions with 4-part versions with
     /// or without leading "v" indicators.
     /// </summary>
-    [CLSCompliant(false)]
-    public class WixVersion
+    public class WixVersion : IComparable, IComparable<WixVersion>, IEquatable<WixVersion>
     {
         /// <summary>
         /// Gets the prefix of the version if present when parsed. Usually, 'v' or 'V'.
         /// </summary>
-        public char? Prefix { get; set; } 
+        public char? Prefix { get; set; }
 
         /// <summary>
         /// Gets or sets the major version.
@@ -73,6 +72,63 @@ namespace WixToolset.Data
         /// Gets or sets the metadata in the version.
         /// </summary>
         public string Metadata { get; set; }
+
+        /// <summary>
+        /// Compare to another WixVersion.
+        /// </summary>
+        /// <param name="version">WixVersion to compare.</param>
+        /// <returns>A comparison between versions.</returns>
+        public int CompareTo(WixVersion version)
+        {
+            return WixVersionComparer.Default.Compare(this, version);
+        }
+
+        /// <summary>
+        /// Compare to another object.
+        /// </summary>
+        /// <param name="version">Object to compare.</param>
+        /// <returns>A comparison between objects.</returns>
+        public int CompareTo(object version)
+        {
+            return WixVersionComparer.Default.Compare(this, version as WixVersion);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the current System.Version object is equal to a specified object.
+        /// </summary>
+        /// <param name="version">An WixVersion to compare with the current WixVersion object, or null.</param>
+        /// <returns>
+        /// true if the current WixVersion object and obj are both WixVersion objects,
+        /// and every component of the current System.Version object matches the corresponding
+        /// component of obj; otherwise, false.
+        /// </returns>
+        public bool Equals(WixVersion version)
+        {
+            return WixVersionComparer.Default.Equals(this, version);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the current WixVersion object is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare with the current WixVersion object, or null.</param>
+        /// <returns>
+        /// true if the current WixVersion object and obj are both WixVersion objects,
+        /// and every component of the current System.Version object matches the corresponding
+        /// component of obj; otherwise, false.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            return WixVersionComparer.Default.Equals(this, obj as WixVersion);
+        }
+
+        /// <summary>
+        /// Returns a hash code for the current WixVersion object.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return WixVersionComparer.Default.GetHashCode(this);
+        }
 
         /// <summary>
         /// Parse a string value into a <c>WixVersion</c>. The returned version may be invalid.
@@ -330,6 +386,78 @@ namespace WixToolset.Data
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether two specified WixVersion objects are equal.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 equals v2; otherwise, false.</returns>
+        public static bool operator ==(WixVersion v1, WixVersion v2)
+        {
+            return WixVersionComparer.Default.Equals(v1, v2);
+        }
+
+        /// <summary>
+        /// Determines whether two specified System.Version objects are not equal.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 does not equal v2; otherwise, false.</returns>
+        public static bool operator !=(WixVersion v1, WixVersion v2)
+        {
+            return !WixVersionComparer.Default.Equals(v1, v2);
+        }
+
+        /// <summary>
+        /// Determines whether the first specified System.Version object is less than the second specified System.Version object.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 is less than v2; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">v1 is null.</exception>
+        public static bool operator <(WixVersion v1, WixVersion v2)
+        {
+            return WixVersionComparer.Default.Compare(v1, v2) == -1;
+        }
+
+        /// <summary>
+        /// Determines whether the first specified System.Version object is greater than the second specified System.Version object.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 is greater than v2; otherwise, false.</returns>
+        public static bool operator >(WixVersion v1, WixVersion v2)
+        {
+            return WixVersionComparer.Default.Compare(v1, v2) == 1;
+        }
+
+        /// <summary>
+        /// Determines whether the first specified System.Version object is less than or equal to the second System.Version object.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 is less than or equal to v2; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">v1 is null.</exception>
+        public static bool operator <=(WixVersion v1, WixVersion v2)
+        {
+            var result = WixVersionComparer.Default.Compare(v1, v2);
+
+            return result == 0 || result == -1;
+        }
+
+        /// <summary>
+        /// Determines whether the first specified System.Version object is greater than or equal to the second specified System.Version object.
+        /// </summary>
+        /// <param name="v1">The first WixVersion object.</param>
+        /// <param name="v2">The second WixVersion object.</param>
+        /// <returns>true if v1 is greater than or equal to v2; otherwise, false.</returns>
+        public static bool operator >=(WixVersion v1, WixVersion v2)
+        {
+            var result = WixVersionComparer.Default.Compare(v1, v2);
+
+            return result == 0 || result == 1;
         }
     }
 }

--- a/src/libs/WixToolset.Versioning/WixVersionComparer.cs
+++ b/src/libs/WixToolset.Versioning/WixVersionComparer.cs
@@ -1,0 +1,253 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Versioning
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// WixVersion comparer.
+    /// </summary>
+    public class WixVersionComparer : IEqualityComparer<WixVersion>, IComparer<WixVersion>
+    {
+        /// <summary>
+        /// Default WixVersion comparer.
+        /// </summary>
+        public static readonly WixVersionComparer Default = new WixVersionComparer();
+
+        /// <inheritdoc />
+        public int Compare(WixVersion x, WixVersion y)
+        {
+            if ((object)x == y)
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            var result = x.Major.CompareTo(y.Major);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = x.Minor.CompareTo(y.Minor);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = x.Patch.CompareTo(y.Patch);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = x.Revision.CompareTo(y.Revision);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            var xLabelCount = x.Labels?.Length ?? 0;
+            var yLabelCount = y.Labels?.Length ?? 0;
+            var maxLabelCount = Math.Max(xLabelCount, yLabelCount);
+
+            if (xLabelCount > 0)
+            {
+                if (yLabelCount == 0)
+                {
+                    return -1;
+                }
+            }
+            else if (yLabelCount > 0)
+            {
+                return 1;
+            }
+
+            for (var i = 0; i < maxLabelCount; ++i)
+            {
+                var xLabel = i < xLabelCount ? x.Labels[i] : null;
+                var yLabel = i < yLabelCount ? y.Labels[i] : null;
+
+                result = CompareReleaseLabel(xLabel, yLabel);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            var compareMetadata = false;
+
+            if (x.Invalid)
+            {
+                if (!y.Invalid)
+                {
+                    return -1;
+                }
+                else
+                {
+                    compareMetadata = true;
+                }
+            }
+            else if (y.Invalid)
+            {
+                return 1;
+            }
+
+            if (compareMetadata)
+            {
+                result = String.Compare(x.Metadata, y.Metadata, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return (result == 0) ? 0 : (result < 0) ? -1 : 1;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(WixVersion x, WixVersion y)
+        {
+            if ((object)x == y)
+            {
+                return true;
+            }
+
+            if (x is null)
+            {
+                return false;
+            }
+
+            if (y is null)
+            {
+                return false;
+            }
+
+            if (x.Major != y.Major)
+            {
+                return false;
+            }
+
+            if (x.Minor != y.Minor)
+            {
+                return false;
+            }
+
+            if (x.Patch != y.Patch)
+            {
+                return false;
+            }
+
+            if (x.Revision != y.Revision)
+            {
+                return false;
+            }
+
+            var labelCount = x.Labels?.Length ?? 0;
+            if (labelCount != (y.Labels?.Length ?? 0))
+            {
+                return false;
+            }
+
+            for (var i = 0; i < labelCount; ++i)
+            {
+                var result = CompareReleaseLabel(x.Labels[i], y.Labels[i]);
+                if (result != 0)
+                {
+                    return false;
+                }
+            }
+
+            if (x.Invalid)
+            {
+                if (y.Invalid)
+                {
+                    return String.Equals(x.Metadata, y.Metadata, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (y.Invalid)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(WixVersion version)
+        {
+            var hash = 23L;
+            hash = hash * 37 + (version.Prefix ?? '\0');
+            hash = hash * 37 + version.Major;
+            hash = hash * 37 + version.Minor;
+            hash = hash * 37 + version.Patch;
+            hash = hash * 37 + version.Revision;
+            hash = hash * 37 + (version.Invalid ? 1 : 0);
+            hash = hash * 37 + (version.HasMajor ? 1 : 0);
+            hash = hash * 37 + (version.HasMinor ? 1 : 0);
+            hash = hash * 37 + (version.HasPatch ? 1 : 0);
+            hash = hash * 37 + (version.HasRevision ? 1 : 0);
+
+            if (version.Labels != null)
+            {
+                foreach (var label in version.Labels)
+                {
+                    hash = hash * 37 + label.Label.GetHashCode();
+                }
+            }
+
+            hash = hash * 37 + version.Metadata?.GetHashCode() ?? 0;
+
+            return unchecked((int)hash);
+        }
+
+        private static int CompareReleaseLabel(WixVersionLabel l1, WixVersionLabel l2)
+        {
+            if (l1 == l2)
+            {
+                return 0;
+            }
+            else if (l2 == null)
+            {
+                return 1;
+            }
+            else if (l1 == null)
+            {
+                return -1;
+            }
+
+            if (l1.Numeric.HasValue)
+            {
+                if (l2.Numeric.HasValue)
+                {
+                    return l1.Numeric.Value.CompareTo(l2.Numeric.Value);
+                }
+                else
+                {
+                    return -1;
+                }
+            }
+            else
+            {
+                if (l2.Numeric.HasValue)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return String.Compare(l1.Label, l2.Label, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+        }
+    }
+}

--- a/src/libs/WixToolset.Versioning/WixVersionLabel.cs
+++ b/src/libs/WixToolset.Versioning/WixVersionLabel.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Versioning
+{
+    /// <summary>
+    /// Label in a <c>WixVersion</c>.
+    /// </summary>
+    public class WixVersionLabel
+    {
+        /// <summary>
+        /// Creates a string only version label.
+        /// </summary>
+        /// <param name="label">String value for version label.</param>
+        public WixVersionLabel(string label)
+        {
+            this.Label = label;
+        }
+
+        /// <summary>
+        /// Creates a string version label with numeric value.
+        /// </summary>
+        /// <param name="label">String value for version label.</param>
+        /// <param name="numeric">Numeric value for the version label.</param>
+        public WixVersionLabel(string label, uint? numeric)
+        {
+            this.Label = label;
+            this.Numeric = numeric;
+        }
+
+        /// <summary>
+        /// Gets the string label value.
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Gets the optional numeric label value.
+        /// </summary>
+        public uint? Numeric { get; set; }
+    }
+}

--- a/src/libs/dutil/WixToolset.DUtil/dutil.v3.ncrunchproject
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/libs/dutil/WixToolset.DUtil/verutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/verutil.cpp
@@ -660,7 +660,7 @@ static HRESULT CompareVersionSubstring(
     HRESULT hr = S_OK;
     int nResult = 0;
 
-    nResult = ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, wzString1, cchCount1, wzString2, cchCount2);
+    nResult = ::CompareStringOrdinal(wzString1, cchCount1, wzString2, cchCount2, TRUE);
     if (!nResult)
     {
         VerExitOnLastError(hr, "Failed to compare version substrings");

--- a/src/libs/dutil/test/DUtilUnitTest/DUtilUnitTest.v3.ncrunchproject
+++ b/src/libs/dutil/test/DUtilUnitTest/DUtilUnitTest.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
+++ b/src/libs/dutil/test/DUtilUnitTest/VerUtilTests.cpp
@@ -606,7 +606,7 @@ namespace DutilTests
 
                 TestVerutilCompareParsedVersions(pVersion1, pVersion2, 1);
                 TestVerutilCompareParsedVersions(pVersion1, pVersion3, 1);
-                TestVerutilCompareParsedVersions(pVersion2, pVersion3, -1);
+                TestVerutilCompareParsedVersions(pVersion2, pVersion3, 1);
             }
             finally
             {

--- a/src/libs/libs.cmd
+++ b/src/libs/libs.cmd
@@ -3,18 +3,42 @@
 
 @set _C=Debug
 @set _L=%~dp0..\..\build\logs
+
 :parse_args
 @if /i "%1"=="release" set _C=Release
+@if /i "%1"=="inc" set _INC=1
+@if /i "%1"=="clean" set _CLEAN=1
 @if not "%1"=="" shift & goto parse_args
 
 @set _B=%~dp0..\..\build\libs\%_C%
+
+:: Clean
+
+@if "%_INC%"=="" call :clean
+@if NOT "%_CLEAN%"=="" goto :end
 
 @echo Building libs %_C%
 
 msbuild -Restore libs_t.proj -p:Configuration=%_C% -nologo -m -warnaserror -bl:%_L%\libs_build.binlog || exit /b
 
+dotnet test %_B%\net6.0\WixToolsetTest.Versioning.dll --nologo -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.Versioning.trx" || exit /b
 dotnet test %_B%\x86\DUtilUnitTest.dll --nologo -l "trx;LogFileName=%_L%\TestResults\DutilUnitTest32.trx" || exit /b
 dotnet test %_B%\x64\DUtilUnitTest.dll --nologo -l "trx;LogFileName=%_L%\TestResults\DutilUnitTest64.trx" || exit /b
 
+@goto :end
+
+:clean
+@rd /s/q "..\..\build\libs" 2> nul
+@del "..\..\build\artifacts\WixToolset.DUtil.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.Versioning.*.nupkg" 2> nul
+@del "..\..\build\artifacts\WixToolset.WcaUtil.*.nupkg" 2> nul
+@del "%_L%\TestResults\WixToolsetTest.Versioning.trx" 2> nul
+@del "%_L%\TestResults\DutilUnitTest*.trx" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.dutil" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.versioning" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.wcautil" 2> nul
+@exit /b
+
+:end
 @popd
 @endlocal

--- a/src/libs/libs.sln
+++ b/src/libs/libs.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dutil", "dutil\WixToolset.DUtil\dutil.vcxproj", "{1244E671-F108-4334-BA52-8A7517F26ECD}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DUtilUnitTest", "dutil\test\DUtilUnitTest\DUtilUnitTest.vcxproj", "{AB7EE608-E5FB-42A5-831F-0DEEEA141223}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wcautil", "wcautil\WixToolset.WcaUtil\wcautil.vcxproj", "{5B3714B6-3A76-463E-8595-D48DA276C512}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolset.Versioning", "WixToolset.Versioning\WixToolset.Versioning.csproj", "{7B14B536-4205-4186-B9FD-0765B84F2075}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WixToolsetTest.Versioning", "test\WixToolsetTest.Versioning\WixToolsetTest.Versioning.csproj", "{3D510701-FF05-4E3B-BB99-BDB97963C3F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +63,38 @@ Global
 		{5B3714B6-3A76-463E-8595-D48DA276C512}.Release|x64.Build.0 = Release|x64
 		{5B3714B6-3A76-463E-8595-D48DA276C512}.Release|x86.ActiveCfg = Release|Win32
 		{5B3714B6-3A76-463E-8595-D48DA276C512}.Release|x86.Build.0 = Release|Win32
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|x64.Build.0 = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Debug|x86.Build.0 = Debug|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|ARM64.Build.0 = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|x64.ActiveCfg = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|x64.Build.0 = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B14B536-4205-4186-B9FD-0765B84F2075}.Release|x86.Build.0 = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|x64.Build.0 = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Debug|x86.Build.0 = Debug|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|ARM64.Build.0 = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|x64.ActiveCfg = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|x64.Build.0 = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|x86.ActiveCfg = Release|Any CPU
+		{3D510701-FF05-4E3B-BB99-BDB97963C3F8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/libs/libs.v3.ncrunchsolution
+++ b/src/libs/libs.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/libs/libs_t.proj
+++ b/src/libs/libs_t.proj
@@ -2,5 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="dutil\dutil_t.proj" />
     <ProjectReference Include="wcautil\wcautil_t.proj" />
+    <ProjectReference Include="WixToolset.Versioning\WixToolset.Versioning.csproj" Targets="Pack" />
+    <ProjectReference Include="test\WixToolsetTest.Versioning\WixToolsetTest.Versioning.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libs/test/WixToolsetTest.Versioning/VerUtilTestsFixture.cs
+++ b/src/libs/test/WixToolsetTest.Versioning/VerUtilTestsFixture.cs
@@ -1,0 +1,683 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.Versioning
+{
+    using System;
+    using WixToolset.Versioning;
+    using Xunit;
+
+    public class VerUtilTestsFixture
+    {
+        [Fact]
+        public void VerCompareVersionsTreatsMissingRevisionAsZero()
+        {
+            var version1 = WixVersion.Parse("1.2.3.4");
+            var version2 = WixVersion.Parse("1.2.3");
+            var version3 = WixVersion.Parse("1.2.3.0");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(1U, version1.Major);
+            Assert.Equal(2U, version1.Minor);
+            Assert.Equal(3U, version1.Patch);
+            Assert.Equal(4U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.True(version1.HasRevision);
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(1U, version2.Major);
+            Assert.Equal(2U, version2.Minor);
+            Assert.Equal(3U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Null(version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.True(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(1U, version3.Major);
+            Assert.Equal(2U, version3.Minor);
+            Assert.Equal(3U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Null(version3.Labels);
+            Assert.Null(version3.Metadata);
+            Assert.False(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.True(version3.HasMinor);
+            Assert.True(version3.HasPatch);
+            Assert.True(version3.HasRevision);
+
+            Assert.Equal(1, version1.CompareTo(version2));
+            Assert.Equal(0, version3.CompareTo(version2));
+        }
+
+        [Fact]
+        public void VerCompareVersionsTreatsNumericReleaseLabelsAsNumbers()
+        {
+            var version1 = WixVersion.Parse("1.0-2.0");
+            var version2 = WixVersion.Parse("1.0-19");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(1U, version1.Major);
+            Assert.Equal(0U, version1.Minor);
+            Assert.Equal(0U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Equal(2, version1.Labels.Length);
+
+            Assert.Equal(2U, version1.Labels[0].Numeric);
+            Assert.Equal("2", version1.Labels[0].Label);
+
+            Assert.Equal(0U, version1.Labels[1].Numeric);
+            Assert.Equal("0", version1.Labels[1].Label);
+
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.False(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(1U, version2.Major);
+            Assert.Equal(0U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Single(version2.Labels);
+
+            Assert.Equal(19U, version2.Labels[0].Numeric);
+            Assert.Equal("19", version2.Labels[0].Label);
+
+            Assert.Null(version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.False(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, -1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsHandlesNormallyInvalidVersions()
+        {
+            var version1 = WixVersion.Parse("10.-4.0");
+            var version2 = WixVersion.Parse("10.-2.0");
+            var version3 = WixVersion.Parse("0");
+            var version4 = WixVersion.Parse("");
+            var version5 = WixVersion.Parse("10-2");
+            var version6 = WixVersion.Parse("10-4.@");
+
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(10U, version1.Major);
+            Assert.Equal(0U, version1.Minor);
+            Assert.Equal(0U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Equal("-4.0", version1.Metadata);
+            Assert.True(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.False(version1.HasMinor);
+            Assert.False(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(10U, version2.Major);
+            Assert.Equal(0U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Equal("-2.0", version2.Metadata);
+            Assert.True(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.False(version2.HasMinor);
+            Assert.False(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(0U, version3.Major);
+            Assert.Equal(0U, version3.Minor);
+            Assert.Equal(0U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Null(version3.Labels);
+            Assert.Null(version3.Metadata);
+            Assert.False(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.False(version3.HasMinor);
+            Assert.False(version3.HasPatch);
+            Assert.False(version3.HasRevision);
+
+            Assert.Null(version4.Prefix);
+            Assert.Equal(0U, version4.Major);
+            Assert.Equal(0U, version4.Minor);
+            Assert.Equal(0U, version4.Patch);
+            Assert.Equal(0U, version4.Revision);
+            Assert.Null(version4.Labels);
+            Assert.Equal(String.Empty, version4.Metadata);
+            Assert.True(version4.Invalid);
+            Assert.False(version4.HasMajor);
+            Assert.False(version4.HasMinor);
+            Assert.False(version4.HasPatch);
+            Assert.False(version4.HasRevision);
+
+            Assert.Null(version5.Prefix);
+            Assert.Equal(10U, version5.Major);
+            Assert.Equal(0U, version5.Minor);
+            Assert.Equal(0U, version5.Patch);
+            Assert.Equal(0U, version5.Revision);
+            Assert.Single(version5.Labels);
+            Assert.Equal(2U, version5.Labels[0].Numeric);
+            Assert.Equal("2", version5.Labels[0].Label);
+
+            Assert.Null(version5.Metadata);
+            Assert.False(version5.Invalid);
+            Assert.True(version5.HasMajor);
+            Assert.False(version5.HasMinor);
+            Assert.False(version5.HasPatch);
+            Assert.False(version5.HasRevision);
+
+            Assert.Null(version6.Prefix);
+            Assert.Equal(10U, version6.Major);
+            Assert.Equal(0U, version6.Minor);
+            Assert.Equal(0U, version6.Patch);
+            Assert.Equal(0U, version6.Revision);
+            Assert.Single(version6.Labels);
+            Assert.Equal(4U, version6.Labels[0].Numeric);
+            Assert.Equal("4", version6.Labels[0].Label);
+
+            Assert.Equal("@", version6.Metadata);
+            Assert.True(version6.Invalid);
+            Assert.True(version6.HasMajor);
+            Assert.False(version6.HasMinor);
+            Assert.False(version6.HasPatch);
+            Assert.False(version6.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 1);
+            TestVerutilCompareParsedVersions(version3, version4, 1);
+            TestVerutilCompareParsedVersions(version5, version6, -1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsTreatsHyphenAsVersionSeparator()
+        {
+            var version1 = WixVersion.Parse("0.0.1-a");
+            var version2 = WixVersion.Parse("0-2");
+            var version3 = WixVersion.Parse("1-2");
+
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(0U, version1.Major);
+            Assert.Equal(0U, version1.Minor);
+            Assert.Equal(1U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Single(version1.Labels);
+            Assert.Null(version1.Labels[0].Numeric);
+            Assert.Equal("a", version1.Labels[0].Label);
+
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(0U, version2.Major);
+            Assert.Equal(0U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Single(version2.Labels);
+            Assert.Equal(2U, version2.Labels[0].Numeric);
+            Assert.Equal("2", version2.Labels[0].Label);
+
+            Assert.Null(version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.False(version2.HasMinor);
+            Assert.False(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(1U, version3.Major);
+            Assert.Equal(0U, version3.Minor);
+            Assert.Equal(0U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Single(version3.Labels);
+            Assert.Equal(2U, version3.Labels[0].Numeric);
+            Assert.Equal("2", version3.Labels[0].Label);
+
+            Assert.Null(version3.Metadata);
+            Assert.False(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.False(version3.HasMinor);
+            Assert.False(version3.HasPatch);
+            Assert.False(version3.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 1);
+            TestVerutilCompareParsedVersions(version1, version3, -1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsIgnoresLeadingZeroes()
+        {
+            var version1 = WixVersion.Parse("0.01-a.1");
+            var version2 = WixVersion.Parse("0.1.0-a.1");
+            var version3 = WixVersion.Parse("0.1-a.b.0");
+            var version4 = WixVersion.Parse("0.1.0-a.b.000");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(0U, version1.Major);
+            Assert.Equal(1U, version1.Minor);
+            Assert.Equal(0U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Equal(2, version1.Labels.Length);
+            Assert.Null(version1.Labels[0].Numeric);
+            Assert.Equal("a", version1.Labels[0].Label);
+            Assert.Equal(1U, version1.Labels[1].Numeric);
+            Assert.Equal("1", version1.Labels[1].Label);
+
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.False(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(0U, version2.Major);
+            Assert.Equal(1U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Equal(2, version2.Labels.Length);
+
+            Assert.Null(version2.Labels[0].Numeric);
+            Assert.Equal("a", version2.Labels[0].Label);
+            Assert.Equal(1U, version2.Labels[1].Numeric);
+            Assert.Equal("1", version2.Labels[1].Label);
+
+            Assert.Null(version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.True(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(0U, version3.Major);
+            Assert.Equal(1U, version3.Minor);
+            Assert.Equal(0U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Equal(3, version3.Labels.Length);
+            Assert.Null(version3.Labels[0].Numeric);
+            Assert.Equal("a", version3.Labels[0].Label);
+            Assert.Null(version3.Labels[1].Numeric);
+            Assert.Equal("b", version3.Labels[1].Label);
+            Assert.Equal(0U, version3.Labels[2].Numeric);
+            Assert.Equal("0", version3.Labels[2].Label);
+
+            Assert.Null(version3.Metadata);
+            Assert.False(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.True(version3.HasMinor);
+            Assert.False(version3.HasPatch);
+            Assert.False(version3.HasRevision);
+
+            Assert.Null(version4.Prefix);
+            Assert.Equal(0U, version4.Major);
+            Assert.Equal(1U, version4.Minor);
+            Assert.Equal(0U, version4.Patch);
+            Assert.Equal(0U, version4.Revision);
+            Assert.Equal(3, version4.Labels.Length);
+            Assert.Null(version4.Labels[0].Numeric);
+            Assert.Equal("a", version4.Labels[0].Label);
+            Assert.Null(version4.Labels[1].Numeric);
+            Assert.Equal("b", version4.Labels[1].Label);
+            Assert.Equal(0U, version4.Labels[2].Numeric);
+            Assert.Equal("000", version4.Labels[2].Label);
+
+            Assert.Null(version4.Metadata);
+            Assert.False(version4.Invalid);
+            Assert.True(version4.HasMajor);
+            Assert.True(version4.HasMinor);
+            Assert.True(version4.HasPatch);
+            Assert.False(version4.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 0);
+            TestVerutilCompareParsedVersions(version3, version4, 0);
+        }
+
+        [Fact]
+        public void VerCompareVersionsTreatsUnexpectedContentAsMetadata()
+        {
+            var version1 = WixVersion.Parse("1.2.3+abcd");
+            var version2 = WixVersion.Parse("1.2.3.abcd");
+            var version3 = WixVersion.Parse("1.2.3.-abcd");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(1U, version1.Major);
+            Assert.Equal(2U, version1.Minor);
+            Assert.Equal(3U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Equal("abcd", version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(1U, version2.Major);
+            Assert.Equal(2U, version2.Minor);
+            Assert.Equal(3U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Equal("abcd", version2.Metadata);
+            Assert.True(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.True(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(1U, version3.Major);
+            Assert.Equal(2U, version3.Minor);
+            Assert.Equal(3U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Null(version3.Labels);
+            Assert.Equal("-abcd", version3.Metadata);
+            Assert.True(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.True(version3.HasMinor);
+            Assert.True(version3.HasPatch);
+            Assert.False(version3.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 1);
+            TestVerutilCompareParsedVersions(version1, version3, 1);
+            TestVerutilCompareParsedVersions(version2, version3, 1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsIgnoresLeadingV()
+        {
+            var version1 = WixVersion.Parse("10.20.30.40");
+            var version2 = WixVersion.Parse("v10.20.30.40");
+            var version3 = WixVersion.Parse("V10.20.30.40");
+            var version4 = WixVersion.Parse("v10.20.30.40-abc");
+            var version5 = WixVersion.Parse("vvv");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(10U, version1.Major);
+            Assert.Equal(20U, version1.Minor);
+            Assert.Equal(30U, version1.Patch);
+            Assert.Equal(40U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.True(version1.HasRevision);
+
+            Assert.Equal('v', version2.Prefix);
+            Assert.Equal(10U, version2.Major);
+            Assert.Equal(20U, version2.Minor);
+            Assert.Equal(30U, version2.Patch);
+            Assert.Equal(40U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Null(version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.True(version2.HasPatch);
+            Assert.True(version2.HasRevision);
+
+            Assert.Equal('V', version3.Prefix);
+            Assert.Equal(10U, version3.Major);
+            Assert.Equal(20U, version3.Minor);
+            Assert.Equal(30U, version3.Patch);
+            Assert.Equal(40U, version3.Revision);
+            Assert.Null(version3.Labels);
+            Assert.Null(version3.Metadata);
+            Assert.False(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.True(version3.HasMinor);
+            Assert.True(version3.HasPatch);
+            Assert.True(version3.HasRevision);
+
+            Assert.Equal('v', version4.Prefix);
+            Assert.Equal(10U, version4.Major);
+            Assert.Equal(20U, version4.Minor);
+            Assert.Equal(30U, version4.Patch);
+            Assert.Equal(40U, version4.Revision);
+            Assert.Single(version4.Labels);
+            Assert.Null(version4.Labels[0].Numeric);
+            Assert.Equal("abc", version4.Labels[0].Label);
+
+            Assert.Null(version4.Metadata);
+            Assert.False(version4.Invalid);
+            Assert.True(version4.HasMajor);
+            Assert.True(version4.HasMinor);
+            Assert.True(version4.HasPatch);
+            Assert.True(version4.HasRevision);
+
+            Assert.Null(version5.Prefix);
+            Assert.Equal(0U, version5.Major);
+            Assert.Equal(0U, version5.Minor);
+            Assert.Equal(0U, version5.Patch);
+            Assert.Equal(0U, version5.Revision);
+            Assert.Null(version5.Labels);
+            Assert.Equal("vvv", version5.Metadata);
+            Assert.True(version5.Invalid);
+            Assert.False(version5.HasMajor);
+            Assert.False(version5.HasMinor);
+            Assert.False(version5.HasPatch);
+            Assert.False(version5.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 0);
+            TestVerutilCompareParsedVersions(version1, version3, 0);
+            TestVerutilCompareParsedVersions(version1, version4, 1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsHandlesTooLargeNumbers()
+        {
+            var version1 = WixVersion.Parse("4294967295.4294967295.4294967295.4294967295");
+            var version2 = WixVersion.Parse("4294967296.4294967296.4294967296.4294967296");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(4294967295, version1.Major);
+            Assert.Equal(4294967295, version1.Minor);
+            Assert.Equal(4294967295, version1.Patch);
+            Assert.Equal(4294967295, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Null(version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.True(version1.HasRevision);
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(0U, version2.Major);
+            Assert.Equal(0U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Equal("4294967296.4294967296.4294967296.4294967296", version2.Metadata);
+            Assert.True(version2.Invalid);
+            Assert.False(version2.HasMajor);
+            Assert.False(version2.HasMinor);
+            Assert.False(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 1);
+        }
+
+        [Fact]
+        public void VerCompareVersionsIgnoresMetadataForValidVersions()
+        {
+            var version1 = WixVersion.Parse("1.2.3+abc");
+            var version2 = WixVersion.Parse("1.2.3+xyz");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(1U, version1.Major);
+            Assert.Equal(2U, version1.Minor);
+            Assert.Equal(3U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Equal("abc", version1.Metadata);
+            Assert.False(version1.Invalid);
+            Assert.True(version1.HasMajor);
+            Assert.True(version1.HasMinor);
+            Assert.True(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(1U, version2.Major);
+            Assert.Equal(2U, version2.Minor);
+            Assert.Equal(3U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Equal("xyz", version2.Metadata);
+            Assert.False(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.True(version2.HasMinor);
+            Assert.True(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+            TestVerutilCompareParsedVersions(version1, version2, 0);
+        }
+
+        [Fact]
+        public void VerParseVersionTreatsTrailingDotsAsInvalid()
+        {
+            var version1 = WixVersion.Parse(".");
+            var version2 = WixVersion.Parse("1.");
+            var version3 = WixVersion.Parse("2.1.");
+            var version4 = WixVersion.Parse("3.2.1.");
+            var version5 = WixVersion.Parse("4.3.2.1.");
+            var version6 = WixVersion.Parse("5-.");
+            var version7 = WixVersion.Parse("6-a.");
+
+            Assert.Null(version1.Prefix);
+            Assert.Equal(0U, version1.Major);
+            Assert.Equal(0U, version1.Minor);
+            Assert.Equal(0U, version1.Patch);
+            Assert.Equal(0U, version1.Revision);
+            Assert.Null(version1.Labels);
+            Assert.Equal(".", version1.Metadata);
+            Assert.True(version1.Invalid);
+            Assert.False(version1.HasMajor);
+            Assert.False(version1.HasMinor);
+            Assert.False(version1.HasPatch);
+            Assert.False(version1.HasRevision);
+
+
+            Assert.Null(version2.Prefix);
+            Assert.Equal(1U, version2.Major);
+            Assert.Equal(0U, version2.Minor);
+            Assert.Equal(0U, version2.Patch);
+            Assert.Equal(0U, version2.Revision);
+            Assert.Null(version2.Labels);
+            Assert.Empty(version2.Metadata);
+            Assert.True(version2.Invalid);
+            Assert.True(version2.HasMajor);
+            Assert.False(version2.HasMinor);
+            Assert.False(version2.HasPatch);
+            Assert.False(version2.HasRevision);
+
+
+            Assert.Null(version3.Prefix);
+            Assert.Equal(2U, version3.Major);
+            Assert.Equal(1U, version3.Minor);
+            Assert.Equal(0U, version3.Patch);
+            Assert.Equal(0U, version3.Revision);
+            Assert.Null(version3.Labels);
+            Assert.Empty(version3.Metadata);
+            Assert.True(version3.Invalid);
+            Assert.True(version3.HasMajor);
+            Assert.True(version3.HasMinor);
+            Assert.False(version3.HasPatch);
+            Assert.False(version3.HasRevision);
+
+            Assert.Null(version4.Prefix);
+            Assert.Equal(3U, version4.Major);
+            Assert.Equal(2U, version4.Minor);
+            Assert.Equal(1U, version4.Patch);
+            Assert.Equal(0U, version4.Revision);
+            Assert.Null(version4.Labels);
+            Assert.Empty(version4.Metadata);
+            Assert.True(version4.Invalid);
+            Assert.True(version4.HasMajor);
+            Assert.True(version4.HasMinor);
+            Assert.True(version4.HasPatch);
+            Assert.False(version4.HasRevision);
+
+            Assert.Null(version5.Prefix);
+            Assert.Equal(4U, version5.Major);
+            Assert.Equal(3U, version5.Minor);
+            Assert.Equal(2U, version5.Patch);
+            Assert.Equal(1U, version5.Revision);
+            Assert.Null(version5.Labels);
+            Assert.Empty(version5.Metadata);
+            Assert.True(version5.Invalid);
+            Assert.True(version5.HasMajor);
+            Assert.True(version5.HasMinor);
+            Assert.True(version5.HasPatch);
+            Assert.True(version5.HasRevision);
+
+            Assert.Null(version6.Prefix);
+            Assert.Equal(5U, version6.Major);
+            Assert.Equal(0U, version6.Minor);
+            Assert.Equal(0U, version6.Patch);
+            Assert.Equal(0U, version6.Revision);
+            Assert.Null(version6.Labels);
+            Assert.Equal(".", version6.Metadata);
+            Assert.True(version6.Invalid);
+            Assert.True(version6.HasMajor);
+            Assert.False(version6.HasMinor);
+            Assert.False(version6.HasPatch);
+            Assert.False(version6.HasRevision);
+
+            Assert.Null(version7.Prefix);
+            Assert.Equal(6U, version7.Major);
+            Assert.Equal(0U, version7.Minor);
+            Assert.Equal(0U, version7.Patch);
+            Assert.Equal(0U, version7.Revision);
+            Assert.Single(version7.Labels);
+            Assert.Null(version7.Labels[0].Numeric);
+            Assert.Equal("a", version7.Labels[0].Label);
+            Assert.Empty(version7.Metadata);
+            Assert.True(version7.Invalid);
+            Assert.True(version7.HasMajor);
+            Assert.False(version7.HasMinor);
+            Assert.False(version7.HasPatch);
+            Assert.False(version7.HasRevision);
+        }
+
+        private static void TestVerutilCompareParsedVersions(WixVersion version1, WixVersion version2, int expectedResult)
+        {
+            var result = version1.CompareTo(version2);
+            Assert.Equal(expectedResult, result);
+
+            result = version2.CompareTo(version1);
+            Assert.Equal(expectedResult, -result);
+
+            var equal = version1.Equals(version2);
+            Assert.Equal(expectedResult == 0, equal);
+        }
+    }
+}

--- a/src/libs/test/WixToolsetTest.Versioning/WixToolsetTest.Versioning.csproj
+++ b/src/libs/test/WixToolsetTest.Versioning/WixToolsetTest.Versioning.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsWixTestProject>true</IsWixTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WixToolset.Versioning\WixToolset.Versioning.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixBuildTools.TestSupport" />
+  </ItemGroup>
+</Project>

--- a/src/libs/test/WixToolsetTest.Versioning/WixVerFixture.cs
+++ b/src/libs/test/WixToolsetTest.Versioning/WixVerFixture.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
-namespace WixToolsetTest.Data
+namespace WixToolsetTest.Versioning
 {
     using System;
     using System.Linq;
-    using WixToolset.Data;
+    using WixToolset.Versioning;
     using Xunit;
 
     public class WixVerFixture
@@ -403,6 +403,49 @@ namespace WixToolsetTest.Data
             Assert.False(version.HasRevision);
             Assert.Equal(String.Empty, version.Metadata);
             Assert.True(version.Invalid);
+        }
+
+        [Fact]
+        public void CanCompareVersions()
+        {
+            var version1 = WixVersion.Parse("1");
+            var version10 = WixVersion.Parse("1.0");
+            var version100 = WixVersion.Parse("1.0.0");
+            var version2 = WixVersion.Parse("2.0.0");
+            var version201 = WixVersion.Parse("2.0.1");
+            var version2a = WixVersion.Parse("2-a");
+            var version2b = WixVersion.Parse("2-b");
+            var versionInvalid3a = WixVersion.Parse("3.-a");
+            var versionInvalid3b = WixVersion.Parse("3.-b");
+
+            Assert.Equal(version1, version1);
+            Assert.Equal(version1, version10);
+            Assert.True(version1 == version10);
+            Assert.True(version1 == version100);
+            Assert.True(version1 <= version10);
+            Assert.True(version1 >= version10);
+            Assert.False(version1 != version10);
+            Assert.False(version1 < version10);
+            Assert.False(version1 < version100);
+            Assert.False(version1 > version10);
+            Assert.False(version1 > version100);
+
+            Assert.NotEqual(version1, version2);
+            Assert.True(version1 < version2);
+            Assert.False(version1 > version2);
+
+            Assert.True(version2 > version2a);
+            Assert.True(version2 != version2a);
+            Assert.False(version2 < version2a);
+
+            Assert.True(version2 < version201);
+
+            Assert.True(version2a < version2b);
+            Assert.False(version2a > version2b);
+
+            Assert.True(versionInvalid3a < versionInvalid3b);
+
+            Assert.True(version1 < versionInvalid3a);
         }
     }
 }

--- a/src/testresultfilelist.txt
+++ b/src/testresultfilelist.txt
@@ -20,4 +20,5 @@ build/logs/TestResults/WixToolsetTest.ManagedHost.trx
 build/logs/TestResults/WixToolsetTest.Mba.Core.trx
 build/logs/TestResults/WixToolsetTest.MsiE2E.trx
 build/logs/TestResults/WixToolsetTest.Sdk.trx
+build/logs/TestResults/WixToolsetTest.Versioning.trx
 build/logs/TestResults/WixToolsetTest.WixE2ETests.trx

--- a/src/wix/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -17,6 +17,7 @@ namespace WixToolset.Core.Burn
     using WixToolset.Extensibility;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     /// <summary>
     /// Binds a this.bundle.

--- a/src/wix/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
@@ -15,6 +15,7 @@ namespace WixToolset.Core.Burn.Bundles
     using WixToolset.Dtf.Resources;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     internal class CreateBundleExeCommand
     {

--- a/src/wix/WixToolset.Core.Burn/WixToolset.Core.Burn.csproj
+++ b/src/wix/WixToolset.Core.Burn/WixToolset.Core.Burn.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WixToolset.Core\WixToolset.Core.csproj" />
     <ProjectReference Include="..\WixToolset.Core.Native\WixToolset.Core.Native.csproj" />
   </ItemGroup>
 
@@ -24,5 +23,6 @@
     <PackageReference Include="WixToolset.Data" />
     <PackageReference Include="WixToolset.Dtf.Resources" />
     <PackageReference Include="WixToolset.Extensibility" />
+    <PackageReference Include="WixToolset.Versioning" />
   </ItemGroup>
 </Project>

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPackageSoftwareTagsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPackageSoftwareTagsCommand.cs
@@ -11,6 +11,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
     using WixToolset.Data.Symbols;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     internal class ProcessPackageSoftwareTagsCommand
     {

--- a/src/wix/WixToolset.Core/Common.cs
+++ b/src/wix/WixToolset.Core/Common.cs
@@ -14,6 +14,7 @@ namespace WixToolset.Core
     using WixToolset.Data;
     using WixToolset.Extensibility;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     /// <summary>
     /// Common Wix utility methods and types.

--- a/src/wix/WixToolset.Core/ExtensibilityServices/BackendHelper.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/BackendHelper.cs
@@ -8,6 +8,7 @@ namespace WixToolset.Core.ExtensibilityServices
     using WixToolset.Data;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     internal class BackendHelper : LayoutServices, IBackendHelper
     {

--- a/src/wix/WixToolset.Core/ExtensibilityServices/ExtensionManager.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/ExtensionManager.cs
@@ -11,6 +11,7 @@ namespace WixToolset.Core.ExtensibilityServices
     using WixToolset.Extensibility;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     internal class ExtensionManager : IExtensionManager
     {
@@ -169,7 +170,7 @@ namespace WixToolset.Core.ExtensibilityServices
                 extensionVersion = extensionReference.Substring(index + 1);
                 extensionId = extensionReference.Substring(0, index);
 
-                if (!NuGet.Versioning.NuGetVersion.TryParse(extensionVersion, out _))
+                if (!WixVersion.TryParse(extensionVersion, out _))
                 {
                     return false;
                 }
@@ -189,15 +190,15 @@ namespace WixToolset.Core.ExtensibilityServices
 
             try
             {
-                NuGet.Versioning.NuGetVersion version = null;
+                WixVersion highestVersion = null;
                 foreach (var versionPath in Directory.GetDirectories(basePath))
                 {
                     var versionFolder = Path.GetFileName(versionPath);
-                    if (NuGet.Versioning.NuGetVersion.TryParse(versionFolder, out var checkVersion) &&
-                        (version == null || version < checkVersion))
+                    if (WixVersion.TryParse(versionFolder, out var checkVersion) &&
+                        (highestVersion == null || highestVersion < checkVersion))
                     {
                         foundVersionFolder = versionFolder;
-                        version = checkVersion;
+                        highestVersion = checkVersion;
                     }
                 }
             }

--- a/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
@@ -15,6 +15,7 @@ namespace WixToolset.Core.ExtensibilityServices
     using WixToolset.Extensibility;
     using WixToolset.Extensibility.Data;
     using WixToolset.Extensibility.Services;
+    using WixToolset.Versioning;
 
     internal class ParseHelper : IParseHelper
     {

--- a/src/wix/WixToolset.Core/WixToolset.Core.csproj
+++ b/src/wix/WixToolset.Core/WixToolset.Core.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="WixToolset.Data" />
     <PackageReference Include="WixToolset.Extensibility" />
+    <PackageReference Include="WixToolset.Versioning" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/WixToolset.Core/WixToolset.Core.csproj
+++ b/src/wix/WixToolset.Core/WixToolset.Core.csproj
@@ -23,6 +23,5 @@
   <ItemGroup>
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
-    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Fix verutil string comparisons
* Move WixVersion to a new WixToolset.Versioning
* Remove dependency on NuGet.Versioning from Core

Closes wixtoolset/issues#6943