### PR TITLE
Add NetFx .NET compatibility check for MSI

### DIFF
--- a/src/ext/NetFx/ca/netfxca.def
+++ b/src/ext/NetFx/ca/netfxca.def
@@ -6,3 +6,4 @@ LIBRARY      "netfxca"
 EXPORTS
 	SchedNetFx
 	ExecNetFx
+	DotNetCompatibilityCheck

--- a/src/ext/NetFx/ca/netfxca.vcxproj
+++ b/src/ext/NetFx/ca/netfxca.vcxproj
@@ -65,7 +65,16 @@
     <PackageReference Include="WixToolset.WcaUtil" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x86" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x64" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.arm64" GeneratePathProperty="true" />
   </ItemGroup>
+
+  <Target Name="CopyNetCoreCheck" AfterTargets="Build">
+    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x86)\win-x86\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\x86" />
+    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x64)\win-x64\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\x64" />
+    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_arm64)\win-arm64\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\arm64" />
+  </Target>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/ext/NetFx/ca/netfxca.vcxproj
+++ b/src/ext/NetFx/ca/netfxca.vcxproj
@@ -42,7 +42,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
 
   <PropertyGroup>
-    <ProjectAdditionalLinkLibraries>msi.lib</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>msi.lib;rpcrt4.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
 
   <ItemGroup>
@@ -65,16 +65,7 @@
     <PackageReference Include="WixToolset.WcaUtil" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x86" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x64" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.arm64" GeneratePathProperty="true" />
   </ItemGroup>
-
-  <Target Name="CopyNetCoreCheck" AfterTargets="Build">
-    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x86)\win-x86\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\x86" />
-    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x64)\win-x64\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\x64" />
-    <Copy SourceFiles="$(PkgMicrosoft_NET_Tools_NETCoreCheck_arm64)\win-arm64\NetCoreCheck.exe" DestinationFolder="$(OutputPath)..\arm64" />
-  </Target>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/ext/NetFx/ca/precomp.h
+++ b/src/ext/NetFx/ca/precomp.h
@@ -2,8 +2,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 
-#include <string>
-
 #include <windows.h>
 #include <msiquery.h>
 #include <strsafe.h>
@@ -13,6 +11,8 @@
 #include "strutil.h"
 #include "pathutil.h"
 #include "procutil.h"
+#include "dirutil.h"
+#include "guidutil.h"
 
 #include "caDecor.h"
 #include "cost.h"

--- a/src/ext/NetFx/ca/precomp.h
+++ b/src/ext/NetFx/ca/precomp.h
@@ -2,6 +2,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 
+#include <string>
+
 #include <windows.h>
 #include <msiquery.h>
 #include <strsafe.h>
@@ -10,6 +12,7 @@
 #include "fileutil.h"
 #include "strutil.h"
 #include "pathutil.h"
