### PR TITLE
Better solution to the UI custom action "problem."

### DIFF
--- a/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
+++ b/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
@@ -20,7 +20,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:AdvancedWelcomeEulaDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
@@ -38,9 +38,15 @@ namespace WixToolsetTest.UI
                 "CustomAction:WixSetDefaultPerUserFolder\t51\tWixPerUserFolder\t[LocalAppDataFolder]Apps\\[ApplicationFolderName]\t",
                 "CustomAction:WixSetPerMachineFolder\t51\tAPPLICATIONFOLDER\t[WixPerMachineFolder]\t",
                 "CustomAction:WixSetPerUserFolder\t51\tAPPLICATIONFOLDER\t[WixPerUserFolder]\t",
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X86\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X86\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X86\t65\tWixUiCa_X86\tPrintEula\t",
+                "CustomAction:WixUIValidatePath_X86\t65\tWixUiCa_X86\tValidatePath\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:AdvancedWelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1",
+                "ControlEvent:BrowseDlg\tOK\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t1",
+                "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t2",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).ToArray());
         }
 
         [Fact]
@@ -50,7 +56,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:AdvancedWelcomeEulaDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
@@ -68,9 +74,15 @@ namespace WixToolsetTest.UI
                 "CustomAction:WixSetDefaultPerUserFolder\t51\tWixPerUserFolder\t[LocalAppDataFolder]Apps\\[ApplicationFolderName]\t",
                 "CustomAction:WixSetPerMachineFolder\t51\tAPPLICATIONFOLDER\t[WixPerMachineFolder]\t",
                 "CustomAction:WixSetPerUserFolder\t51\tAPPLICATIONFOLDER\t[WixPerUserFolder]\t",
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X64\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X64\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X64\t65\tWixUiCa_X64\tPrintEula\t",
+                "CustomAction:WixUIValidatePath_X64\t65\tWixUiCa_X64\tValidatePath\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:AdvancedWelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_X64\t1\t1",
+                "ControlEvent:BrowseDlg\tOK\tDoAction\tWixUIValidatePath_X64\tNOT WIXUI_DONTVALIDATEPATH\t1",
+                "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_X64\tNOT WIXUI_DONTVALIDATEPATH\t2",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).ToArray());
         }
 
         [Fact]
@@ -80,7 +92,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(BuildARM64, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(BuildARM64, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:AdvancedWelcomeEulaDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
@@ -98,9 +110,15 @@ namespace WixToolsetTest.UI
                 "CustomAction:WixSetDefaultPerUserFolder\t51\tWixPerUserFolder\t[LocalAppDataFolder]Apps\\[ApplicationFolderName]\t",
                 "CustomAction:WixSetPerMachineFolder\t51\tAPPLICATIONFOLDER\t[WixPerMachineFolder]\t",
                 "CustomAction:WixSetPerUserFolder\t51\tAPPLICATIONFOLDER\t[WixPerUserFolder]\t",
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_A64\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_A64\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_A64\t65\tWixUiCa_A64\tPrintEula\t",
+                "CustomAction:WixUIValidatePath_A64\t65\tWixUiCa_A64\tValidatePath\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:AdvancedWelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_A64\t1\t1",
+                "ControlEvent:BrowseDlg\tOK\tDoAction\tWixUIValidatePath_A64\tNOT WIXUI_DONTVALIDATEPATH\t1",
+                "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_A64\tNOT WIXUI_DONTVALIDATEPATH\t2",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).ToArray());
         }
 
         [Fact]
@@ -110,7 +128,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:WelcomeDlg\t"));
             Assert.Single(results, result => result.StartsWith("Dialog:CustomizeDlg\t"));
             Assert.Empty(results.Where(result => result.StartsWith("Dialog:SetupTypeDlg\t")));
@@ -122,13 +140,16 @@ namespace WixToolsetTest.UI
                 "Binary:WixUI_Bmp_Up\t[Binary data]",
                 "Binary:WixUI_Ico_Exclam\t[Binary data]",
                 "Binary:WixUI_Ico_Info\t[Binary data]",
