### PR TITLE
Latest fixes on path to -rc.1

### DIFF
--- a/src/libs/dutil/WixToolset.DUtil/inc/conutil.h
+++ b/src/libs/dutil/WixToolset.DUtil/inc/conutil.h
@@ -33,16 +33,46 @@ void DAPI ConsoleRed();
 void DAPI ConsoleYellow();
 void DAPI ConsoleNormal();
 
+/********************************************************************
+ ConsoleWrite - full color printfA without libc
+
+ NOTE: only supports ANSI characters
+       assumes already in normal color and resets the screen to normal color
+********************************************************************/
 HRESULT DAPI ConsoleWrite(
     CONSOLE_COLOR cc,
     __in_z __format_string LPCSTR szFormat,
     ...
     );
+
+/********************************************************************
+ ConsoleWriteW - sends UTF-8 characters to console out in color.
+
+ NOTE: assumes already in normal color and resets the screen to normal color
+********************************************************************/
+HRESULT DAPI ConsoleWriteW(
+    __in CONSOLE_COLOR cc,
+    __in_z LPCWSTR wzData
+    );
+
+/********************************************************************
+ ConsoleWriteLine - full color printfA plus newline without libc
+
+ NOTE: only supports ANSI characters
+       assumes already in normal color and resets the screen to normal color
+********************************************************************/
 HRESULT DAPI ConsoleWriteLine(
     CONSOLE_COLOR cc,
     __in_z __format_string LPCSTR szFormat,
     ...
     );
+
+/********************************************************************
+ ConsoleWriteError - display an error to the console out
+
+ NOTE: only supports ANSI characters
+       does not write to stderr
+********************************************************************/
 HRESULT DAPI ConsoleWriteError(
     HRESULT hrError,
     CONSOLE_COLOR cc,
@@ -50,28 +80,58 @@ HRESULT DAPI ConsoleWriteError(
     ...
     );
 
+/********************************************************************
+ ConsoleReadW - reads a line from console in as UTF-8 to populate Unicode buffer
+
+********************************************************************/
 HRESULT DAPI ConsoleReadW(
     __deref_out_z LPWSTR* ppwzBuffer
     );
 
-HRESULT DAPI ConsoleReadStringA(
-    __deref_inout_ecount_part(cchCharBuffer,*pcchNumCharReturn) LPSTR* szCharBuffer,
-    CONST DWORD cchCharBuffer,
-    __out DWORD* pcchNumCharReturn
-    );
-HRESULT DAPI ConsoleReadStringW(
-    __deref_inout_ecount_part(cchCharBuffer,*pcchNumCharReturn) LPWSTR* szCharBuffer,
-    CONST DWORD cchCharBuffer,
-    __out DWORD* pcchNumCharReturn
-    );
+/********************************************************************
+ ConsoleReadNonBlockingW - Read from the console without blocking
+ Won't work for redirected files (exe < txtfile), but will work for stdin redirected to
+ an anonymous or named pipe
 
+ if (fReadLine), stop reading immediately when \r\n is found
+*********************************************************************/
 HRESULT DAPI ConsoleReadNonBlockingW(
     __deref_out_ecount_opt(*pcchSize) LPWSTR* ppwzBuffer,
     __out DWORD* pcchSize,
     BOOL fReadLine
     );
 
+/********************************************************************
+ ConsoleReadStringA - get console input without libc
+
+ NOTE: only supports ANSI characters
+*********************************************************************/
+HRESULT DAPI ConsoleReadStringA(
+    __deref_inout_ecount_part(cchCharBuffer,*pcchNumCharReturn) LPSTR* szCharBuffer,
+    CONST DWORD cchCharBuffer,
+    __out DWORD* pcchNumCharReturn
+    );
+
+/********************************************************************
+ ConsoleReadStringW - get console input without libc
+
+*********************************************************************/
+HRESULT DAPI ConsoleReadStringW(
+    __deref_inout_ecount_part(cchCharBuffer,*pcchNumCharReturn) LPWSTR* szCharBuffer,
+    CONST DWORD cchCharBuffer,
+    __out DWORD* pcchNumCharReturn
+    );
+
+/********************************************************************
+ ConsoleSetReadHidden - set console input no echo
+
+*********************************************************************/
 HRESULT DAPI ConsoleSetReadHidden(void);
+
+/********************************************************************
+ ConsoleSetReadNormal - reset to echo
+
+*********************************************************************/
 HRESULT DAPI ConsoleSetReadNormal(void);
 
 #ifdef __cplusplus

--- a/src/test/wix/TestData/WixprojPackageVcxprojWindowsApp/WixprojPackageVcxprojWindowsApp.wixproj
+++ b/src/test/wix/TestData/WixprojPackageVcxprojWindowsApp/WixprojPackageVcxprojWindowsApp.wixproj
@@ -3,6 +3,7 @@
 <Project Sdk='WixToolset.Sdk'> 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <SignOutput>true</SignOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,4 +13,8 @@
 
     <PackageReference Include="Wixtoolset.UI.wixext" />
   </ItemGroup>
+
+  <Target Name="SignMsi">
+    <Warning Text="SignMsi = @(SignMsi)" />
+  </Target>
 </Project>

--- a/src/test/wix/WixE2E/WixE2EFixture.cs
+++ b/src/test/wix/WixE2E/WixE2EFixture.cs
@@ -55,6 +55,14 @@ namespace WixE2E
 
             var result = RestoreAndBuild(projectPath);
             result.AssertSuccess();
+
+            var signingStatement = result.Output.Where(s => s.Contains("warning :"))
+                                                .Select(s => s.Replace(Path.GetDirectoryName(projectPath), "<projectFolder>").Replace(@"\Debug\", @"\<configuration>\").Replace(@"\Release\", @"\<configuration>\"))
+                                                .ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                @"<projectFolder>\WixprojPackageVcxprojWindowsApp.wixproj(18,5): warning : SignMsi = obj\<configuration>\en-US\WixprojPackageVcxprojWindowsApp.msi;obj\<configuration>\ja-JP\WixprojPackageVcxprojWindowsApp.msi"
+            }, signingStatement);
         }
 
         [Fact]