+#include "procutil.h"
 
 #include "caDecor.h"
 #include "cost.h"

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
@@ -73,6 +73,7 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(Build, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
+                "Binary:Wix4NetCheck_X86\t[Binary data]",
                 "Binary:Wix4NetFxCA_X86\t[Binary data]",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
@@ -92,6 +93,7 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(BuildX64, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
+                "Binary:Wix4NetCheck_X64\t[Binary data]",
                 "Binary:Wix4NetFxCA_X64\t[Binary data]",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
@@ -111,6 +113,7 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(BuildARM64, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
+                "Binary:Wix4NetCheck_A64\t[Binary data]",
                 "Binary:Wix4NetFxCA_A64\t[Binary data]",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
@@ -73,13 +73,16 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(Build, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
-                "Binary:Wix4NetCheck_X86\t[Binary data]",
+                "Binary:Wix4NetCheck_arm64\t[Binary data]",
+                "Binary:Wix4NetCheck_x64\t[Binary data]",
+                "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_X86\t[Binary data]",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X86\t65\tWix4NetFxCA_X86\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_X86\t3137\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_X86\t3137\tWix4NetFxCA_X86\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_X86\t1\tWix4NetFxCA_X86\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_X86\t65\tWix4NetFxCA_X86\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }
@@ -93,13 +96,16 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(BuildX64, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
-                "Binary:Wix4NetCheck_X64\t[Binary data]",
+                "Binary:Wix4NetCheck_arm64\t[Binary data]",
+                "Binary:Wix4NetCheck_x64\t[Binary data]",
+                "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_X64\t[Binary data]",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X64\t65\tWix4NetFxCA_X64\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_X64\t1\tWix4NetFxCA_X64\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_X64\t65\tWix4NetFxCA_X64\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }
@@ -113,13 +119,16 @@ namespace WixToolsetTest.Netfx
             var results = build.BuildAndQuery(BuildARM64, "Binary", "CustomAction", "Wix4NetFxNativeImage");
             WixAssert.CompareLineByLine(new[]
             {
-                "Binary:Wix4NetCheck_A64\t[Binary data]",
+                "Binary:Wix4NetCheck_arm64\t[Binary data]",
+                "Binary:Wix4NetCheck_x64\t[Binary data]",
+                "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_A64\t[Binary data]",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_A64\t65\tWix4NetFxCA_A64\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_A64\t3137\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_A64\t3137\tWix4NetFxCA_A64\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_A64\t1\tWix4NetFxCA_A64\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_A64\t65\tWix4NetFxCA_A64\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
@@ -77,12 +77,12 @@ namespace WixToolsetTest.Netfx
                 "Binary:Wix4NetCheck_x64\t[Binary data]",
                 "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_X86\t[Binary data]",
-                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X86\t65\tWix4NetFxCA_X86\tDotNetCompatibilityCheck\t",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X86\t1\tWix4NetFxCA_X86\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X86\t3649\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_X86\t3137\tWix4NetFxCA_X86\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_X86\t3137\tWix4NetFxCA_X86\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_X86\t65\tWix4NetFxCA_X86\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_X86\t1\tWix4NetFxCA_X86\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }
@@ -100,12 +100,12 @@ namespace WixToolsetTest.Netfx
                 "Binary:Wix4NetCheck_x64\t[Binary data]",
                 "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_X64\t[Binary data]",
-                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X64\t65\tWix4NetFxCA_X64\tDotNetCompatibilityCheck\t",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X64\t1\tWix4NetFxCA_X64\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_X64\t65\tWix4NetFxCA_X64\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_X64\t1\tWix4NetFxCA_X64\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }
@@ -123,12 +123,12 @@ namespace WixToolsetTest.Netfx
                 "Binary:Wix4NetCheck_x64\t[Binary data]",
                 "Binary:Wix4NetCheck_x86\t[Binary data]",
                 "Binary:Wix4NetFxCA_A64\t[Binary data]",
-                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_A64\t65\tWix4NetFxCA_A64\tDotNetCompatibilityCheck\t",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_A64\t1\tWix4NetFxCA_A64\tDotNetCompatibilityCheck\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_A64\t3649\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageInstall_A64\t3137\tWix4NetFxCA_A64\tExecNetFx\t",
                 "CustomAction:Wix4NetFxExecuteNativeImageUninstall_A64\t3137\tWix4NetFxCA_A64\tExecNetFx\t",
-                "CustomAction:Wix4NetFxScheduleNativeImage_A64\t65\tWix4NetFxCA_A64\tSchedNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_A64\t1\tWix4NetFxCA_A64\tSchedNetFx\t",
                 "Wix4NetFxNativeImage:ExampleNgen\tfil6349_KNDJhqShNzVdHX3ihhvA6Y\t3\t8\t\t",
             }, results.OrderBy(s => s).ToArray());
         }

--- a/src/ext/NetFx/wixext/NetFxCompiler.cs
+++ b/src/ext/NetFx/wixext/NetFxCompiler.cs
@@ -370,9 +370,7 @@ namespace WixToolset.Netfx
         {
             var sourceLineNumbers = this.ParseHelper.GetSourceLineNumbers(element);
             Identifier id = null;
-            string variable = null;
-            string condition = null;
-            string after = null;
+            string property = null;
             string runtimeType = null;
             string platform = null;
             string version = null;
@@ -387,14 +385,8 @@ namespace WixToolset.Netfx
                         case "Id":
                             id = this.ParseHelper.GetAttributeIdentifier(sourceLineNumbers, attrib);
                             break;
-                        case "Variable":
-                            variable = this.ParseHelper.GetAttributeBundleVariableNameValue(sourceLineNumbers, attrib);
-                            break;
-                        case "Condition":
-                            condition = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
-                            break;
-                        case "After":
-                            after = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                        case "Property":
+                            property = this.ParseHelper.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
                             break;
                         case "RuntimeType":
                             runtimeType = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
@@ -410,7 +402,7 @@ namespace WixToolset.Netfx
                                     runtimeType = "Microsoft.NETCore.App";
                                     break;
                                 default:
-                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, runtimeType, "aspnet, desktop and core"));
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, runtimeType, "aspnet", "desktop", "core"));
                                     break;
                             }
                             break;