-                "Binary:WixUiCa_X86\t[Binary data]",
+                "Binary:WixUiCa_X64\t[Binary data]",
             }, results.Where(r => r.StartsWith("Binary:")).ToArray());
             WixAssert.CompareLineByLine(new[]
             {
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X86\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X86\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X64\t65\tWixUiCa_X64\tPrintEula\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:LicenseAgreementDlg\tPrint\tDoAction\tWixUIPrintEula_X64\t1\t1",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).ToArray());
         }
 
         [Fact]
@@ -138,7 +159,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "Property");
+            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "Property", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:InstallDirDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
@@ -152,13 +173,19 @@ namespace WixToolsetTest.UI
             }, results.Where(r => r.StartsWith("Binary:")).ToArray());
             WixAssert.CompareLineByLine(new[]
             {
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X86\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X86\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X86\t65\tWixUiCa_X86\tPrintEula\t",
+                "CustomAction:WixUIValidatePath_X86\t65\tWixUiCa_X86\tValidatePath\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
             WixAssert.CompareLineByLine(new[]
             {
                 "Property:WIXUI_INSTALLDIR\tINSTALLFOLDER",
             }, results.Where(r => r.StartsWith("Property:WIXUI")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:BrowseDlg\tOK\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t3",
+                "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t2",
+                "ControlEvent:LicenseAgreementDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).OrderBy(s => s).ToArray());
         }
 
         [Fact]
@@ -168,7 +195,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:WelcomeEulaDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
@@ -182,9 +209,12 @@ namespace WixToolsetTest.UI
             }, results.Where(r => r.StartsWith("Binary:")).ToArray());
             WixAssert.CompareLineByLine(new[]
             {
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X86\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X86\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X86\t65\tWixUiCa_X86\tPrintEula\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:WelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).OrderBy(s => s).ToArray());
         }
 
         [Fact]
@@ -232,7 +262,7 @@ namespace WixToolsetTest.UI
             var bindFolder = TestData.Get(@"TestData\data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
-            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction");
+            var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
             Assert.Single(results, result => result.StartsWith("Dialog:WelcomeDlg\t"));
             Assert.Single(results, result => result.StartsWith("Dialog:CustomizeDlg\t"));
             Assert.Single(results, result => result.StartsWith("Dialog:SetupTypeDlg\t"));
@@ -248,9 +278,15 @@ namespace WixToolsetTest.UI
             }, results.Where(r => r.StartsWith("Binary:")).ToArray());
             WixAssert.CompareLineByLine(new[]
             {
-                "CustomAction:WixUIPrintEula\t65\tWixUiCa_X86\tPrintEula\t",
-                "CustomAction:WixUIValidatePath\t65\tWixUiCa_X86\tValidatePath\t",
+                "CustomAction:WixUIPrintEula_X86\t65\tWixUiCa_X86\tPrintEula\t",
+                "CustomAction:WixUIValidatePath_X86\t65\tWixUiCa_X86\tValidatePath\t",
             }, results.Where(r => r.StartsWith("CustomAction:")).ToArray());
+            WixAssert.CompareLineByLine(new[]
+            {
+                "ControlEvent:BrowseDlg\tOK\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t3",
+                "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t2",
+                "ControlEvent:LicenseAgreementDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1",
+            }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).ToArray());
         }
 
         [Fact]

--- a/src/ext/UI/wixext/UICompiler.cs
+++ b/src/ext/UI/wixext/UICompiler.cs
@@ -17,11 +17,6 @@ namespace WixToolset.UI
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/ui";
 
         /// <summary>
-        /// Flag to prevent custom action symbols duplication.
-        /// </summary>
-        private bool customActionsAdded = false;
-
-        /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>
         /// <param name="sourceLineNumbers">Source line number for the parent element.</param>
@@ -91,40 +86,9 @@ namespace WixToolset.UI
             }
             else
             {
+                var platform = this.Context.Platform == Platform.ARM64 ? "A64" : this.Context.Platform.ToString();
                 this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixUI, id);
