### PR TITLE
Robmen/fixes

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -640,19 +640,19 @@ namespace WixToolset.Data
 
         public static Message FileNotFound(SourceLineNumber sourceLineNumbers, string file)
         {
-            return Message(sourceLineNumbers, Ids.FileNotFound, "The system cannot find the file '{0}'.", file);
+            return Message(sourceLineNumbers, Ids.FileNotFound, "Cannot find the file '{0}'.", file);
         }
 
         public static Message FileNotFound(SourceLineNumber sourceLineNumbers, string file, string fileType)
         {
-            return Message(sourceLineNumbers, Ids.FileNotFound, "The system cannot find the file '{0}' with type '{1}'.", file, fileType);
+            return Message(sourceLineNumbers, Ids.FileNotFound, "Cannot find the {0} file '{1}'.", fileType, file);
         }
 
         public static Message FileNotFound(SourceLineNumber sourceLineNumbers, string file, string fileType, IEnumerable<string> checkedPaths)
         {
             var combinedCheckedPaths = String.Join(", ", checkedPaths);
-            var withType = String.IsNullOrEmpty(fileType) ? String.Empty : $" with type '{fileType}'";
-            return Message(sourceLineNumbers, Ids.FileNotFound, "The system cannot find the file '{0}'{1}. The following paths were checked: {2}", file, withType, combinedCheckedPaths);
+            var fileTypePrefix = String.IsNullOrEmpty(fileType) ? String.Empty : fileType + " ";
+            return Message(sourceLineNumbers, Ids.FileNotFound, "Cannot find the {0}file '{1}'. The following paths were checked: {2}", fileTypePrefix, file, combinedCheckedPaths);
         }
 
         public static Message FileOrDirectoryPathRequired(string parameter)
@@ -662,12 +662,12 @@ namespace WixToolset.Data
 
         public static Message FilePathRequired(string filePurpose)
         {
-            return Message(null, Ids.FilePathRequired, "The path to {0} is required.", filePurpose);
+            return Message(null, Ids.FilePathRequired, "The path to the {0} is required.", filePurpose);
         }
 
         public static Message FilePathRequired(string parameter, string filePurpose)
         {
-            return Message(null, Ids.FilePathRequired, "The parameter '{0}' must be followed by a file path for {1}.", parameter, filePurpose);
+            return Message(null, Ids.FilePathRequired, "The parameter '{0}' must be followed by a file path for the {1}.", parameter, filePurpose);
         }
 
         public static Message FileTooLarge(SourceLineNumber sourceLineNumbers, string fileName)