@@ -424,7 +416,7 @@ namespace WixToolset.Netfx
                                     platform = platform.ToLower();
                                     break;
                                 default:
-                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, platform, "x86, x64 and arm64"));
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, platform, "x86", "x64", "arm64"));
                                     break;
                             }
                             break;
@@ -454,7 +446,7 @@ namespace WixToolset.Netfx
                                     rollForward = "Disable";
                                     break;
                                 default:
-                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, rollForward, "latestmajor, major, latestminor, minor, latestpatch and disable"));
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, rollForward, "latestmajor", "major", "latestminor", "minor", "latestpatch", "disable"));
                                     break;
                             }
                             break;
@@ -471,7 +463,12 @@ namespace WixToolset.Netfx
 
             if (null == id)
             {
-                id = this.ParseHelper.CreateIdentifier("ndncc", runtimeType, platform, version, variable);
+                id = this.ParseHelper.CreateIdentifier("ndncc", property, runtimeType, platform, version);
+            }
+
+            if (String.IsNullOrEmpty(property))
+            {
+                this.Messaging.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, element.Name.LocalName, "Property"));
             }
 
             if (String.IsNullOrEmpty(runtimeType))
@@ -495,16 +492,13 @@ namespace WixToolset.Netfx
 
             if (!this.Messaging.EncounteredError)
             {
-                // TODO: This will eventually be supported under Module/Product, but is not yet.
-                // this.ParseHelper.CreateWixSearchSymbol(section, sourceLineNumbers, element.Name.LocalName, id, variable, condition, after, null);
-
                 section.AddSymbol(new NetFxDotNetCompatibilityCheckSymbol(sourceLineNumbers, id)
                 {
                     RuntimeType = runtimeType,
                     Platform = platform,
                     Version = version,
                     RollForward = rollForward,
-                    Variable = variable,
+                    Property = property,
                 });
             }
         }

--- a/src/ext/NetFx/wixext/NetFxCompiler.cs
+++ b/src/ext/NetFx/wixext/NetFxCompiler.cs
@@ -40,7 +40,6 @@ namespace WixToolset.Netfx
                             break;
                     }
                     break;
-                case "Bundle":
                 case "Fragment":
                     switch (element.Name.LocalName)
                     {
@@ -50,8 +49,45 @@ namespace WixToolset.Netfx
                         case "DotNetCoreSearchRef":
                             this.ParseDotNetCoreSearchRefElement(intermediate, section, element);
                             break;
+                        case "DotNetCompatibilityCheck":
+                            this.ParseDotNetCompatibilityCheckElement(intermediate, section, element);
+                            break;
+                        case "DotNetCompatibilityCheckRef":
+                            this.ParseDotNetCompatibilityCheckRefElement(intermediate, section, element);
+                            break;
+                        default:
+                            this.ParseHelper.UnexpectedElement(parentElement, element);
+                            break;
                     }
-
+                    break;
+                case "Bundle":
+                    switch (element.Name.LocalName)
+                    {
+                        case "DotNetCoreSearch":
+                            this.ParseDotNetCoreSearchElement(intermediate, section, element);
+                            break;
+                        case "DotNetCoreSearchRef":
+                            this.ParseDotNetCoreSearchRefElement(intermediate, section, element);
+                            break;
+                        default:
+                            this.ParseHelper.UnexpectedElement(parentElement, element);
+                            break;
+                    }
+                    break;
+                case "Package":
+                case "Module":
+                    switch (element.Name.LocalName)
+                    {
+                        case "DotNetCompatibilityCheck":
+                            this.ParseDotNetCompatibilityCheckElement(intermediate, section, element);
+                            break;
+                        case "DotNetCompatibilityCheckRef":
+                            this.ParseDotNetCompatibilityCheckRefElement(intermediate, section, element);
+                            break;
+                        default:
+                            this.ParseHelper.UnexpectedElement(parentElement, element);
+                            break;
+                    }
                     break;
                 default:
                     this.ParseHelper.UnexpectedElement(parentElement, element);