-
-                if (!customActionsAdded)
-                {
-                    // Because these custom actions are "scheduled" via `DoAction` control events, we have to create the
-                    // custom action definitions here, so the `DoAction` references are static and the targets are
-                    // dynamically created to properly reflect the platform-specific DLL and avoid having duplicate ids
-                    // in the UI .wixlib.
-                    var platform = this.Context.Platform == Platform.ARM64 ? "A64" : this.Context.Platform.ToString();
-                    var source = $"WixUiCa_{platform}";
-                    this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.Binary, source);
-
-                    section.AddSymbol(new CustomActionSymbol(sourceLineNumbers, new Identifier(AccessModifier.Global, "WixUIPrintEula"))
-                    {
-                        TargetType = CustomActionTargetType.Dll,
-                        Target = "PrintEula",
-                        SourceType = CustomActionSourceType.Binary,
-                        Source = source,
-                        IgnoreResult = true,
-                        ExecutionType = CustomActionExecutionType.Immediate,
-                    });
-
-                    section.AddSymbol(new CustomActionSymbol(sourceLineNumbers, new Identifier(AccessModifier.Global, "WixUIValidatePath"))
-                    {
-                        TargetType = CustomActionTargetType.Dll,
-                        Target = "ValidatePath",
-                        SourceType = CustomActionSourceType.Binary,
-                        Source = source,
-                        IgnoreResult = true,
-                        ExecutionType = CustomActionExecutionType.Immediate,
-                    });
-
-                    customActionsAdded = true;
-                }
+                this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixUI, $"{id}_{platform}");
 
                 if (installDirectory != null)
                 {

--- a/src/ext/UI/wixlib/AdvancedWelcomeEulaDlg.wxs
+++ b/src/ext/UI/wixlib/AdvancedWelcomeEulaDlg.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -11,9 +11,7 @@
                 <Control Id="DescriptionPerMachine" Type="Text" X="20" Y="202" Width="330" Height="31" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="!(loc.AdvancedWelcomeEulaDlgDescriptionPerMachine)" ShowCondition="ALLUSERS" />
                 <Control Id="DescriptionPerUser" Type="Text" X="20" Y="202" Width="330" Height="31" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="!(loc.AdvancedWelcomeEulaDlgDescriptionPerUser)" ShowCondition="NOT ALLUSERS" />
                 <Control Id="LicenseAcceptedCheckBox" Type="CheckBox" X="20" Y="180" Width="226" Height="18" CheckBoxValue="1" Property="LicenseAccepted" Text="!(loc.WelcomeEulaDlgLicenseAcceptedCheckBox)" />
-                <Control Id="Print" Type="PushButton" X="88" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)">
-                    <Publish Event="DoAction" Value="WixUIPrintEula" />
-                </Control>
+                <Control Id="Print" Type="PushButton" X="88" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)" />
                 <Control Id="Advanced" Type="PushButton" X="156" Y="243" Width="56" Height="17" Text="!(loc.AdvancedWelcomeEulaDlgAdvanced)" DisableCondition="LicenseAccepted &lt;&gt; &quot;1&quot;" EnableCondition="LicenseAccepted = &quot;1&quot;" />
                 <Control Id="Install" Type="PushButton" ElevationShield="yes" X="212" Y="243" Width="80" Height="17" Default="yes" Text="!(loc.AdvancedWelcomeEulaDlgInstall)" Hidden="yes" DisableCondition="LicenseAccepted &lt;&gt; &quot;1&quot;" EnableCondition="LicenseAccepted = &quot;1&quot;" ShowCondition="ALLUSERS">
                     <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg" Condition="!(wix.WixUICostingPopupOptOut) OR CostingComplete = 1" />

--- a/src/ext/UI/wixlib/Common_Platform.wxi
+++ b/src/ext/UI/wixlib/Common_Platform.wxi
@@ -1,16 +1,18 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <?include ..\..\caDecor.wxi ?>
 
-    <!-- 
-      Custom actions to print EULA amd validate install directories are defined
-      in WixUIExtension compiler extension, to handle platform-specific custom
-      actions referred to from `DoAction` control events.
-    -->
+    <Fragment>
+        <CustomAction Id="WixUIPrintEula$(Suffix)" BinaryRef="WixUiCa$(Suffix)" DllEntry="PrintEula" Return="ignore" Execute="immediate" />
+    </Fragment>
 
     <Fragment>
-        <Binary Id="WixUiCa$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))uica.dll" />
+        <CustomAction Id="WixUIValidatePath$(Suffix)" BinaryRef="WixUiCa$(Suffix)" DllEntry="ValidatePath" Return="ignore" Execute="immediate" />
+    </Fragment>
+
+    <Fragment>
+        <Binary Id="WixUiCa$(Suffix)" SourceFile="!(bindpath.$(platform))uica.dll" />
     </Fragment>
 </Include>

--- a/src/ext/UI/wixlib/LicenseAgreementDlg.wxs
+++ b/src/ext/UI/wixlib/LicenseAgreementDlg.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -11,9 +11,7 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.LicenseAgreementDlgDescription)" />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.LicenseAgreementDlgTitle)" />
                 <Control Id="LicenseAcceptedCheckBox" Type="CheckBox" X="20" Y="207" Width="330" Height="18" CheckBoxValue="1" Property="LicenseAccepted" Text="!(loc.LicenseAgreementDlgLicenseAcceptedCheckBox)" />
-                <Control Id="Print" Type="PushButton" X="112" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)">
-                    <Publish Event="DoAction" Value="WixUIPrintEula" />
-                </Control>
+                <Control Id="Print" Type="PushButton" X="112" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)" />
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" DisableCondition="LicenseAccepted &lt;&gt; &quot;1&quot;" EnableCondition="LicenseAccepted = &quot;1&quot;">
                     <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg" Condition="!(wix.WixUICostingPopupOptOut) OR CostingComplete = 1" />

--- a/src/ext/UI/wixlib/WelcomeEulaDlg.wxs
+++ b/src/ext/UI/wixlib/WelcomeEulaDlg.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -9,9 +9,7 @@
                 <Control Id="Title" Type="Text" X="130" Y="6" Width="225" Height="30" Transparent="yes" NoPrefix="yes" Text="!(loc.WelcomeEulaDlgTitle)" />
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
                 <Control Id="LicenseAcceptedCheckBox" Type="CheckBox" X="130" Y="207" Width="226" Height="18" CheckBoxValue="1" Property="LicenseAccepted" Text="!(loc.WelcomeEulaDlgLicenseAcceptedCheckBox)" />
