### PR TITLE
Better file system error messages and fix standard directory code generation

### DIFF
--- a/src/api/wix/WixToolset.Data/OutputType.cs
+++ b/src/api/wix/WixToolset.Data/OutputType.cs
@@ -2,6 +2,8 @@
 
 namespace WixToolset.Data
 {
+    using System;
+
     /// <summary>
     /// Various types of output.
     /// </summary>
@@ -25,8 +27,12 @@ namespace WixToolset.Data
         /// <summary>Patch Creation output type.</summary>
         PatchCreation,
 
-        /// <summary>Product output type.</summary>
-        Product,
+        /// <summary>Package output type.</summary>
+        Package,
+
+        /// <summary>Package output type.</summary>
+        [Obsolete]
+        Product = Package,
 
         /// <summary>Transform output type.</summary>
         Transform,

--- a/src/api/wix/WixToolset.Data/SectionType.cs
+++ b/src/api/wix/WixToolset.Data/SectionType.cs
@@ -2,6 +2,8 @@
 
 namespace WixToolset.Data
 {
+    using System;
+
     /// <summary>
     /// Type of section.
     /// </summary>
@@ -19,8 +21,12 @@ namespace WixToolset.Data
         /// <summary>Module section type.</summary>
         Module,
 
-        /// <summary>Product section type.</summary>
-        Product,
+        /// <summary>Package section type.</summary>
+        Package,
+
+        /// <summary>Package output type.</summary>
+        [Obsolete]
+        Product = Package,
 
         /// <summary>Patch creation section type.</summary>
         PatchCreation,

--- a/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerData.cs
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerData.cs
@@ -217,8 +217,9 @@ namespace WixToolset.Data.WindowsInstaller
                             case "PatchCreation":
                                 output.Type = OutputType.PatchCreation;
                                 break;
+                            case "Package":
                             case "Product":
-                                output.Type = OutputType.Product;
+                                output.Type = OutputType.Package;
                                 break;
                             case "Transform":
                                 output.Type = OutputType.Transform;

--- a/src/api/wix/WixToolset.Data/WindowsInstaller/Xsd/data.xsd
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/Xsd/data.xsd
@@ -38,6 +38,7 @@
                         <xs:enumeration value="Module" />
                         <xs:enumeration value="Patch" />
                         <xs:enumeration value="PatchCreation" />
+                        <xs:enumeration value="Package" />
                         <xs:enumeration value="Product" />
                         <xs:enumeration value="Transform" />
                     </xs:restriction>

--- a/src/api/wix/WixToolset.Data/WindowsInstaller/Xsd/objects.xsd
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/Xsd/objects.xsd
@@ -119,6 +119,7 @@
             <xs:enumeration value="bundle"/>
             <xs:enumeration value="fragment" />
             <xs:enumeration value="module" />
+            <xs:enumeration value="package" />
             <xs:enumeration value="product" />
             <xs:enumeration value="patchCreation" />
             <xs:enumeration value="patch" />

--- a/src/api/wix/WixToolset.Extensibility/Services/IFileSystem.cs
+++ b/src/api/wix/WixToolset.Extensibility/Services/IFileSystem.cs
@@ -4,6 +4,7 @@ namespace WixToolset.Extensibility.Services
 {
     using System;
     using System.IO;
+    using WixToolset.Data;
 
     /// <summary>
     /// Abstracts basic file system operations.
@@ -13,34 +14,38 @@ namespace WixToolset.Extensibility.Services
         /// <summary>
         /// Copies a file.
         /// </summary>
+        /// <param name="sourceLineNumbers">Optional source line number requiring the copy.</param>
         /// <param name="source">The file to copy.</param>
         /// <param name="destination">The destination file.</param>
         /// <param name="allowHardlink">Allow hardlinks.</param>
-        void CopyFile(string source, string destination, bool allowHardlink);
+        void CopyFile(SourceLineNumber sourceLineNumbers, string source, string destination, bool allowHardlink);
 
         /// <summary>
         /// Deletes a file.
         /// </summary>
+        /// <param name="sourceLineNumbers">Optional source line number requiring the delete.</param>
         /// <param name="source">The file to delete.</param>
         /// <param name="throwOnError">Indicates the file must be deleted. Default is a best effort delete.</param>
         /// <param name="maxRetries">Maximum retry attempts. Default is 4.</param>
-        void DeleteFile(string source, bool throwOnError = false, int maxRetries = 4);
+        void DeleteFile(SourceLineNumber sourceLineNumbers, string source, bool throwOnError = false, int maxRetries = 4);
 
         /// <summary>
         /// Moves a file.
         /// </summary>
+        /// <param name="sourceLineNumbers">Optional source line number requiring the move.</param>
         /// <param name="source">The file to move.</param>
         /// <param name="destination">The destination file.</param>
-        void MoveFile(string source, string destination);
+        void MoveFile(SourceLineNumber sourceLineNumbers, string source, string destination);
 
         /// <summary>
         /// Opens a file.
         /// </summary>
+        /// <param name="sourceLineNumbers">Optional source line number requiring the file.</param>
         /// <param name="path">The file to open.</param>
         /// <param name="mode">A System.IO.FileMode value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.</param>
         /// <param name="access">A System.IO.FileAccess value that specifies the operations that can be performed on the file.</param>
         /// <param name="share">A System.IO.FileShare value specifying the type of access other threads have to the file.</param>
-        FileStream OpenFile(string path, FileMode mode, FileAccess access, FileShare share);
+        FileStream OpenFile(SourceLineNumber sourceLineNumbers, string path, FileMode mode, FileAccess access, FileShare share);
 
         /// <summary>
         /// Executes an action and retries on any exception a few times with short pause

--- a/src/api/wix/test/WixToolsetTest.Data/SerializeFixture.cs
+++ b/src/api/wix/test/WixToolsetTest.Data/SerializeFixture.cs
@@ -21,7 +21,7 @@ namespace WixToolsetTest.Data
         {
             var sln = new SourceLineNumber("test.wxs", 1);
 
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
 
             section.AddSymbol(new ComponentSymbol(sln, new Identifier(AccessModifier.Global, "TestComponent"))
             {
@@ -66,7 +66,7 @@ namespace WixToolsetTest.Data
         public void CanUpdateIntermediate()
         {
             var sln = new SourceLineNumber("test.wxs", 1);
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
 
             section.AddSymbol(new ComponentSymbol(sln, new Identifier(AccessModifier.Global, "TestComponent"))
             {
@@ -123,7 +123,7 @@ namespace WixToolsetTest.Data
         {
             var sln = new SourceLineNumber("test.wxs", 1);
 
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
 
             var fieldDefs = new[]
             {
@@ -182,7 +182,7 @@ namespace WixToolsetTest.Data
             symbol.Set(1, 2);
             symbol.Set(2, true);
 
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
             section.AddSymbol(symbol);
 
             var intermediate1 = new Intermediate("TestIntermediate", new[] { section }, null);
@@ -265,7 +265,7 @@ namespace WixToolsetTest.Data
 
             symbol.AddTag("symbol1tag");
 
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
             section.AddSymbol(symbol);
 
             var intermediate1 = new Intermediate("TestIntermediate", new[] { section }, null);
@@ -358,7 +358,7 @@ namespace WixToolsetTest.Data
                 new Localization(65001, 1252, null, bindVariables.ToDictionary(b => b.Id), controls.ToDictionary(c => c.GetKey()))
             };
 
-            var section = new IntermediateSection("test", SectionType.Product);
+            var section = new IntermediateSection("test", SectionType.Package);
 
             section.AddSymbol(new ComponentSymbol(sln, new Identifier(AccessModifier.Global, "TestComponent"))
             {
@@ -397,7 +397,7 @@ namespace WixToolsetTest.Data
             var sln = new SourceLineNumber("test.wxs", 1);
             var windowsInstallerData = new Wid.WindowsInstallerData(sln)
             {
-                Type = OutputType.Product,
+                Type = OutputType.Package,
             };
 
             var fileTable = windowsInstallerData.EnsureTable(Wid.WindowsInstallerTableDefinitions.File);

--- a/src/tools/heat/UtilHeatExtension.cs
+++ b/src/tools/heat/UtilHeatExtension.cs
@@ -263,6 +263,7 @@ namespace WixToolset.Harvesters
                             case "module":
                                 utilMutator.TemplateType = TemplateType.Module;
                                 break;
+                            case "package":
                             case "product":
                                 utilMutator.TemplateType = TemplateType.Package ;
                                 break;

--- a/src/wix/WixToolset.Converters.Symbolizer/ConvertSymbols.cs
+++ b/src/wix/WixToolset.Converters.Symbolizer/ConvertSymbols.cs
@@ -823,7 +823,7 @@ namespace WixToolset.Converters.Symbolizer
             case Wix3.OutputType.PatchCreation:
                 return SectionType.PatchCreation;
             case Wix3.OutputType.Product:
-                return SectionType.Product;
+                return SectionType.Package;
             case Wix3.OutputType.Transform:
             case Wix3.OutputType.Unknown:
             default:

--- a/src/wix/WixToolset.Core.Burn/Bundles/BurnReader.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/BurnReader.cs
@@ -56,7 +56,7 @@ namespace WixToolset.Core.Burn.Bundles
         /// <returns>Burn reader.</returns>
         public static BurnReader Open(IMessaging messaging, IFileSystem fileSystem, string fileExe)
         {
-            var binaryReader = new BinaryReader(fileSystem.OpenFile(fileExe, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete));
+            var binaryReader = new BinaryReader(fileSystem.OpenFile(null, fileExe, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete));
             var reader = new BurnReader(messaging, fileSystem, fileExe)
             {
                 binaryReader = binaryReader,
@@ -92,7 +92,7 @@ namespace WixToolset.Core.Burn.Bundles
             var uxContainerSlot = this.AttachedContainers[0];
 
             this.binaryReader.BaseStream.Seek(this.UXAddress, SeekOrigin.Begin);
-            using (Stream tempCab = this.fileSystem.OpenFile(tempCabPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (Stream tempCab = this.fileSystem.OpenFile(null, tempCabPath, FileMode.Create, FileAccess.Write, FileShare.Read))
             {
                 BurnCommon.CopyStream(this.binaryReader.BaseStream, tempCab, (int)uxContainerSlot.Size);
             }
@@ -100,7 +100,7 @@ namespace WixToolset.Core.Burn.Bundles
             var cabinet = new Cabinet(tempCabPath);
             cabinet.Extract(outputDirectory);
 
-            this.fileSystem.MoveFile(manifestOriginalPath, manifestPath);
+            this.fileSystem.MoveFile(null, manifestOriginalPath, manifestPath);
 
             var document = new XmlDocument();
             document.Load(manifestPath);
@@ -117,7 +117,7 @@ namespace WixToolset.Core.Burn.Bundles
                 var sourcePath = Path.Combine(outputDirectory, sourcePathNode.Value);
                 var destinationPath = Path.Combine(outputDirectory, filePathNode.Value);
 
-                this.fileSystem.MoveFile(sourcePath, destinationPath);
+                this.fileSystem.MoveFile(null, sourcePath, destinationPath);
             }
 
             foreach (XmlNode payload in payloads)
@@ -169,7 +169,7 @@ namespace WixToolset.Core.Burn.Bundles
                 var tempCabPath = Path.Combine(tempDirectory, $"a{i}.cab");
 
                 this.binaryReader.BaseStream.Seek(nextAddress, SeekOrigin.Begin);
-                using (Stream tempCab = this.fileSystem.OpenFile(tempCabPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                using (Stream tempCab = this.fileSystem.OpenFile(null, tempCabPath, FileMode.Create, FileAccess.Write, FileShare.Read))
                 {
                     BurnCommon.CopyStream(this.binaryReader.BaseStream, tempCab, (int)cntnr.Size);
                 }
@@ -185,7 +185,7 @@ namespace WixToolset.Core.Burn.Bundles
                 var sourcePath = Path.Combine(outputDirectory, (string)entry.Key);
                 var destinationPath = Path.Combine(outputDirectory, (string)entry.Value);
 
-                this.fileSystem.MoveFile(sourcePath, destinationPath);
+                this.fileSystem.MoveFile(null, sourcePath, destinationPath);
             }
 
             return true;

--- a/src/wix/WixToolset.Core.Burn/Bundles/BurnWriter.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/BurnWriter.cs
@@ -43,14 +43,14 @@ namespace WixToolset.Core.Burn.Bundles
         {
             var writer = new BurnWriter(messaging, fileSystem, fileExe);
 
-            using (var binaryReader = new BinaryReader(fileSystem.OpenFile(fileExe, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete)))
+            using (var binaryReader = new BinaryReader(fileSystem.OpenFile(null, fileExe, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete)))
             {
                 writer.Initialize(binaryReader);
             }
 
             if (!writer.Invalid)
             {
-                writer.binaryWriter = new BinaryWriter(fileSystem.OpenFile(fileExe, FileMode.Open, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete));
+                writer.binaryWriter = new BinaryWriter(fileSystem.OpenFile(null, fileExe, FileMode.Open, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete));
             }
 
             return writer;
@@ -102,12 +102,13 @@ namespace WixToolset.Core.Burn.Bundles
         /// <summary>
         /// Appends a UX or Attached container to the exe and updates the ".wixburn" section data to point to it.
         /// </summary>
+        /// <param name="sourceLineNumbers">Source line numbers for the container.</param>
         /// <param name="fileContainer">File path to append to the current exe.</param>
         /// <param name="container">Container section represented by the fileContainer.</param>
         /// <returns>true if the container data is successfully appended; false otherwise</returns>
-        public bool AppendContainer(string fileContainer, BurnCommon.Container container)
+        public bool AppendContainer(SourceLineNumber sourceLineNumbers, string fileContainer, BurnCommon.Container container)
         {
-            using (var reader = this.fileSystem.OpenFile(fileContainer, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = this.fileSystem.OpenFile(sourceLineNumbers, fileContainer, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 return this.AppendContainer(reader, reader.Length, container);
             }

--- a/src/wix/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
@@ -71,7 +71,7 @@ namespace WixToolset.Core.Burn.Bundles
 
             this.Transfer = this.BackendHelper.CreateFileTransfer(bundleTempPath, this.OutputPath, true, this.BundleSymbol.SourceLineNumbers);
 
-            this.FileSystem.CopyFile(stubFile, bundleTempPath, allowHardlink: false);
+            this.FileSystem.CopyFile(this.BundleSymbol.SourceLineNumbers, stubFile, bundleTempPath, allowHardlink: false);
             File.SetAttributes(bundleTempPath, FileAttributes.Normal);
 
             var fourPartVersion = this.GetFourPartVersion(this.BundleSymbol);
@@ -88,7 +88,7 @@ namespace WixToolset.Core.Burn.Bundles
                 writer.InitializeBundleSectionData(burnStubFile.Length, this.BundleSymbol.BundleId);
 
                 // Always attach the UX container first
-                writer.AppendContainer(this.UXContainer.WorkingPath, BurnWriter.Container.UX);
+                writer.AppendContainer(this.UXContainer.SourceLineNumbers, this.UXContainer.WorkingPath, BurnWriter.Container.UX);
 
                 // Now append all other attached containers
                 foreach (var container in this.Containers)
@@ -98,7 +98,7 @@ namespace WixToolset.Core.Burn.Bundles
                         // The container was only created if it had payloads.
                         if (!String.IsNullOrEmpty(container.WorkingPath) && BurnConstants.BurnUXContainerName != container.Id.Id)
                         {
-                            writer.AppendContainer(container.WorkingPath, BurnWriter.Container.Attached);
+                            writer.AppendContainer(container.SourceLineNumbers, container.WorkingPath, BurnWriter.Container.Attached);
                         }
                     }
                 }

--- a/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleCommand.cs
@@ -38,7 +38,7 @@ namespace WixToolset.Core.Burn.Inscribe
 
             using (var reader = BurnReader.Open(this.Messaging, this.FileSystem, this.InputFilePath))
             {
-                this.FileSystem.CopyFile(this.SignedEngineFile, tempFile, allowHardlink: false);
+                this.FileSystem.CopyFile(null, this.SignedEngineFile, tempFile, allowHardlink: false);
 
                 using (var writer = BurnWriter.Open(this.Messaging, this.FileSystem, tempFile))
                 {
@@ -46,7 +46,7 @@ namespace WixToolset.Core.Burn.Inscribe
                 }
             }
 
-            this.FileSystem.MoveFile(tempFile, this.OutputFile);
+            this.FileSystem.MoveFile(null, tempFile, this.OutputFile);
 
             return inscribed;
         }

--- a/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleEngineCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleEngineCommand.cs
@@ -33,7 +33,7 @@ namespace WixToolset.Core.Burn.Inscribe
             var tempFile = Path.Combine(this.IntermediateFolder, "bundle_engine_unsigned.exe");
 
             using (var reader = BurnReader.Open(this.Messaging, this.FileSystem, this.InputFilePath))
-            using (var writer = this.FileSystem.OpenFile(tempFile, FileMode.Create, FileAccess.Write, FileShare.Read | FileShare.Delete))
+            using (var writer = this.FileSystem.OpenFile(null, tempFile, FileMode.Create, FileAccess.Write, FileShare.Read | FileShare.Delete))
             {
                 reader.Stream.Seek(0, SeekOrigin.Begin);
 
@@ -58,7 +58,7 @@ namespace WixToolset.Core.Burn.Inscribe
                 // TODO: update writer with detached container signatures.
             }
 
-            this.FileSystem.MoveFile(tempFile, this.OutputFile);
+            this.FileSystem.MoveFile(null, tempFile, this.OutputFile);
         }
     }
 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/AssemblyNameReader.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/AssemblyNameReader.cs
@@ -19,7 +19,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
         {
             try
             {
-                using (var stream = fileSystem.OpenFile(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var stream = fileSystem.OpenFile(sourceLineNumbers, assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (var peReader = new PEReader(stream))
                 {
                     var reader = peReader.GetMetadataReader();

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/AssignMediaCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/AssignMediaCommand.cs
@@ -60,7 +60,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             }
 
             // If neither symbol is authored, default to a media template.
-            if (SectionType.Product == this.Section.Type && mediaTemplateSymbols.Count == 0 && mediaSymbols.Count == 0)
+            if (SectionType.Package == this.Section.Type && mediaTemplateSymbols.Count == 0 && mediaSymbols.Count == 0)
             {
                 var mediaTemplate = new WixMediaTemplateSymbol()
                 {
@@ -166,7 +166,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             {
                 // When building a product, if the current file is not to be compressed or if
                 // the package set not to be compressed, don't cab it.
-                if (SectionType.Product == this.Section.Type && (facade.Uncompressed || !this.FilesCompressed))
+                if (SectionType.Package == this.Section.Type && (facade.Uncompressed || !this.FilesCompressed))
                 {
                     uncompressedFiles.Add(facade);
                     continue;
@@ -265,7 +265,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 // the package set not to be compressed, don't cab it.
                 var compressed = facade.Compressed;
                 var uncompressed = facade.Uncompressed;
-                if (SectionType.Product == this.Section.Type && (uncompressed || (!compressed && !this.FilesCompressed)))
+                if (SectionType.Package == this.Section.Type && (uncompressed || (!compressed && !this.FilesCompressed)))
                 {
                     uncompressedFiles.Add(facade);
                 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -171,12 +171,6 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 command.Execute();
             }
 
-            if (section.Type == SectionType.Product || section.Type == SectionType.Module)
-            {
-                var command = new AddRequiredStandardDirectories(section, platform);
-                command.Execute();
-            }
-
             {
                 var command = new CreateSpecialPropertiesCommand(section);
                 command.Execute();

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -212,7 +212,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
                 if (softwareTags.Any())
                 {
-                    var command = new ProcessPackageSoftwareTagsCommand(section, this.WindowsInstallerBackendHelper, softwareTags, this.IntermediateFolder);
+                    var command = new ProcessPackageSoftwareTagsCommand(section, this.WindowsInstallerBackendHelper, this.FileSystem, softwareTags, this.IntermediateFolder);
                     command.Execute();
 
                     trackedFiles.AddRange(command.TrackedFiles);

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -109,7 +109,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
             var section = this.Intermediate.Sections.Single();
 
-            var packageSymbol = (section.Type == SectionType.Product) ? this.GetSingleSymbol<WixPackageSymbol>(section) : null;
+            var packageSymbol = (section.Type == SectionType.Package) ? this.GetSingleSymbol<WixPackageSymbol>(section) : null;
             var moduleSymbol = (section.Type == SectionType.Module) ? this.GetSingleSymbol<WixModuleSymbol>(section) : null;
             var patchSymbol = (section.Type == SectionType.Patch) ? this.GetSingleSymbol<WixPatchSymbol>(section) : null;
 
@@ -127,7 +127,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 tableDefinitions = command.TableDefinitions;
             }
 
-            if (section.Type == SectionType.Product)
+            if (section.Type == SectionType.Package)
             {
                 this.ProcessProductVersion(packageSymbol, section, validate: false);
             }
@@ -188,7 +188,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             }
 
             // Process dependency references.
-            if (SectionType.Product == section.Type || SectionType.Module == section.Type)
+            if (SectionType.Package == section.Type || SectionType.Module == section.Type)
             {
                 var dependencyRefs = section.Symbols.OfType<WixDependencyRefSymbol>().ToList();
 
@@ -200,7 +200,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             }
 
             // Process SoftwareTags in MSI packages.
-            if (SectionType.Product == section.Type)
+            if (SectionType.Package == section.Type)
             {
                 var softwareTags = section.Symbols.OfType<WixPackageTagSymbol>().ToList();
 
@@ -250,7 +250,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             }
 
             // Retrieve file information from merge modules.
-            if (SectionType.Product == section.Type)
+            if (SectionType.Package == section.Type)
             {
                 var wixMergeSymbols = section.Symbols.OfType<WixMergeSymbol>().ToList();
 
@@ -293,7 +293,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
             // Now that delayed fields are processed, fixup the package version (if needed) and validate it
             // which will short circuit duplicate errors later if the ProductVersion is invalid.
-            if (SectionType.Product == section.Type)
+            if (SectionType.Package == section.Type)
             {
                 this.ProcessProductVersion(packageSymbol, section, validate: true);
             }
@@ -330,7 +330,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 }
             }
 
-            if (SectionType.Product == section.Type)
+            if (SectionType.Package == section.Type)
             {
                 var command = new ValidateWindowsInstallerProductConstraints(this.Messaging, section);
                 command.Execute();
@@ -402,7 +402,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 var unsuppress = new AddBackSuppressedSequenceTablesCommand(data, tableDefinitions);
                 suppressedTableNames = unsuppress.Execute();
             }
-            else if (data.Type == OutputType.Product) // we can create instance transforms since Component Guids and Outputs are created.
+            else if (data.Type == OutputType.Package) // we can create instance transforms since Component Guids and Outputs are created.
             {
                 var command = new CreateInstanceTransformsCommand(section, data, tableDefinitions, this.WindowsInstallerBackendHelper);
                 command.Execute();

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindTransformCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindTransformCommand.cs
@@ -401,7 +401,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             {
                 if (!String.IsNullOrEmpty(emptyFile))
                 {
-                    using (var fileStream = this.FileSystem.OpenFile(emptyFile, FileMode.Create, FileAccess.Write, FileShare.None))
+                    using (var fileStream = this.FileSystem.OpenFile(null, emptyFile, FileMode.Create, FileAccess.Write, FileShare.None))
                     {
                     }
                 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreatePatchTransformsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreatePatchTransformsCommand.cs
@@ -108,7 +108,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 var exportBasePath = Path.Combine(this.IntermediateFolder, stageFolder);
                 var extractFilesFolder = Path.Combine(exportBasePath, "File");
 
-                var command = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, path, null, OutputType.Product, exportBasePath, extractFilesFolder, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: false);
+                var command = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, path, null, OutputType.Package, exportBasePath, extractFilesFolder, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: false);
                 data = command.Execute();
             }
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -1389,7 +1389,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                     this.Data.EnsureTable(this.TableDefinitions["Properties"]);
                     break;
 
-                case OutputType.Product:
+                case OutputType.Package:
                     this.Data.EnsureTable(this.TableDefinitions["File"]);
                     this.Data.EnsureTable(this.TableDefinitions["Media"]);
                     break;
@@ -1476,7 +1476,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                         }
                         break;
 
-                    case OutputType.Product:
+                    case OutputType.Package:
                         if ("ModuleAdminExecuteSequence" == table.Name ||
                             "ModuleAdminUISequence" == table.Name ||
                             "ModuleAdvtExecuteSequence" == table.Name ||
@@ -1540,7 +1540,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             }
 
             // Ensure the Error table exists if output is marked for MSI 1.0 or below (see ICE40).
-            if (outputInstallerVersion <= 100 && OutputType.Product == this.Data.Type)
+            if (outputInstallerVersion <= 100 && OutputType.Package == this.Data.Type)
             {
                 this.Data.EnsureTable(this.TableDefinitions["Error"]);
             }
@@ -1581,8 +1581,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                     return OutputType.Bundle;
                 case SectionType.Module:
                     return OutputType.Module;
-                case SectionType.Product:
-                    return OutputType.Product;
+                case SectionType.Package:
+                    return OutputType.Package;
                 case SectionType.PatchCreation:
                     return OutputType.PatchCreation;
                 case SectionType.Patch:

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/FileSystemManager.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/FileSystemManager.cs
@@ -5,7 +5,6 @@ namespace WixToolset.Core.WindowsInstaller.Bind
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Runtime.CompilerServices;
     using WixToolset.Extensibility;
     using WixToolset.Extensibility.Services;
 
@@ -42,8 +41,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 return true;
             }
 
-            using (var firstStream = this.FileSystem.OpenFile(firstPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var secondStream = this.FileSystem.OpenFile(secondPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var firstStream = this.FileSystem.OpenFile(null, firstPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var secondStream = this.FileSystem.OpenFile(null, secondPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 if (firstStream.Length != secondStream.Length)
                 {

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPackageSoftwareTagsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPackageSoftwareTagsCommand.cs
@@ -15,10 +15,11 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
     internal class ProcessPackageSoftwareTagsCommand
     {
-        public ProcessPackageSoftwareTagsCommand(IntermediateSection section, IBackendHelper backendHelper, IEnumerable<WixPackageTagSymbol> softwareTags, string intermediateFolder)
+        public ProcessPackageSoftwareTagsCommand(IntermediateSection section, IBackendHelper backendHelper, IFileSystem fileSystem, IEnumerable<WixPackageTagSymbol> softwareTags, string intermediateFolder)
         {
             this.Section = section;
             this.BackendHelper = backendHelper;
+            this.FileSystem = fileSystem;
             this.SoftwareTags = softwareTags;
             this.IntermediateFolder = intermediateFolder;
         }
@@ -28,6 +29,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
         private IntermediateSection Section { get; }
 
         private IBackendHelper BackendHelper { get; }
+
+        private IFileSystem FileSystem { get; }
 
         private IEnumerable<WixPackageTagSymbol> SoftwareTags { get; }
 
@@ -61,7 +64,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
                     trackedFiles.Add(this.BackendHelper.TrackFile(fileSymbol.Source.Path, TrackedFileType.Intermediate, tagRow.SourceLineNumbers));
 
-                    using (var fs = new FileStream(fileSymbol.Source.Path, FileMode.Create))
+                    using (var fs = this.FileSystem.OpenFile(fileSymbol.SourceLineNumbers, fileSymbol.Source.Path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read))
                     {
                         CreateTagFile(fs, uniqueId, packageSymbol.Name, packageSymbol.Version, tagRow.Regid, packageSymbol.Manufacturer, persistentId);
                     }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPropertiesCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/ProcessPropertiesCommand.cs
@@ -39,7 +39,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             PropertySymbol languageSymbol = null;
             var variableCache = this.PopulateDelayedVariables ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) : null;
 
-            if (SectionType.Product == this.Section.Type || variableCache != null)
+            if (SectionType.Package == this.Section.Type || variableCache != null)
             {
                 foreach (var propertySymbol in this.Section.Symbols.OfType<PropertySymbol>())
                 {
@@ -60,7 +60,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                     }
                 }
 
-                if (this.Section.Type == SectionType.Product && String.IsNullOrEmpty(languageSymbol?.Value))
+                if (this.Section.Type == SectionType.Package && String.IsNullOrEmpty(languageSymbol?.Value))
                 {
                     if (languageSymbol == null)
                     {

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
@@ -343,7 +343,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             var set = new HashSet<string>();
 
             // gather the required actions for the output type
-            if (SectionType.Product == this.Section.Type)
+            if (SectionType.Package == this.Section.Type)
             {
                 // AdminExecuteSequence table
                 set.Add("AdminExecuteSequence/CostFinalize");

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateFileFacadesCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateFileFacadesCommand.cs
@@ -84,7 +84,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 return;
             }
 
-            using (var fileStream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var fileStream = this.FileSystem.OpenFile(facade.SourceLineNumber, fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 if (Int32.MaxValue < fileStream.Length)
                 {

--- a/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/DecompilerSubcommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/DecompilerSubcommand.cs
@@ -207,7 +207,7 @@ namespace WixToolset.Core.WindowsInstaller.CommandLine
                 case "package":
                 case "msi":
                 case ".msi":
-                    decompileType = OutputType.Product;
+                    decompileType = OutputType.Package;
                     break;
 
                 case "mergemodule":
@@ -231,7 +231,7 @@ namespace WixToolset.Core.WindowsInstaller.CommandLine
         {
             switch (decompileType)
             {
-                case OutputType.Product:
+                case OutputType.Package:
                     return this.SaveAsData ? ".wixmsi" : ".wxs";
 
                 case OutputType.Module:

--- a/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/TransformSubcommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/TransformSubcommand.cs
@@ -382,7 +382,7 @@ namespace WixToolset.Core.WindowsInstaller.CommandLine
         {
             if (!DataLoader.TryLoadWindowsInstallerData(path, out var data))
             {
-                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, path, null, OutputType.Product, this.ExportBasePath, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: false);
+                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, path, null, OutputType.Package, this.ExportBasePath, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: false);
                 data = unbindCommand.Execute();
             }
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
@@ -136,7 +136,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                 case OutputType.PatchCreation:
                     this.DecompilerHelper.RootElement = new XElement(Names.PatchCreationElement);
                     break;
-                case OutputType.Product:
+                case OutputType.Package:
                     this.DecompilerHelper.RootElement = new XElement(Names.PackageElement);
                     break;
                 default:
@@ -1234,7 +1234,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                     {
                         xFile.SetAttributeValue("Source", String.Concat(this.BaseSourcePath, Path.DirectorySeparatorChar, "File", Path.DirectorySeparatorChar, fileId, '.', this.ModularizationGuid.Substring(1, 36).Replace('-', '_')));
                     }
-                    else if (fileCompressed == "yes" || (fileCompressed != "no" && this.Compressed) || (OutputType.Product == this.OutputType && this.TreatProductAsModule))
+                    else if (fileCompressed == "yes" || (fileCompressed != "no" && this.Compressed) || (OutputType.Package == this.OutputType && this.TreatProductAsModule))
                     {
                         xFile.SetAttributeValue("Source", String.Concat(this.BaseSourcePath, Path.DirectorySeparatorChar, "File", Path.DirectorySeparatorChar, fileId));
                     }
@@ -1940,7 +1940,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
         private void FinalizeSequenceTables(TableIndexedCollection tables)
         {
             // finalize the normal sequence tables
-            if (OutputType.Product == this.OutputType && !this.TreatProductAsModule)
+            if (OutputType.Package == this.OutputType && !this.TreatProductAsModule)
             {
                 foreach (SequenceTable sequenceTable in Enum.GetValues(typeof(SequenceTable)))
                 {
@@ -3009,7 +3009,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
         {
             var table = tables["_SummaryInformation"];
 
-            if (OutputType.Module == this.OutputType || OutputType.Product == this.OutputType)
+            if (OutputType.Module == this.OutputType || OutputType.Package == this.OutputType)
             {
                 var xSummaryInformation = new XElement(Names.SummaryInformationElement);
 
@@ -3071,7 +3071,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                                 if (0x1 == (wordCount & 0x1))
                                 {
                                     this.ShortNames = true;
-                                    if (OutputType.Product == this.OutputType)
+                                    if (OutputType.Package == this.OutputType)
                                     {
                                         this.DecompilerHelper.RootElement.SetAttributeValue("ShortNames", "yes");
                                     }
@@ -3082,7 +3082,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                                     this.Compressed = true;
                                 }
 
-                                if (OutputType.Product == this.OutputType)
+                                if (OutputType.Package == this.OutputType)
                                 {
                                     if (0x8 == (wordCount & 0x8))
                                     {
@@ -3103,7 +3103,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                     }
                 }
 
-                if (OutputType.Product == this.OutputType && !this.Compressed)
+                if (OutputType.Package == this.OutputType && !this.Compressed)
                 {
                     this.DecompilerHelper.RootElement.SetAttributeValue("Compressed", "no");
                 }
@@ -6245,7 +6245,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
 
                     continue;
                 }
-                else if (OutputType.Product == this.OutputType)
+                else if (OutputType.Package == this.OutputType)
                 {
                     switch (id)
                     {
@@ -7522,7 +7522,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
         private void SetPrimaryFeature(Row row, int featureColumnIndex, int componentColumnIndex)
         {
             // only products contain primary features
-            if (OutputType.Product == this.OutputType)
+            if (OutputType.Package == this.OutputType)
             {
                 var featureField = row.Fields[featureColumnIndex];
                 var componentField = row.Fields[componentColumnIndex];

--- a/src/wix/WixToolset.Core.WindowsInstaller/Inscribe/InscribeMsiPackageCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Inscribe/InscribeMsiPackageCommand.cs
@@ -51,7 +51,7 @@ namespace WixToolset.Core.WindowsInstaller.Inscribe
 
             if (!String.Equals(this.InputPath, this.OutputPath, StringComparison.OrdinalIgnoreCase))
             {
-                this.FileSystem.CopyFile(this.InputPath, this.OutputPath, allowHardlink: false);
+                this.FileSystem.CopyFile(null, this.InputPath, this.OutputPath, allowHardlink: false);
             }
 
             var attributes = File.GetAttributes(databasePath);
@@ -98,7 +98,7 @@ namespace WixToolset.Core.WindowsInstaller.Inscribe
                                 Directory.CreateDirectory(hashPath);
                                 hashPath = Path.Combine(hashPath, hashFileName);
 
-                                using (var fs = this.FileSystem.OpenFile(hashPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                                using (var fs = this.FileSystem.OpenFile(null, hashPath, FileMode.Create, FileAccess.Write, FileShare.None))
                                 {
                                     int bytesRead;
                                     var buffer = new byte[1024 * 4];
@@ -129,7 +129,7 @@ namespace WixToolset.Core.WindowsInstaller.Inscribe
                             Directory.CreateDirectory(certPath);
                             certPath = Path.Combine(certPath, String.Concat(certificateId, ".cer"));
 
-                            using (var fs = this.FileSystem.OpenFile(certPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                            using (var fs = this.FileSystem.OpenFile(null, certPath, FileMode.Create, FileAccess.Write, FileShare.None))
                             {
                                 int bytesRead;
                                 var buffer = new byte[1024 * 4];
@@ -223,9 +223,9 @@ namespace WixToolset.Core.WindowsInstaller.Inscribe
                             var certPath = Path.Combine(this.IntermediateFolder, "MsiDigitalCertificate");
                             Directory.CreateDirectory(certPath);
                             certPath = Path.Combine(certPath, String.Concat(cert2.Thumbprint, ".cer"));
-                            this.FileSystem.DeleteFile(certPath, true);
+                            this.FileSystem.DeleteFile(null, certPath, true);
 
-                            using (var writer = new BinaryWriter(this.FileSystem.OpenFile(certPath, FileMode.Create, FileAccess.Write, FileShare.Read)))
+                            using (var writer = new BinaryWriter(this.FileSystem.OpenFile(null, certPath, FileMode.Create, FileAccess.Write, FileShare.Read)))
                             {
                                 writer.Write(cert2.RawData);
                                 writer.Close();

--- a/src/wix/WixToolset.Core.WindowsInstaller/Melter.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Melter.cs
@@ -84,7 +84,7 @@ namespace WixToolset
 
             PreDecompile(wixout);
 
-            wixout.Type = OutputType.Product;
+            wixout.Type = OutputType.Package;
             this.decompiler.TreatProductAsModule = true;
             Wix.Wix wix = this.decompiler.Decompile(wixout);
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
@@ -97,6 +97,8 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
                         {
                             if (null != record)
                             {
+                                embeddedCabinetRowsByDiskId.TryGetValue(diskId, out var cabinetMediaRow);
+
                                 // since the cabinets are stored in case-sensitive streams inside the msi, but the file system is not (typically) case-sensitive,
                                 // embedded cabinets must be extracted to a canonical file name (like their diskid) to ensure extraction will always work
                                 var cabinetPath = Path.Combine(this.IntermediateFolder, "Media", diskId.ToString(CultureInfo.InvariantCulture), ".cab");
@@ -104,7 +106,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
                                 // ensure the parent directory exists
                                 Directory.CreateDirectory(Path.GetDirectoryName(cabinetPath));
 
-                                using (var fs = this.FileSystem.OpenFile(cabinetPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                                using (var fs = this.FileSystem.OpenFile(cabinetMediaRow.SourceLineNumbers, cabinetPath, FileMode.Create, FileAccess.Write, FileShare.None))
                                 {
                                     int bytesRead;
                                     var buffer = new byte[4096];
@@ -115,7 +117,6 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
                                     }
                                 }
 
-                                embeddedCabinetRowsByDiskId.TryGetValue(diskId, out var cabinetMediaRow);
                                 cabinetPathsWithMediaRow.Add(cabinetPath, cabinetMediaRow);
                             }
                             else

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
@@ -61,7 +61,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             {
                 foreach (var mediaRow in mediaTable.Rows.Cast<MediaRow>().Where(r => !String.IsNullOrEmpty(r.Cabinet)))
                 {
-                    if (OutputType.Product == this.Output.Type ||
+                    if (OutputType.Package == this.Output.Type ||
                         (OutputType.Transform == this.Output.Type && RowOperation.Add == mediaRow.Operation))
                     {
                         if (mediaRow.Cabinet.StartsWith("#", StringComparison.Ordinal))

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindDatabaseCommand.cs
@@ -206,7 +206,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
 
                                                     Directory.CreateDirectory(Path.Combine(this.ExportBasePath, tableName));
 
-                                                    using (var fs = this.FileSystem.OpenFile(source, FileMode.Create, FileAccess.Write, FileShare.None))
+                                                    using (var fs = this.FileSystem.OpenFile(null, source, FileMode.Create, FileAccess.Write, FileShare.None))
                                                     {
                                                         int bytesRead;
                                                         var buffer = new byte[4096];

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
@@ -98,7 +98,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
         {
             var schemaData = new WindowsInstallerData(new SourceLineNumber(schemaDatabasePath))
             {
-                Type = OutputType.Product,
+                Type = OutputType.Package,
             };
 
             foreach (var tableDefinition in this.TableDefinitions)
@@ -119,7 +119,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             using (var msiDatabase = this.ApplyTransformToSchemaDatabase(schemaDatabasePath, TransformErrorConditions.All | TransformErrorConditions.ViewTransform))
             {
                 // unbind the database
-                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, schemaDatabasePath, msiDatabase, OutputType.Product, null, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: true);
+                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, schemaDatabasePath, msiDatabase, OutputType.Package, null, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: true);
                 var transformViewOutput = unbindCommand.Execute();
 
                 return transformViewOutput.Tables["_TransformView"];
@@ -180,7 +180,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             {
 
                 // unbind the database
-                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, schemaDatabasePath, database, OutputType.Product, this.ExportBasePath, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: true);
+                var unbindCommand = new UnbindDatabaseCommand(this.Messaging, this.BackendHelper, this.FileSystem, this.PathResolver, schemaDatabasePath, database, OutputType.Package, this.ExportBasePath, null, this.IntermediateFolder, enableDemodularization: false, skipSummaryInfo: true);
                 output = unbindCommand.Execute();
             }
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Unbind/UnbindTransformCommand.cs
@@ -327,7 +327,7 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
                         if (null == this.EmptyFile)
                         {
                             this.EmptyFile = Path.Combine(this.IntermediateFolder, ".empty");
-                            using (var fileStream = this.FileSystem.OpenFile(this.EmptyFile, FileMode.Create, FileAccess.Write, FileShare.None))
+                            using (var fileStream = this.FileSystem.OpenFile(null, this.EmptyFile, FileMode.Create, FileAccess.Write, FileShare.None))
                             {
                             }
                         }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Validate/ValidateDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Validate/ValidateDatabaseCommand.cs
@@ -71,7 +71,7 @@ namespace WixToolset.Core.WindowsInstaller.Validate
             var workingDatabasePath = Path.Combine(this.IntermediateFolder, workingDatabaseFilename);
             try
             {
-                this.FileSystem.CopyFile(this.DatabasePath, workingDatabasePath, allowHardlink: false);
+                this.FileSystem.CopyFile(null, this.DatabasePath, workingDatabasePath, allowHardlink: false);
 
                 var attributes = File.GetAttributes(workingDatabasePath);
                 File.SetAttributes(workingDatabasePath, attributes & ~FileAttributes.ReadOnly);
@@ -81,7 +81,7 @@ namespace WixToolset.Core.WindowsInstaller.Validate
             }
             finally
             {
-                this.FileSystem.DeleteFile(workingDatabasePath);
+                this.FileSystem.DeleteFile(null, workingDatabasePath);
             }
 
             stopwatch.Stop();

--- a/src/wix/WixToolset.Core/Bind/TransferFilesCommand.cs
+++ b/src/wix/WixToolset.Core/Bind/TransferFilesCommand.cs
@@ -53,12 +53,12 @@ namespace WixToolset.Core.Bind
                         if (fileTransfer.Move)
                         {
                             this.Messaging.Write(VerboseMessages.MoveFile(fileTransfer.Source, fileTransfer.Destination));
-                            this.MoveFile(fileTransfer.Source, fileTransfer.Destination);
+                            this.MoveFile(fileTransfer.SourceLineNumbers, fileTransfer.Source, fileTransfer.Destination);
                         }
                         else
                         {
                             this.Messaging.Write(VerboseMessages.CopyFile(fileTransfer.Source, fileTransfer.Destination));
-                            this.CopyFile(fileTransfer.Source, fileTransfer.Destination);
+                            this.CopyFile(fileTransfer.SourceLineNumbers, fileTransfer.Source, fileTransfer.Destination);
                         }
 
                         retry = false;
@@ -170,7 +170,7 @@ namespace WixToolset.Core.Bind
             }
         }
 
-        private void CopyFile(string source, string destination)
+        private void CopyFile(SourceLineNumber sourceLineNumbers, string source, string destination)
         {
             foreach (var extension in this.Extensions)
             {
@@ -180,10 +180,10 @@ namespace WixToolset.Core.Bind
                 }
             }
 
-            this.FileSystem.CopyFile(source, destination, allowHardlink: true);
+            this.FileSystem.CopyFile(sourceLineNumbers, source, destination, allowHardlink: true);
         }
 
-        private void MoveFile(string source, string destination)
+        private void MoveFile(SourceLineNumber sourceLineNumbers, string source, string destination)
         {
             foreach (var extension in this.Extensions)
             {
@@ -193,7 +193,7 @@ namespace WixToolset.Core.Bind
                 }
             }
 
-            this.FileSystem.MoveFile(source, destination);
+            this.FileSystem.MoveFile(sourceLineNumbers, source, destination);
         }
 
         private void AclReset(IEnumerable<string> files)

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -418,7 +418,7 @@ namespace WixToolset.Core.CommandLine
                     return ".exe";
                 case SectionType.Module:
                     return ".msm";
-                case SectionType.Product:
+                case SectionType.Package:
                     return ".msi";
                 case SectionType.PatchCreation:
                     return ".pcp";
@@ -445,7 +445,7 @@ namespace WixToolset.Core.CommandLine
                     return ".msp";
                 case OutputType.PatchCreation:
                     return ".pcp";
-                case OutputType.Product:
+                case OutputType.Package:
                     return ".msi";
                 case OutputType.Transform:
                     return ".mst";
@@ -701,7 +701,7 @@ namespace WixToolset.Core.CommandLine
                     case "product":
                     case "package":
                     case ".msi":
-                        return Data.OutputType.Product;
+                        return Data.OutputType.Package;
 
                     case "transform":
                     case ".mst":

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -7131,6 +7131,11 @@ namespace WixToolset.Core
                     this.Core.ParseExtensionElement(node, child);
                 }
             }
+
+            if (!this.Core.EncounteredError)
+            {
+                this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, id);
+            }
         }
 
         /// <summary>

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -157,7 +157,7 @@ namespace WixToolset.Core
             try
             {
                 this.compilingProduct = true;
-                this.Core.CreateActiveSection(productCode, SectionType.Product, this.Context.CompilationId);
+                this.Core.CreateActiveSection(productCode, SectionType.Package, this.Context.CompilationId);
 
                 this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "Manufacturer"), manufacturer, false, false, false, true);
                 this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "ProductCode"), productCode, false, false, false, true);

--- a/src/wix/WixToolset.Core/CoreErrors.cs
+++ b/src/wix/WixToolset.Core/CoreErrors.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using WixToolset.Data;
+
+    internal static class CoreErrors
+    {
+        public static Message UnableToCopyFile(SourceLineNumber sourceLineNumbers, string source, string destination, string detail)
+        {
+            return Message(sourceLineNumbers, Ids.UnableToCopyFile, "Unable to copy file from: {0}, to: {1}. Error detail: {2}", source, destination, detail);
+        }
+
+        public static Message UnableToDeleteFile(SourceLineNumber sourceLineNumbers, string path, string detail)
+        {
+            return Message(sourceLineNumbers, Ids.UnableToDeleteFile, "Unable to delete file: {0}. Error detail: {1}", path, detail);
+        }
+
+        public static Message UnableToMoveFile(SourceLineNumber sourceLineNumbers, string source, string destination, string detail)
+        {
+            return Message(sourceLineNumbers, Ids.UnableToMoveFile, "Unable to move file from: {0}, to: {1}. Error detail: {2}", source, destination, detail);
+        }
+
+        public static Message UnableToOpenFile(SourceLineNumber sourceLineNumbers, string path, string detail)
+        {
+            return Message(sourceLineNumbers, Ids.UnableToOpenFile, "Unable to open file: {0}. Error detail: {1}", path, detail);
+        }
+
+        private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
+        {
+            return new Message(sourceLineNumber, MessageLevel.Error, (int)id, format, args);
+        }
+
+        public enum Ids
+        {
+            UnableToCopyFile = 7010,
+            UnableToDeleteFile = 7011,
+            UnableToMoveFile = 7012,
+            UnableToOpenFile = 7013,
+        } // last available is 7099. 7100 is WindowsInstallerBackendWarnings.
+    }
+}

--- a/src/wix/WixToolset.Core/LayoutCreator.cs
+++ b/src/wix/WixToolset.Core/LayoutCreator.cs
@@ -114,7 +114,7 @@ namespace WixToolset.Core
             {
                 this.SplitUniqueFolders(intermediateFolder, tempPath, uniqueFolders);
 
-                this.FileSystem.DeleteFile(tempPath);
+                this.FileSystem.DeleteFile(null, tempPath);
             }
 
             // Clean up empty temp folders.

--- a/src/wix/WixToolset.Core/Link/FindEntrySectionAndLoadSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/FindEntrySectionAndLoadSymbolsCommand.cs
@@ -58,7 +58,7 @@ namespace WixToolset.Core.Link
             foreach (var section in this.Sections)
             {
                 // Try to find the one and only entry section.
-                if (SectionType.Product == section.Type || SectionType.Module == section.Type || SectionType.PatchCreation == section.Type || SectionType.Patch == section.Type || SectionType.Bundle == section.Type)
+                if (SectionType.Package == section.Type || SectionType.Module == section.Type || SectionType.PatchCreation == section.Type || SectionType.Patch == section.Type || SectionType.Bundle == section.Type)
                 {
                     // TODO: remove this?
                     //if (SectionType.Unknown != expectedEntrySectionType && section.Type != expectedEntrySectionType)

--- a/src/wix/WixToolset.Core/Linker.cs
+++ b/src/wix/WixToolset.Core/Linker.cs
@@ -193,49 +193,49 @@ namespace WixToolset.Core
                         switch (symbol.Definition.Type)
                         {
                             case SymbolDefinitionType.Class:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)ClassSymbolFields.ComponentRef, (int)ClassSymbolFields.FeatureRef, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.Extension:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)ExtensionSymbolFields.ComponentRef, (int)ExtensionSymbolFields.FeatureRef, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.Assembly:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)AssemblySymbolFields.ComponentRef, (int)AssemblySymbolFields.FeatureRef, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.PublishComponent:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)PublishComponentSymbolFields.ComponentRef, (int)PublishComponentSymbolFields.FeatureRef, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.Shortcut:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)ShortcutSymbolFields.ComponentRef, (int)ShortcutSymbolFields.Target, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.TypeLib:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, (int)TypeLibSymbolFields.ComponentRef, (int)TypeLibSymbolFields.FeatureRef, componentsToFeatures, multipleFeatureComponents);
                                 }
                                 break;
 
                             case SymbolDefinitionType.WixMerge:
-                                if (SectionType.Product == resolvedSection.Type)
+                                if (SectionType.Package == resolvedSection.Type)
                                 {
                                     this.ResolveFeatures(symbol, -1, (int)WixMergeSymbolFields.FeatureRef, modulesToFeatures, null);
                                 }
@@ -288,7 +288,7 @@ namespace WixToolset.Core
                     var command = new FlattenAndProcessBundleTablesCommand(resolvedSection, this.Messaging);
                     command.Execute();
                 }
-                else if (resolvedSection.Type == SectionType.Product || resolvedSection.Type == SectionType.Module)
+                else if (resolvedSection.Type == SectionType.Package || resolvedSection.Type == SectionType.Module)
                 {
                     // Packages and modules get standard directories add.
                     var command = new AddRequiredStandardDirectories(resolvedSection, references);

--- a/src/wix/WixToolset.Core/Linker.cs
+++ b/src/wix/WixToolset.Core/Linker.cs
@@ -90,8 +90,6 @@ namespace WixToolset.Core
                     }
                 }
 
-                //this.activeOutput = null;
-
                 var multipleFeatureComponents = new Hashtable();
 
                 var wixVariables = new Dictionary<string, WixVariableSymbol>();
@@ -178,6 +176,7 @@ namespace WixToolset.Core
                 // Create a new section to hold the linked content. Start with the entry section's
                 // metadata.
                 var resolvedSection = new IntermediateSection(find.EntrySection.Id, find.EntrySection.Type);
+                var references = new List<WixSimpleReferenceSymbol>();
 
                 foreach (var section in sections)
                 {
@@ -248,6 +247,7 @@ namespace WixToolset.Core
 
                             case SymbolDefinitionType.WixSimpleReference:
                                 copySymbol = false;
+                                references.Add(symbol as WixSimpleReferenceSymbol);
                                 break;
 
                             case SymbolDefinitionType.WixVariable:
@@ -286,6 +286,12 @@ namespace WixToolset.Core
                 if (resolvedSection.Type == SectionType.Bundle)
                 {
                     var command = new FlattenAndProcessBundleTablesCommand(resolvedSection, this.Messaging);
+                    command.Execute();
+                }
+                else if (resolvedSection.Type == SectionType.Product || resolvedSection.Type == SectionType.Module)
+                {
+                    // Packages and modules get standard directories add.
+                    var command = new AddRequiredStandardDirectories(resolvedSection, references);
                     command.Execute();
                 }
 

--- a/src/wix/WixToolset.Sdk/tools/wix.targets
+++ b/src/wix/WixToolset.Sdk/tools/wix.targets
@@ -519,7 +519,7 @@
     ================================================================================================
                                         GetTargetPath - OVERRIDE DependsOn
 
-    This stand-alone target returns the name of the build product (i.e. MSI, MSM) that would be
+    This stand-alone target returns the name of the build package (i.e. MSI, MSM) that would be
     produced if we built this project.
     ================================================================================================
     -->

--- a/src/wix/test/WixToolsetTest.CoreIntegration/DirectoryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/DirectoryFixture.cs
@@ -97,7 +97,8 @@ namespace WixToolsetTest.CoreIntegration
             {
                 var baseFolder = fs.GetFolder();
                 var intermediateFolder = Path.Combine(baseFolder, "obj");
-                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+                var msiPath = Path.Combine(baseFolder, "bin", "test.msi");
+                var wixpdbPath = Path.Combine(baseFolder, "bin", "test.wixpdb");
 
                 var result = WixRunner.Execute(new[]
                 {
@@ -111,7 +112,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 result.AssertSuccess();
 
-                var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
+                var intermediate = Intermediate.Load(wixpdbPath);
                 var section = intermediate.Sections.Single();
 
                 var dirSymbols = section.Symbols.OfType<WixToolset.Data.Symbols.DirectorySymbol>().ToList();
@@ -119,70 +120,23 @@ namespace WixToolsetTest.CoreIntegration
                 {
                     "BinFolder\tCompanyFolder\t.",
                     "CompanyFolder\tProgramFilesFolder\tExample Corporation",
+                    "DesktopFolder\tTARGETDIR\tDesktop",
                     "ProgramFilesFolder\tTARGETDIR\tPFiles",
+                    "ProgramMenuFolder\tTARGETDIR\tPMenu",
                     "TARGETDIR\t\tSourceDir"
-                }, dirSymbols.OrderBy(d => d.Id.Id).Select(d => String.Join('\t', d.Id.Id, d.ParentDirectoryRef, d.Name)).ToArray());
+                }, dirSymbols.Select(d => String.Join('\t', d.Id.Id, d.ParentDirectoryRef, d.Name)).OrderBy(s => s).ToArray());
 
-                var data = WindowsInstallerData.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
+                var data = WindowsInstallerData.Load(wixpdbPath);
                 var directoryRows = data.Tables["Directory"].Rows;
                 WixAssert.CompareLineByLine(new[]
                 {
                     "BinFolder\tCompanyFolder\t.",
                     "CompanyFolder\tProgramFilesFolder\tu7-b4gch|Example Corporation",
+                    "DesktopFolder\tTARGETDIR\tDesktop",
                     "ProgramFilesFolder\tTARGETDIR\tPFiles",
+                    "ProgramMenuFolder\tTARGETDIR\tPMenu",
                     "TARGETDIR\t\tSourceDir"
-                }, directoryRows.Select(r => String.Join('\t', r.FieldAsString(0), r.FieldAsString(1), r.FieldAsString(2))).ToArray());
-            }
-        }
-
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/6977")]
-        public void CanGetEmptyStandardDirectory()
-        {
-            var folder = TestData.Get(@"TestData");
-
-            using (var fs = new DisposableFileSystem())
-            {
-                var baseFolder = fs.GetFolder();
-                var intermediateFolder = Path.Combine(baseFolder, "obj");
-                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
-
-                var result = WixRunner.Execute(new[]
-                {
-                    "build",
-                    Path.Combine(folder, "Directory", "DefaultName.wxs"),
-                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
-                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
-                    "-intermediateFolder", intermediateFolder,
-                    "-o", msiPath
-                });
-
-                result.AssertSuccess();
-
-                var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
-                var section = intermediate.Sections.Single();
-
-                var dirSymbols = section.Symbols.OfType<WixToolset.Data.Symbols.DirectorySymbol>().ToList();
-                WixAssert.CompareLineByLine(new[]
-                {
-                    "BinFolder\tCompanyFolder\t.",
-                    "CompanyFolder\tProgramFilesFolder\tExample Corporation",
-                    "DesktopFolder\tTARGETDIR\t.",
-                    "ProgramFilesFolder\tTARGETDIR\tPFiles",
-                    "ProgramMenuFolder\tTARGETDIR\t.",
-                    "TARGETDIR\t\tSourceDir"
-                }, dirSymbols.OrderBy(d => d.Id.Id).Select(d => String.Join('\t', d.Id.Id, d.ParentDirectoryRef, d.Name)).ToArray());
-
-                var data = WindowsInstallerData.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
-                var directoryRows = data.Tables["Directory"].Rows;
-                WixAssert.CompareLineByLine(new[]
-                {
-                    "BinFolder\tCompanyFolder\t.",
-                    "CompanyFolder\tProgramFilesFolder\tu7-b4gch|Example Corporation",
-                    "DesktopFolder\tTARGETDIR\t.",
-                    "ProgramFilesFolder\tTARGETDIR\tPFiles",
-                    "ProgramMenuFolder\tTARGETDIR\t.",
-                    "TARGETDIR\t\tSourceDir"
-                }, directoryRows.Select(r => String.Join('\t', r.FieldAsString(0), r.FieldAsString(1), r.FieldAsString(2))).ToArray());
+                }, directoryRows.Select(r => String.Join('\t', r.FieldAsString(0), r.FieldAsString(1), r.FieldAsString(2))).OrderBy(s => s).ToArray());
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
@@ -20,7 +20,7 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void MustCompileBeforeLinking()
         {
-            var intermediate1 = new Intermediate("TestIntermediate1", new[] { new IntermediateSection("test1", SectionType.Product) }, null);
+            var intermediate1 = new Intermediate("TestIntermediate1", new[] { new IntermediateSection("test1", SectionType.Package) }, null);
             var intermediate2 = new Intermediate("TestIntermediate2", new[] { new IntermediateSection("test2", SectionType.Fragment) }, null);
             var serviceProvider = WixToolsetServiceProviderFactory.CreateServiceProvider();
 


### PR DESCRIPTION
* Provide useful error message when file system operations fail - fixes wixtoolset/issues#5417
* Move Directory code generation to the linker - fixes wixtoolset/issues#6977
* Normalize SectionType and OutputType "Product" to "Package"