@@ -324,6 +360,185 @@ namespace WixToolset.Netfx
                     ApplicationBaseDirectoryRef = appBaseDirectory,
                 });
             }
+        }
+
+        /// <summary>
+        /// Parses a DotNetCompatibilityCheck element.
+        /// </summary>
+        /// <param name="element">The element to parse.</param>
+        private void ParseDotNetCompatibilityCheckElement(Intermediate intermediate, IntermediateSection section, XElement element)
+        {
+            var sourceLineNumbers = this.ParseHelper.GetSourceLineNumbers(element);
+            Identifier id = null;
+            string variable = null;
+            string condition = null;
+            string after = null;
+            string runtimeType = null;
+            string platform = null;
+            string version = null;
+            string rollForward = "Minor";
+
+            foreach (var attrib in element.Attributes())
+            {
+                if (String.IsNullOrEmpty(attrib.Name.NamespaceName) || this.Namespace == attrib.Name.Namespace)
+                {
+                    switch (attrib.Name.LocalName)
+                    {
+                        case "Id":
+                            id = this.ParseHelper.GetAttributeIdentifier(sourceLineNumbers, attrib);
+                            break;
+                        case "Variable":
+                            variable = this.ParseHelper.GetAttributeBundleVariableNameValue(sourceLineNumbers, attrib);
+                            break;
+                        case "Condition":
+                            condition = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "After":
+                            after = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "RuntimeType":
+                            runtimeType = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                            switch (runtimeType.ToLower())
+                            {
+                                case "aspnet":
+                                    runtimeType = "Microsoft.AspNetCore.App";
+                                    break;
+                                case "desktop":
+                                    runtimeType = "Microsoft.WindowsDesktop.App";
+                                    break;
+                                case "core":
+                                    runtimeType = "Microsoft.NETCore.App";
+                                    break;
+                                default:
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, runtimeType, "aspnet, desktop and core"));
+                                    break;
+                            }
+                            break;
+                        case "Platform":
+                            platform = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                            switch (platform.ToLower())
+                            {
+                                case "x86":
+                                case "x64":
+                                case "arm64":
+                                    platform = platform.ToLower();
+                                    break;
+                                default:
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, platform, "x86, x64 and arm64"));
+                                    break;
+                            }
+                            break;
+                        case "Version":
+                            version = this.ParseHelper.GetAttributeVersionValue(sourceLineNumbers, attrib);
+                            break;
+                        case "RollForward":
+                            rollForward = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
+                            switch (rollForward.ToLower())
+                            {
+                                case "latestmajor":
+                                    rollForward = "LatestMajor";
+                                    break;
+                                case "major":
+                                    rollForward = "Major";
+                                    break;
+                                case "latestminor":
+                                    rollForward = "LatestMinor";
+                                    break;
+                                case "minor":
+                                    rollForward = "Minor";
+                                    break;
+                                case "latestpatch":
+                                    rollForward = "LatestPatch";
+                                    break;
+                                case "disable":
+                                    rollForward = "Disable";
+                                    break;
+                                default:
+                                    this.Messaging.Write(ErrorMessages.IllegalAttributeValueWithLegalList(sourceLineNumbers, element.Name.LocalName, attrib.Name.LocalName, rollForward, "latestmajor, major, latestminor, minor, latestpatch and disable"));
+                                    break;
+                            }
+                            break;
+                        default:
+                            this.ParseHelper.UnexpectedAttribute(element, attrib);
+                            break;
+                    }
+                }
+                else
+                {
+                    this.ParseHelper.ParseExtensionAttribute(this.Context.Extensions, intermediate, section, element, attrib);
+                }
+            }
+
+            if (null == id)
+            {
+                id = this.ParseHelper.CreateIdentifier("ndncc", runtimeType, platform, version, variable);
+            }
+
+            if (String.IsNullOrEmpty(runtimeType))
+            {
+                this.Messaging.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, element.Name.LocalName, "RuntimeType"));
+            }
+
+            if (String.IsNullOrEmpty(platform))
+            {
+                this.Messaging.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, element.Name.LocalName, "Platform"));
+            }
+
+            if (String.IsNullOrEmpty(version))
+            {
+                this.Messaging.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, element.Name.LocalName, "Version"));
+            }
+
+            this.ParseHelper.ParseForExtensionElements(this.Context.Extensions, intermediate, section, element);
+
+            this.ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "Wix4NetFxDotNetCompatibilityCheck", this.Context.Platform, CustomActionPlatforms.ARM64 | CustomActionPlatforms.X64 | CustomActionPlatforms.X86);
+
+            if (!this.Messaging.EncounteredError)
+            {
+                // TODO: This will eventually be supported under Module/Product, but is not yet.
+                // this.ParseHelper.CreateWixSearchSymbol(section, sourceLineNumbers, element.Name.LocalName, id, variable, condition, after, null);
+
+                section.AddSymbol(new NetFxDotNetCompatibilityCheckSymbol(sourceLineNumbers, id)
+                {
+                    RuntimeType = runtimeType,
+                    Platform = platform,
+                    Version = version,
+                    RollForward = rollForward,
+                    Variable = variable,
+                });
+            }
+        }
+
+        /// <summary>
+        /// Parses a DotNetCompatibilityCheckRef element.
+        /// </summary>
+        /// <param name="element">The element to parse.</param>
+        private void ParseDotNetCompatibilityCheckRefElement(Intermediate intermediate, IntermediateSection section, XElement element)
+        {
+            var sourceLineNumbers = this.ParseHelper.GetSourceLineNumbers(element);
+
+            foreach (var attrib in element.Attributes())
+            {
+                if (String.IsNullOrEmpty(attrib.Name.NamespaceName) || this.Namespace == attrib.Name.Namespace)
+                {
+                    switch (attrib.Name.LocalName)
+                    {
+                        case "Id":
+                            var refId = this.ParseHelper.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                            this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck, refId);
+                            break;
+                        default:
+                            this.ParseHelper.UnexpectedAttribute(element, attrib);
+                            break;
+                    }
+                }
+                else
+                {
+                    this.ParseHelper.ParseExtensionAttribute(this.Context.Extensions, intermediate, section, element, attrib);
+                }
+            }
+
+            this.ParseHelper.ParseForExtensionElements(this.Context.Extensions, intermediate, section, element);
         }
     }
 }