-                <Control Id="Print" Type="PushButton" X="88" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)">
-                    <Publish Event="DoAction" Value="WixUIPrintEula" />
-                </Control>
+                <Control Id="Print" Type="PushButton" X="88" Y="243" Width="56" Height="17" Text="!(loc.WixUIPrint)" />
                 <Control Id="Back" Type="PushButton" X="156" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)" />
                 <Control Id="Install" Type="PushButton" ElevationShield="yes" X="212" Y="243" Width="80" Height="17" Default="yes" Text="!(loc.WelcomeEulaDlgInstall)" Hidden="yes" DisableCondition="LicenseAccepted &lt;&gt; &quot;1&quot;" EnableCondition="LicenseAccepted = &quot;1&quot;" ShowCondition="ALLUSERS">
                     <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg" Condition="!(wix.WixUICostingPopupOptOut) OR CostingComplete = 1" />

--- a/src/ext/UI/wixlib/WixUI_Advanced.wxs
+++ b/src/ext/UI/wixlib/WixUI_Advanced.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 
@@ -67,7 +67,6 @@ Todo:
             <DialogRef Id="WelcomeDlg" />
 
             <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999" />
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="1" />
             <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="2" Condition="WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
 
             <Publish Dialog="AdvancedWelcomeEulaDlg" Control="Advanced" Event="NewDialog" Value="InstallScopeDlg" Order="1" Condition="!(wix.WixUISupportPerMachine) AND !(wix.WixUISupportPerUser)" />
@@ -87,7 +86,6 @@ Todo:
             <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Condition="!(wix.WixUISupportPerUser)" />
             <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="AdvancedWelcomeEulaDlg" Condition="NOT !(wix.WixUISupportPerUser)" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="FeaturesDlg" Order="4" Condition="WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID=&quot;1&quot;" />
             <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1" />
@@ -117,4 +115,14 @@ Todo:
         <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
         <UIRef Id="WixUI_Common" />
     </Fragment>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_Advanced_$(WIXUIARCH)">
+            <Publish Dialog="AdvancedWelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="1" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+    </Fragment>
+    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_FeatureTree.wxs
+++ b/src/ext/UI/wixlib/WixUI_FeatureTree.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 
@@ -65,4 +65,12 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_FeatureTree_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+        </UI>
+    </Fragment>
+    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_InstallDir.wxs
+++ b/src/ext/UI/wixlib/WixUI_InstallDir.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 
@@ -41,7 +41,6 @@ Patch dialog sequence:
             <DialogRef Id="ProgressDlg" />
             <DialogRef Id="ResumeDlg" />
             <DialogRef Id="UserExit" />
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3" />
             <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4" Condition="NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
 
             <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999" />
@@ -54,7 +53,6 @@ Patch dialog sequence:
 
             <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4" Condition="WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID=&quot;1&quot;" />
             <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1" />
@@ -74,4 +72,14 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_InstallDir_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+    </Fragment>
+    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_Minimal.wxs
+++ b/src/ext/UI/wixlib/WixUI_Minimal.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 
@@ -59,4 +59,12 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_Minimal_$(WIXUIARCH)">
+            <Publish Dialog="WelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+        </UI>
+    </Fragment>
+    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_Mondo.wxs
+++ b/src/ext/UI/wixlib/WixUI_Mondo.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 
@@ -74,4 +74,14 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_Mondo_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+    </Fragment>
+    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/ui.wixproj
+++ b/src/ext/UI/wixlib/ui.wixproj
@@ -1,12 +1,10 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <BindFiles>true</BindFiles>
     <Cultures>en-us</Cultures>
   </PropertyGroup>
-
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
@@ -19,19 +17,19 @@
       upIco=$(MSBuildProjectDirectory)\Bitmaps\up.ico;
     </DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
-    <BindInputPaths Include="$(OutputPath)x86" BindName='x86' />
-    <BindInputPaths Include="$(OutputPath)x64" BindName='x64' />
-    <BindInputPaths Include="$(OutputPath)arm64" BindName='arm64' />
+    <BindInputPaths Include="$(OutputPath)x86" BindName="x86" />
+    <BindInputPaths Include="$(OutputPath)x64" BindName="x64" />
+    <BindInputPaths Include="$(OutputPath)arm64" BindName="arm64" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Content Include="Common_Platform.wxi" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=x86" />
     <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=x64" />
     <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=ARM64" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Add platform-specific fragments that are referenced by the compiler extension. That makes it easier to customize: Just copy the dialog set authoring and rename, like in v3.