--- a/src/wix/WixToolset.BuildTasks/ReadTracking.cs
+++ b/src/wix/WixToolset.BuildTasks/ReadTracking.cs
@@ -93,7 +93,7 @@ namespace WixToolset.BuildTasks
                     }
                     else
                     {
-                        this.Log.LogError($"Failed to parse tracked line: {line}");
+                        this.Log.LogError("Failed to parse tracked line: {0}", line);
                     }
                 }
             }

--- a/src/wix/WixToolset.Core.Native/WixNativeExe.cs
+++ b/src/wix/WixToolset.Core.Native/WixNativeExe.cs
@@ -6,6 +6,7 @@ namespace WixToolset.Core.Native
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Text;
 
     internal class WixNativeExe
     {
@@ -40,6 +41,7 @@ namespace WixToolset.Core.Native
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
                 CreateNoWindow = true,
                 ErrorDialog = false,
                 UseShellExecute = false
@@ -61,7 +63,8 @@ namespace WixToolset.Core.Native
                 {
                     foreach (var line in this.stdinLines)
                     {
-                        process.StandardInput.WriteLine(line);
+                        var bytes = Encoding.UTF8.GetBytes(line + Environment.NewLine);
+                        process.StandardInput.BaseStream.Write(bytes, 0, bytes.Length);
                     }
 
                     // Trailing blank line indicates stdin complete.

--- a/src/wix/WixToolset.Sdk/WixToolset.Sdk.csproj
+++ b/src/wix/WixToolset.Sdk/WixToolset.Sdk.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Content Include="build\$(MSBuildThisFileName).props" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="build\$(MSBuildThisFileName).targets" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="tools\WixToolset.Signing.props" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="tools\WixToolset.Signing.targets" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="tools\wix.props" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="tools\wix.targets" CopyToOutputDirectory="PreserveNewest" />

--- a/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.props
+++ b/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.props
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WixSigningPropsImported>true</WixSigningPropsImported>
+  </PropertyGroup>
+
+  <!--
+  ==================================================================================================
+  BeforeSigning
+
+    Redefine this target in your project in order to run tasks just before all signing tasks.
+  ==================================================================================================
+  -->
+  <Target Name="BeforeSigning" />
+
+  <!--
+  ==================================================================================================
+  SignMsm
+
+    Redefine this target in your project in order to sign merge modules.
+
+    [IN]
+    @(SignMsm) - merge module files to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignMsm" />
+
+  <!--
+  ==================================================================================================
+  SignCabs
+
+    Redefine this target in your project in order to sign the cabs of your database.
+
+    [IN]
+    @(SignCabs) - cabinet files to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignCabs" />
+
+  <!--
+  ==================================================================================================
+  SignMsi
+
+    Redefine this target in your project in order to sign your database, after it has been inscribed
+    with the signatures of your signed cabs.
+
+    [IN]
+    @(SignMsi) - database files to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignMsi" />
+
+  <!--
+  ==================================================================================================
+  SignContainers
+
+    Redefine this target in your project in order to sign your bundle's detached containers.
+
+    [IN]
+    @(SignContainers) - detached container files to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignContainers" />
+
+  <!--
+  ==================================================================================================
+  SignBundleEngine
+
+    Redefine this target in your project in order to sign your bundle, after it has been inscribed
+    with the signatures of your signed containers.
+
+    [IN]
+    @(SignBundleEngine) - bundle engine file to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignBundleEngine" />
+
+  <!--
+  ==================================================================================================
+  SignBundle
+
+    Redefine this target in your project in order to sign your bundle, after the attached container
+    is reattached.
+
+    [IN]
+    @(SignBundle) - bundle file to sign.
+  ==================================================================================================
+  -->
+  <Target Name="SignBundle" />
+
+  <!--
+  ==================================================================================================
+  AfterSigning
+
+    Redefine this target in your project in order to run tasks just after all signing tasks.
+  ==================================================================================================
+  -->
+  <Target Name="AfterSigning" />
+
+</Project>

--- a/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.targets
+++ b/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.targets
@@ -3,9 +3,12 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <WixSigningTargetsImported>true</WixSigningTargetsImported>
     <SignedFileName Condition=" '$(SignedFileName)' == '' ">$(MSBuildProjectFile).Signed.txt</SignedFileName>
     <SignedFilePath>$(IntermediateOutputPath)$(SignedFileName)</SignedFilePath>
   </PropertyGroup>
+
+  <Import Project="WixToolset.Signing.props" Condition=" '$(WixSigningPropsImported)' != 'true' " />
 
   <UsingTask TaskName="GetCabList" Condition=" '$(WixTasksPath64)' == '' " AssemblyFile="$(WixTasksPath)" />
   <UsingTask TaskName="GetCabList" Condition=" '$(WixTasksPath64)' != '' " AssemblyFile="$(WixTasksPath)" Architecture="x86" />
@@ -308,98 +311,5 @@
       <Output TaskParameter="Output" ItemName="FileWrites" />
     </ReattachSignedBundleEngine>
   </Target>
-
-  <!--
-  ==================================================================================================
-  BeforeSigning
-
-    Redefine this target in your project in order to run tasks just before all signing tasks.
-  ==================================================================================================
-  -->
-  <Target Name="BeforeSigning" />
-
-  <!--
-  ==================================================================================================
-  SignMsm
-
-    Redefine this target in your project in order to sign merge modules.
-
-    [IN]
-    @(SignMsm) - merge module files to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignMsm" />
-
-  <!--
-  ==================================================================================================
-  SignCabs
-
-    Redefine this target in your project in order to sign the cabs of your database.
-
-    [IN]
-    @(SignCabs) - cabinet files to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignCabs" />
-
-  <!--
-  ==================================================================================================
-  SignMsi
-
-    Redefine this target in your project in order to sign your database, after it has been inscribed
-    with the signatures of your signed cabs.
-
-    [IN]
-    @(SignMsi) - database files to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignMsi" />
-
-  <!--
-  ==================================================================================================
-  SignContainers
-
-    Redefine this target in your project in order to sign your bundle's detached containers.
-
-    [IN]
-    @(SignContainers) - detached container files to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignContainers" />
-
-  <!--
-  ==================================================================================================
-  SignBundleEngine
-
-    Redefine this target in your project in order to sign your bundle, after it has been inscribed
-    with the signatures of your signed containers.
-
-    [IN]
-    @(SignBundleEngine) - bundle engine file to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignBundleEngine" />
-
-  <!--
-  ==================================================================================================
-  SignBundle
-
-    Redefine this target in your project in order to sign your bundle, after the attached container
-    is reattached.
-
-    [IN]
-    @(SignBundle) - bundle file to sign.
-  ==================================================================================================
-  -->
-  <Target Name="SignBundle" />
-
-  <!--
-  ==================================================================================================
-  AfterSigning
-
-    Redefine this target in your project in order to run tasks just after all signing tasks.
-  ==================================================================================================
-  -->
-  <Target Name="AfterSigning" />
 
 </Project>

--- a/src/wix/WixToolset.Sdk/tools/wix.props
+++ b/src/wix/WixToolset.Sdk/tools/wix.props
@@ -19,6 +19,8 @@
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 
+  <Import Project="WixToolset.Signing.props" Condition=" '$(WixSigningPropsImported)' != 'true' " />
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>

--- a/src/wix/WixToolset.Sdk/tools/wix.targets
+++ b/src/wix/WixToolset.Sdk/tools/wix.targets
@@ -31,10 +31,6 @@
     <WixTasksPath Condition=" '$(WixTasksPath)' == '' ">$(WixBinDir)WixToolset.BuildTasks.dll</WixTasksPath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <WixSigningTargetsPath Condition=" '$(WixSigningTargetsPath)' == '' ">$(MSBuildThisFileDirectory)WixToolset.Signing.targets</WixSigningTargetsPath>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*.wxs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
     <EmbeddedResource Include="**/*.wxl" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " />
@@ -937,7 +933,7 @@
     </Copy>
   </Target>
 
-  <Import Project="$(WixSigningTargetsPath)"  />
+  <Import Project="WixToolset.Signing.targets" Condition=" '$(WixSigningTargetsImported)' != 'true' " />
 
   <!-- Extension point: Define CustomAfterWixTargets to a .targets file that you want to include after this file. -->
   <Import Project="$(CustomAfterWixTargets)" Condition=" '$(CustomAfterWixTargets)' != '' and Exists('$(CustomAfterWixTargets)')" />

--- a/src/wix/test/WixToolsetTest.Core.Native/CabinetFixture.cs
+++ b/src/wix/test/WixToolsetTest.Core.Native/CabinetFixture.cs
@@ -34,6 +34,27 @@ namespace WixToolsetTest.CoreNative
         }
 
         [Fact]
+        public void CanCreateCabinetUsingLocalizedPath()
+        {
+            using (var fs = new DisposableFileSystem())
+            {
+                var intermediateFolder = fs.GetFolder(true);
+                var cabPath = Path.Combine(intermediateFolder, "testout.cab");
+
+                var files = new[] { new CabinetCompressFile(TestData.Get(@"TestData", "Testüber", "t道場t.txt"), "test.txt") };
+
+                var cabinet = new Cabinet(cabPath);
+                var created = cabinet.Compress(files, CompressionLevel.Low);
+
+                Assert.True(File.Exists(cabPath));
+                Assert.Equal(new[]
+                {
+                    "testout.cab, test.txt"
+                }, created.Select(c => String.Join(", ", c.CabinetName, c.FirstFileToken)).ToArray());
+            }
+        }
+
+        [Fact]
         public void CanCreateSpannedFileCabinet()
         {
             using (var fs = new DisposableFileSystem())

--- a/src/wix/test/WixToolsetTest.Core.Native/TestData/Testüber/t道場t.txt
+++ b/src/wix/test/WixToolsetTest.Core.Native/TestData/Testüber/t道場t.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/wixnative/smartcab.cpp
+++ b/src/wix/wixnative/smartcab.cpp
@@ -123,7 +123,7 @@ static HRESULT CompressFiles(
         hr = StrSplitAllocArray(&rgsczSplit, &cSplit, sczLine, L"\t");
         ConsoleExitOnFailure(hr, CONSOLE_COLOR_RED, "failed to split smartcab line from stdin: %ls", sczLine);
 
-        if (cSplit != 2 && cSplit != 6)
+        if (!rgsczSplit || (cSplit != 2 && cSplit != 6))
         {
             hr = E_INVALIDARG;
             ConsoleExitOnFailure(hr, CONSOLE_COLOR_RED, "failed to split smartcab line into hash x 4, token, source file: %ls", sczLine);
@@ -176,5 +176,15 @@ static void __stdcall CabNamesCallback(
     __in_z LPCWSTR wzFileToken
     )
 {
-    ConsoleWriteLine(CONSOLE_COLOR_NORMAL, "%ls\t%ls\t%ls", wzFirstCabName, wzNewCabName, wzFileToken);
+    HRESULT hr;
+    LPWSTR scz = NULL;
+
+    hr = StrAllocFormatted(&scz, L"%s\t%s\t%s\r\n", wzFirstCabName, wzNewCabName, wzFileToken);
+    ConsoleExitOnFailure(hr, CONSOLE_COLOR_RED, "failed to allocate cabinet names message");
+
+    hr = ConsoleWriteW(CONSOLE_COLOR_NORMAL, scz);
+    ConsoleExitOnFailure(hr, CONSOLE_COLOR_RED, "failed to send cabinet names message");
+
+LExit:
+    ReleaseStr(scz);
 }


### PR DESCRIPTION
* Add support for UTF-8 console and use it for passing smartcab paths - fixes wixtoolset/issues#7024
* Allow signing targets to be overridden in simple Sdk-style .wixproj - closes wixtoolset/issues#7038
* Log error when path to executable cannot be found in MSBuild tool task - debugging wixtoolset/issues#7035