--- a/src/ext/NetFx/wixext/NetFxExtensionData.cs
+++ b/src/ext/NetFx/wixext/NetFxExtensionData.cs
@@ -10,6 +10,8 @@ namespace WixToolset.Netfx
     /// </summary>
     public sealed class NetfxExtensionData : BaseExtensionData
     {
+        public override string DefaultCulture => "en-US";
+        
         public override bool TryGetSymbolDefinitionByName(string name, out IntermediateSymbolDefinition symbolDefinition)
         {
             symbolDefinition = NetfxSymbolDefinitions.ByName(name);

--- a/src/ext/NetFx/wixext/NetfxTableDefinitions.cs
+++ b/src/ext/NetFx/wixext/NetfxTableDefinitions.cs
@@ -23,7 +23,7 @@ namespace WixToolset.Netfx
         );
 
         public static readonly TableDefinition NetFxDotNetCompatibilityCheck = new TableDefinition(
-            "Wix4NetFxDotNetCompatibilityCheck",
+            "Wix4NetFxDotNetCheck",
             NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck,
             new[]
             {
@@ -32,7 +32,7 @@ namespace WixToolset.Netfx
                 new ColumnDefinition("Platform", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Text, description: "Sets the platform for the .NET runtime being checked for. Possible values: x86, x64 and arm64", modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("Version", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Version, description: "The version of the .NET runtime being checked for (e.g. 3.1.10, 5.0.1).", modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("RollForward", ColumnType.String, 72, primaryKey: false, nullable: true, ColumnCategory.Text, description: "Sets the roll-forward policy that the application is using. Possible values: latestmajor, major, latestminor, minor, latestpatch and disable", modularizeType: ColumnModularizeType.Column),
-                new ColumnDefinition("Variable", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, description: "Name of the variable in which to place the result of the check.", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("Property", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, description: "Name of the property in which to place the result of the check.", modularizeType: ColumnModularizeType.Column),
             },
             symbolIdIsPrimaryKey: true
         );

--- a/src/ext/NetFx/wixext/NetfxTableDefinitions.cs
+++ b/src/ext/NetFx/wixext/NetfxTableDefinitions.cs
@@ -22,9 +22,25 @@ namespace WixToolset.Netfx
             symbolIdIsPrimaryKey: true
         );
 
+        public static readonly TableDefinition NetFxDotNetCompatibilityCheck = new TableDefinition(
+            "Wix4NetFxDotNetCompatibilityCheck",
+            NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck,
+            new[]
+            {
+                new ColumnDefinition("NetFxDotNetCompatibilityCheck", ColumnType.String, 72, primaryKey: true, nullable: false, ColumnCategory.Identifier, description: "The primary key, a non-localized token.", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("RuntimeType", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Text, description: "The type of .NET runtime being checked for. Possible values: aspnet, desktop and core", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("Platform", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Text, description: "Sets the platform for the .NET runtime being checked for. Possible values: x86, x64 and arm64", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("Version", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Version, description: "The version of the .NET runtime being checked for (e.g. 3.1.10, 5.0.1).", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("RollForward", ColumnType.String, 72, primaryKey: false, nullable: true, ColumnCategory.Text, description: "Sets the roll-forward policy that the application is using. Possible values: latestmajor, major, latestminor, minor, latestpatch and disable", modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("Variable", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, description: "Name of the variable in which to place the result of the check.", modularizeType: ColumnModularizeType.Column),
+            },
+            symbolIdIsPrimaryKey: true
+        );
+
         public static readonly TableDefinition[] All = new[]
         {
             NetFxNativeImage,
+            NetFxDotNetCompatibilityCheck
         };
     }
 }

--- a/src/ext/NetFx/wixext/Symbols/NetFxDotNetCompatibilityCheckSymbol.cs
+++ b/src/ext/NetFx/wixext/Symbols/NetFxDotNetCompatibilityCheckSymbol.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Netfx
+{
+    using WixToolset.Data;
+    using WixToolset.Netfx.Symbols;
+
+    public static partial class NetfxSymbolDefinitions
+    {
+        public static readonly IntermediateSymbolDefinition NetFxDotNetCompatibilityCheck = new IntermediateSymbolDefinition(
+            NetfxSymbolDefinitionType.NetFxDotNetCompatibilityCheck.ToString(),
+            new[]
+            {
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.RuntimeType), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Platform), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Version), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.RollForward), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Variable), IntermediateFieldType.String),
+            },
+            typeof(NetFxNativeImageSymbol));
+    }
+}
+
+namespace WixToolset.Netfx.Symbols
+{
+    using WixToolset.Data;
+
+    public enum NetFxDotNetCompatibilityCheckSymbollFields
+    {
+        RuntimeType,
+        Platform,
+        Version,
+        RollForward,
+        Variable,
+    }
+
+    public class NetFxDotNetCompatibilityCheckSymbol : IntermediateSymbol
+    {
+        public NetFxDotNetCompatibilityCheckSymbol() : base(NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck, null, null)
+        {
+        }
+
+        public NetFxDotNetCompatibilityCheckSymbol(SourceLineNumber sourceLineNumber, Identifier id = null) : base(NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck, sourceLineNumber, id)
+        {
+        }
+
+        public IntermediateField this[NetFxDotNetCompatibilityCheckSymbollFields index] => this.Fields[(int)index];
+
+        public string RuntimeType
+        {
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.RuntimeType].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.RuntimeType, value);
+        }
+
+        public string Platform
+        {
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.Platform].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.Platform, value);
+        }
+
+        public string Version
+        {
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.Version].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.Version, value);
+        }
+
+        public string RollForward
+        {
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.RollForward].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.RollForward, value);
+        }
+
+        public string Variable
+        {
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.Variable].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.Variable, value);
+        }
+    }
+}