--- a/src/internal/WixInternal.BaseBuildTasks.Sources/BaseToolsetTask.cs
+++ b/src/internal/WixInternal.BaseBuildTasks.Sources/BaseToolsetTask.cs
@@ -178,11 +178,11 @@ namespace WixToolset.BaseBuildTasks
         private string GetDefaultToolFullPath()
         {
 #if NETCOREAPP
-                var thisTaskFolder = Path.GetDirectoryName(typeof(BaseToolsetTask).Assembly.Location);
+                var thisTaskFolder = Path.GetDirectoryName(Path.GetFullPath(typeof(BaseToolsetTask).Assembly.Location));
 
                 return Path.Combine(thisTaskFolder, this.ToolExe);
 #else
-                var thisTaskFolder = Path.GetDirectoryName(new Uri(typeof(BaseToolsetTask).Assembly.CodeBase).AbsolutePath);
+                var thisTaskFolder = Path.GetDirectoryName(Path.GetFullPath(new Uri(typeof(BaseToolsetTask).Assembly.CodeBase).LocalPath));
 
                 return this.FindArchitectureSpecificToolPath(thisTaskFolder);
 #endif

--- a/src/test/wix/TestData/CsprojWpfNetCore/CsprojWpfNetCore.csproj
+++ b/src/test/wix/TestData/CsprojWpfNetCore/CsprojWpfNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net5.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/Package.wxs
+++ b/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/Package.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name='~WpfApp' Manufacturer='WiX Toolset' Version='0.0.1' UpgradeCode='41a2c17e-1976-465b-bcde-eae03516ca68'>
+
+    <StandardDirectory Id='ProgramFiles6432Folder'>
+      <Directory Id='ApplicationFolder' Name='~Wpf App'>
+      </Directory>
+    </StandardDirectory>
+
+    <Feature Id='Main' Title='WpfApp'>
+      <Component Directory='ApplicationFolder'>
+        <File Source='CsprojWpfNetCore.exe' />
+      </Component>
+    </Feature>
+  </Package>
+</Wix>

--- a/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
+++ b/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
@@ -1,0 +1,17 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk='WixToolset.Sdk'>
+<!-- <Project> -->
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.props' /> -->
+
+  <PropertyGroup>
+    <!-- <WixBinDir>D:\src\wix4\build\wix\Debug\net472\</WixBinDir> -->
+    <!-- <WixBinDir64>D:\src\wix4\build\wix\Debug\publish\WixToolset.Sdk\tools\net472\x64\</WixBinDir64> -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SkipPublish="true" BindPath="$(MSBuildProjectDirectory)\does\not\exist" BindName="Xxx" Publish="true" -->
+    <ProjectReference Include="..\CsprojWpfNetCore\CsprojWpfNetCore.csproj" Publish="true" />
+  </ItemGroup>
+
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.targets' /> -->
+</Project>

--- a/src/tools/test/WixToolsetTest.HeatTasks/MsbuildHeatFixture.cs
+++ b/src/tools/test/WixToolsetTest.HeatTasks/MsbuildHeatFixture.cs
@@ -13,7 +13,7 @@ namespace WixToolsetTest.Sdk
 
     public class MsbuildHeatFixture
     {
-        public static readonly string HeatTargetsPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(MsbuildHeatFixture).Assembly.CodeBase).AbsolutePath), "..", "..", "..", "publish", "WixToolset.Heat", "build", "WixToolset.Heat.targets");
+        public static readonly string HeatTargetsPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(MsbuildHeatFixture).Assembly.CodeBase).LocalPath), "..", "..", "..", "publish", "WixToolset.Heat", "build", "WixToolset.Heat.targets");
 
         public MsbuildHeatFixture()
         {

--- a/src/wix/WixToolset.Core.Burn/Bundles/HarvestBundlePackageCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/HarvestBundlePackageCommand.cs
@@ -281,7 +281,7 @@ namespace WixToolset.Core.Burn.Bundles
                 if (!payloadNames.Contains(containerFullName))
                 {
                     var generatedId = this.BackendHelper.GenerateIdentifier("hcp", this.PackagePayload.Id.Id, containerName);
-                    var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, containerName, "Container", this.PackagePayload.SourceLineNumbers);
+                    var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, containerName, "container", this.PackagePayload.SourceLineNumbers);
 
                     this.Payloads.Add(new WixBundlePayloadSymbol(this.PackagePayload.SourceLineNumbers, new Identifier(AccessModifier.Section, generatedId))
                     {
@@ -341,7 +341,7 @@ namespace WixToolset.Core.Burn.Bundles
                 if (!payloadNames.Contains(payloadFullName))
                 {
                     var generatedId = this.BackendHelper.GenerateIdentifier("hpp", this.PackagePayload.Id.Id, payloadName);
-                    var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, payloadName, "Payload", this.PackagePayload.SourceLineNumbers);
+                    var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, payloadName, "payload", this.PackagePayload.SourceLineNumbers);
 
                     this.Payloads.Add(new WixBundlePayloadSymbol(this.PackagePayload.SourceLineNumbers, new Identifier(AccessModifier.Section, generatedId))
                     {

--- a/src/wix/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
@@ -452,7 +452,7 @@ namespace WixToolset.Core.Burn.Bundles
                             if (!payloadNames.Contains(cabinetName))
                             {
                                 var generatedId = this.BackendHelper.GenerateIdentifier("cab", this.PackagePayload.Id.Id, cabinet);
-                                var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, cabinet, "Cabinet", sourceLineNumbers);
+                                var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, cabinet, "cabinet", sourceLineNumbers);
 
                                 this.Section.AddSymbol(new WixBundlePayloadSymbol(sourceLineNumbers, new Identifier(AccessModifier.Section, generatedId))
                                 {
@@ -516,7 +516,7 @@ namespace WixToolset.Core.Burn.Bundles
                             if (!payloadNames.Contains(name))
                             {
                                 var generatedId = this.BackendHelper.GenerateIdentifier("f", this.PackagePayload.Id.Id, record.GetString(2));
-                                var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, fileSourcePath, "File", sourceLineNumbers);
+                                var payloadSourceFile = this.ResolveRelatedFile(this.PackagePayload.SourceFile.Path, this.PackagePayload.UnresolvedSourceFile, fileSourcePath, "payload", sourceLineNumbers);
 
                                 this.Section.AddSymbol(new WixBundlePayloadSymbol(sourceLineNumbers, new Identifier(AccessModifier.Section, generatedId))
                                 {

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -697,7 +697,7 @@ namespace WixToolset.Core.CommandLine
                 }
                 else
                 {
-                    parser.GetArgumentAsFilePathOrError(arg, "input file", this.UnclassifiedInputFilePaths);
+                    parser.GetArgumentAsFilePathOrError(arg, "input", this.UnclassifiedInputFilePaths);
                     return true;
                 }
             }

--- a/src/wix/WixToolset.Sdk/tools/wix.props
+++ b/src/wix/WixToolset.Sdk/tools/wix.props
@@ -51,7 +51,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssetTargetFallback>$(AssetTargetFallback);net6.0-windows;net6.0;net5.0-windows;net5.0;netcoreapp3.1;netcoreapp3.0;netcoreapp2.0;net462;net47;net471;net472;net48;native</AssetTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);net7.0-windows;net7.0;net6.0-windows7.0;net6.0-windows;net6.0;net5.0-windows7.0;net5.0-windows;net5.0;netcoreapp3.1;netcoreapp3.0;netcoreapp2.0;net462;net47;net471;net472;net48;native</AssetTargetFallback>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/wix/test/WixToolsetTest.BuildTasks/WixBuildTaskFixture.cs
+++ b/src/wix/test/WixToolsetTest.BuildTasks/WixBuildTaskFixture.cs
@@ -15,7 +15,7 @@ namespace WixToolsetTest.BuildTasks
 
     public class WixBuildTaskFixture
     {
-        public static readonly string PublishedWixSdkToolsFolder = Path.Combine(Path.GetDirectoryName(new Uri(typeof(WixBuildTaskFixture).Assembly.CodeBase).AbsolutePath), "..", "..", "..", "publish", "WixToolset.Sdk", "tools");
+        public static readonly string PublishedWixSdkToolsFolder = Path.Combine(Path.GetDirectoryName(new Uri(typeof(WixBuildTaskFixture).Assembly.CodeBase).LocalPath), "..", "..", "..", "publish", "WixToolset.Sdk", "tools");
 
         // This line replicates what happens in WixBuild task when hosted in the PublishedWixSdkToolsFolder. However, WixBuild task is hosted inproc to this test assembly so the
         // root folder is relative to the test assembly's folder which does not have wix.exe local. So, we have to find wix.exe relative to PublishedWixSdkToolsFolder.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
@@ -84,8 +84,8 @@ namespace WixToolsetTest.CoreIntegration
                 var errorMessages = messages.Select(m => m.ToString().Replace(folder, "<folder>")).ToArray();
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"The system cannot find the file 'test.txt' with type 'File'. The following paths were checked: test.txt, <folder>\does-not-exist\test.txt, <folder>\also-does-not-exist\test.txt",
-                    @"The system cannot find the file 'test.txt' with type 'File'. The following paths were checked: test.txt, <folder>\does-not-exist\test.txt, <folder>\also-does-not-exist\test.txt",
+                    @"Cannot find the File file 'test.txt'. The following paths were checked: test.txt, <folder>\does-not-exist\test.txt, <folder>\also-does-not-exist\test.txt",
+                    @"Cannot find the File file 'test.txt'. The following paths were checked: test.txt, <folder>\does-not-exist\test.txt, <folder>\also-does-not-exist\test.txt",
                 }, errorMessages);
 
                 var errorMessage = errorMessages.First();

--- a/src/wix/test/WixToolsetTest.CoreIntegration/PatchFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/PatchFixture.cs
@@ -391,7 +391,7 @@ namespace WixToolsetTest.CoreIntegration
                 var messages = result.Messages.Select(m => m.ToString().Replace(tempFolderPatch, "<tempFolderPatch>").Replace(templateBaselineFolder, "<templateBaselineFolder>").Replace(templateUpdateFolder, "<templateUpdateFolder>")).ToArray();
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"The system cannot find the file 'Missing.wixpdb' with type 'WixPatchBaseline'. The following paths were checked: Missing.wixpdb, <tempFolderPatch>\bin\Missing.wixpdb, <templateBaselineFolder>\Missing.wixpdb, <templateUpdateFolder>\Missing.wixpdb",
+                    @"Cannot find the WixPatchBaseline file 'Missing.wixpdb'. The following paths were checked: Missing.wixpdb, <tempFolderPatch>\bin\Missing.wixpdb, <templateBaselineFolder>\Missing.wixpdb, <templateUpdateFolder>\Missing.wixpdb",
                 }, messages);
             }
         }

--- a/src/wix/test/WixToolsetTest.Sdk/MsbuildFixture.cs
+++ b/src/wix/test/WixToolsetTest.Sdk/MsbuildFixture.cs
@@ -11,7 +11,7 @@ namespace WixToolsetTest.Sdk
 
     public class MsbuildFixture
     {
-        public static readonly string WixMsbuildPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(MsbuildFixture).Assembly.CodeBase).AbsolutePath), "..", "..", "..", "publish", "WixToolset.Sdk");
+        public static readonly string WixMsbuildPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(MsbuildFixture).Assembly.CodeBase).LocalPath), "..", "..", "..", "publish", "WixToolset.Sdk");
         public static readonly string WixPropsPath = Path.Combine(WixMsbuildPath, "build", "WixToolset.Sdk.props");
 
         [Theory]


### PR DESCRIPTION
* Improve file not found error message - fixes wixtoolset/issues#2805
* Handle spaces when finding path to executables in MSBuild task - fixes wixtoolset/issues#7035
* Add additional AssetTargetFallback - fixes wixtoolset/issues#7034