--- a/src/ext/NetFx/wixext/Symbols/NetFxDotNetCompatibilityCheckSymbol.cs
+++ b/src/ext/NetFx/wixext/Symbols/NetFxDotNetCompatibilityCheckSymbol.cs
@@ -15,9 +15,9 @@ namespace WixToolset.Netfx
                 new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Platform), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Version), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.RollForward), IntermediateFieldType.String),
-                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Variable), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(NetFxDotNetCompatibilityCheckSymbollFields.Property), IntermediateFieldType.String),
             },
-            typeof(NetFxNativeImageSymbol));
+            typeof(NetFxDotNetCompatibilityCheckSymbol));
     }
 }
 
@@ -31,7 +31,7 @@ namespace WixToolset.Netfx.Symbols
         Platform,
         Version,
         RollForward,
-        Variable,
+        Property,
     }
 
     public class NetFxDotNetCompatibilityCheckSymbol : IntermediateSymbol
@@ -70,10 +70,10 @@ namespace WixToolset.Netfx.Symbols
             set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.RollForward, value);
         }
 
-        public string Variable
+        public string Property
         {
-            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.Variable].AsString();
-            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.Variable, value);
+            get => this.Fields[(int)NetFxDotNetCompatibilityCheckSymbollFields.Property].AsString();
+            set => this.Set((int)NetFxDotNetCompatibilityCheckSymbollFields.Property, value);
         }
     }
 }

--- a/src/ext/NetFx/wixext/Symbols/NetfxSymbolDefinitions.cs
+++ b/src/ext/NetFx/wixext/Symbols/NetfxSymbolDefinitions.cs
@@ -10,10 +10,13 @@ namespace WixToolset.Netfx
     {
         NetFxNativeImage,
         NetFxNetCoreSearch,
+        NetFxDotNetCompatibilityCheck
     }
 
     public static partial class NetfxSymbolDefinitions
     {
+        public static readonly Version Version = new Version("4.0.0");
+
         public static IntermediateSymbolDefinition ByName(string name)
         {
             if (!Enum.TryParse(name, out NetfxSymbolDefinitionType type))
@@ -33,6 +36,9 @@ namespace WixToolset.Netfx
 
                 case NetfxSymbolDefinitionType.NetFxNetCoreSearch:
                     return NetfxSymbolDefinitions.NetFxNetCoreSearch;
+                    
+                case NetfxSymbolDefinitionType.NetFxDotNetCompatibilityCheck:
+                    return NetfxSymbolDefinitions.NetFxDotNetCompatibilityCheck;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type));

--- a/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
+++ b/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
@@ -5,12 +5,12 @@
   <?include ..\..\caDecor.wxi ?>
 
   <Fragment>
-    <CustomAction Id="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" DllEntry="SchedNetFx" Execute="immediate" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
+    <CustomAction Id="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" DllEntry="SchedNetFx" Execute="immediate" Return="check" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageInstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="deferred" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageCommitInstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="commit" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageUninstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="deferred" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageCommitUninstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="commit" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
-    <CustomAction Id="$(var.Prefix)NetFxDotNetCompatibilityCheck$(var.Suffix)" DllEntry="DotNetCompatibilityCheck" Execute="immediate" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
+    <CustomAction Id="$(var.Prefix)NetFxDotNetCompatibilityCheck$(var.Suffix)" DllEntry="DotNetCompatibilityCheck" Execute="immediate" Return="check" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
 
     <InstallExecuteSequence>
       <Custom Action="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" Before="InstallFiles" Overridable="yes" />
@@ -29,8 +29,8 @@
   <!-- NetFx Custom Action DLL Definitions -->
   <Fragment>
     <Binary Id="$(var.Prefix)NetFxCA$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))netfxca.dll" />
-    <?foreach PLATFORM in x86;x64;arm64?>
-      <Binary Id="$(var.Prefix)NetCheck_$(var.PLATFORM)" SourceFile="!(bindpath.$(var.PLATFORM))NetCoreCheck.exe" />
-    <?endforeach?>
+    <Binary Id="$(var.Prefix)NetCheck_x86" SourceFile="!(bindpath.x86)NetCoreCheck.exe" />
+    <Binary Id="$(var.Prefix)NetCheck_x64" SourceFile="!(bindpath.x64)NetCoreCheck.exe" />
+    <Binary Id="$(var.Prefix)NetCheck_arm64" SourceFile="!(bindpath.arm64)NetCoreCheck.exe" />
   </Fragment>
 </Include>

--- a/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
+++ b/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
@@ -23,5 +23,8 @@
   <!-- NetFx Custom Action DLL Definitions -->
   <Fragment>
     <Binary Id="$(var.Prefix)NetFxCA$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))netfxca.dll" />
+    <?foreach PLATFORM in x86;x64;arm64?>
+      <Binary Id="$(var.Prefix)NetCheck_$(var.PLATFORM)" SourceFile="!(bindpath.$(var.PLATFORM))NetCoreCheck.exe" />
+    <?endforeach?>
   </Fragment>
 </Include>

--- a/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
+++ b/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
@@ -5,11 +5,12 @@
   <?include ..\..\caDecor.wxi ?>
 
   <Fragment>
-    <CustomAction Id="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" DllEntry="SchedNetFx" Execute="immediate" Return="check" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
+    <CustomAction Id="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" DllEntry="SchedNetFx" Execute="immediate" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageInstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="deferred" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageCommitInstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="commit" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageUninstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="deferred" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
     <CustomAction Id="$(var.Prefix)NetFxExecuteNativeImageCommitUninstall$(var.Suffix)" DllEntry="ExecNetFx" Execute="commit" Impersonate="no" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
+    <CustomAction Id="$(var.Prefix)NetFxDotNetCompatibilityCheck$(var.Suffix)" DllEntry="DotNetCompatibilityCheck" Execute="immediate" Return="ignore" SuppressModularization="yes" BinaryRef="$(var.Prefix)NetFxCA$(var.Suffix)" />
 
     <InstallExecuteSequence>
       <Custom Action="$(var.Prefix)NetFxScheduleNativeImage$(var.Suffix)" Before="InstallFiles" Overridable="yes" />
@@ -17,7 +18,12 @@
       <Custom Action="$(var.Prefix)NetFxExecuteNativeImageUninstall$(var.Suffix)" After="$(var.Prefix)NetFxExecuteNativeImageCommitUninstall$(var.Suffix)" Overridable="yes" Condition="RollbackDisabled = 1" />
       <Custom Action="$(var.Prefix)NetFxExecuteNativeImageCommitInstall$(var.Suffix)" After="$(var.Prefix)NetFxExecuteNativeImageUninstall$(var.Suffix)" Overridable="yes" Condition="RollbackDisabled &lt;&gt; 1" />
       <Custom Action="$(var.Prefix)NetFxExecuteNativeImageInstall$(var.Suffix)" After="$(var.Prefix)NetFxExecuteNativeImageCommitInstall$(var.Suffix)" Overridable="yes" Condition="RollbackDisabled = 1" />
+      <Custom Action="$(var.Prefix)NetFxDotNetCompatibilityCheck$(var.Suffix)" Before="LaunchConditions" Overridable="yes" />
     </InstallExecuteSequence>
+
+    <InstallUISequence>
+      <Custom Action="$(var.Prefix)NetFxDotNetCompatibilityCheck$(var.Suffix)" Before="LaunchConditions" Overridable="yes" />
+    </InstallUISequence>
   </Fragment>
 
   <!-- NetFx Custom Action DLL Definitions -->

--- a/src/ext/NetFx/wixlib/netfx.wixproj
+++ b/src/ext/NetFx/wixlib/netfx.wixproj
@@ -11,6 +11,9 @@
     <BindInputPaths Include="$(OutputPath)x86" BindName='x86' />
     <BindInputPaths Include="$(OutputPath)x64" BindName='x64' />
     <BindInputPaths Include="$(OutputPath)arm64" BindName='arm64' />
+    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x86)\win-x86" BindName='x86' />
+    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x64)\win-x64" BindName='x64' />
+    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_arm64)\win-arm64" BindName='arm64' />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,5 +36,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="GitInfo" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x86" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.x64" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Tools.NETCoreCheck.arm64" GeneratePathProperty="true" />
   </ItemGroup>
 </Project>

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -83,4 +83,10 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="xunit.assert" Version="2.4.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x86" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x64" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.arm64" Version="6.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds new custom element in NetFx extension for running NetCoreCheck.exe tool from within the MSI installer - `<netfx:DotNetCompatibilityCheck />`. The checks are run before evaluating launch conditions, so their results can be used in those conditions. There is no limitation on the number of checks that can be run, so installer may query various runtimes on different platforms and versions and with different roll forward policies.

Fixes https://github.com/wixtoolset/issues/issues/6264