### PR TITLE
Fix bundle signing

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -143,6 +143,20 @@
           WorkingDirectory="$(MSBuildProjectDirectory)" EchoOff="true" />
   </Target>
 
+  <Target Name="SignBundleEngine" DependsOnTargets="_GetSignClient" Condition=" '$(SigningUser)'!='' and '$(SignOutput)'!='false' ">
+    <Message Importance="high" Text="Signing bundle engine: @(SignBundleEngine->&apos;%(Identity)&apos;) using configuration from: $(SigningConfiguration)" />
+
+    <Exec Command='"$(SigningToolExe)" sign -i "@(SignBundleEngine->&apos;%(Identity)&apos;)" -c "$(SigningConfiguration)" -f "$(SigningFilelist)" -n "WiX Toolset" -d "WiX Toolset" -u https://wixtoolset.org/ -r "$(SigningUser)" -s "$(SigningSecret)"'
+          WorkingDirectory="$(MSBuildProjectDirectory)" EchoOff="true" />
+  </Target>
+
+  <Target Name="SignBundle" DependsOnTargets="_GetSignClient" Condition=" '$(SigningUser)'!='' and '$(SignOutput)'!='false' ">
+    <Message Importance="high" Text="Signing bundle: @(SignBundle->&apos;%(Identity)&apos;) using configuration from: $(SigningConfiguration)" />
+
+    <Exec Command='"$(SigningToolExe)" sign -i "@(SignBundle->&apos;%(Identity)&apos;)" -c "$(SigningConfiguration)" -f "$(SigningFilelist)" -n "WiX Toolset" -d "WiX Toolset" -u https://wixtoolset.org/ -r "$(SigningUser)" -s "$(SigningSecret)"'
+          WorkingDirectory="$(MSBuildProjectDirectory)" EchoOff="true" />
+  </Target>
+
   <Import Project="Directory$(MSBuildProjectExtension).targets" Condition=" Exists('Directory$(MSBuildProjectExtension).targets') " />
   <Import Project="Custom.Build.targets" Condition=" Exists('Custom.Build.targets') " />
 </Project>

--- a/src/setup/WixAdditionalTools/WixAdditionalTools.wixproj
+++ b/src/setup/WixAdditionalTools/WixAdditionalTools.wixproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Bundle</OutputType>
     <OutputPath>$(PackageOutputPath)</OutputPath>
+    <SignOutput>true</SignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/wix/WixToolset.Converters.Symbolizer/WixToolset.Converters.Symbolizer.net472.v3.ncrunchproject
+++ b/src/wix/WixToolset.Converters.Symbolizer/WixToolset.Converters.Symbolizer.net472.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>LostReference</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/src/wix/WixToolset.Converters.Symbolizer/WixToolset.Converters.Symbolizer.netstandard2.0.v3.ncrunchproject
+++ b/src/wix/WixToolset.Converters.Symbolizer/WixToolset.Converters.Symbolizer.netstandard2.0.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>LostReference</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/src/wix/WixToolset.Core.Burn/Bundles/BurnCommon.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/BurnCommon.cs
@@ -451,7 +451,7 @@ namespace WixToolset.Core.Burn.Bundles
 
     internal struct ContainerSlot
     {
-        public ContainerSlot(uint size) : this()
+        public ContainerSlot(uint size)
         {
             this.Size = size;
         }

--- a/src/wix/WixToolset.Core.Burn/Bundles/BurnWriter.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/BurnWriter.cs
@@ -135,13 +135,13 @@ namespace WixToolset.Core.Burn.Bundles
             var nextAddress = this.EngineSize;
             for (var i = 1; i < reader.AttachedContainers.Count; i++)
             {
-                var cntnr = reader.AttachedContainers[i];
+                var slot = reader.AttachedContainers[i];
 
                 reader.Stream.Seek(nextAddress, SeekOrigin.Begin);
                 // TODO: verify that the size in the section data is 0 or the same size.
-                this.AppendContainer(reader.Stream, cntnr.Size, BurnCommon.Container.Attached);
+                this.AppendContainer(reader.Stream, slot.Size, BurnCommon.Container.Attached);
 
-                nextAddress += cntnr.Size;
+                nextAddress += slot.Size;
             }
 
             return true;

--- a/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleEngineCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleEngineCommand.cs
@@ -37,7 +37,7 @@ namespace WixToolset.Core.Burn.Inscribe
             {
                 reader.Stream.Seek(0, SeekOrigin.Begin);
 
-                var buffer = new byte[4 * 1024];
+                var buffer = new byte[8 * 1024];
                 var total = 0;
                 var read = 0;
                 do

--- a/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.targets
+++ b/src/wix/WixToolset.Sdk/tools/WixToolset.Signing.targets
@@ -246,7 +246,7 @@
 
     <DetachBundleEngineForSigning
         BundleFile="@(SignTargetPath)"
-        OutputFile="$(IntermediateOutputPath)%(SignTargetPath.Filename)%(SignTargetPath.Extension)"
+        OutputFile="$(IntermediateOutputPath)%(SignTargetPath.Filename)-engine%(SignTargetPath.Extension)"
         IntermediateDirectory="%(SignTargetPath.RootDir)%(SignTargetPath.Directory)"
 
         NoLogo="$(InscribeNoLogo)"
@@ -264,7 +264,7 @@
 
     <!-- Explicitly add output to FileWrites to ensure it is included even when the target is up to date. -->
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)%(SignTargetPath.Filename)%(SignTargetPath.Extension)" />
+      <FileWrites Include="$(IntermediateOutputPath)%(SignTargetPath.Filename)-engine%(SignTargetPath.Extension)" />
     </ItemGroup>
   </Target>
 
@@ -275,7 +275,7 @@
     To be called after signing the bundle engine to reattach the attached container.
 
     [IN]
-    @(Inscribe) - The bundle to inscribe.
+    @(SignBundleEngine) - The bundle to inscribe.
 
     [OUT]
     @(SignBundle) - The bundle engine file to be signed.
@@ -288,7 +288,7 @@
   <Target
       Name="InscribeBundle"
       DependsOnTargets="$(InscribeBundleDependsOn)"
-      Inputs="@(SignTargetPath)"
+      Inputs="@(SignTargetPath);@(SignBundleEngine)"
       Outputs="$(SignedFilePath)">
 
     <ReattachSignedBundleEngine

--- a/src/wix/test/WixToolsetTest.Sdk/MsbuildFixture.cs
+++ b/src/wix/test/WixToolsetTest.Sdk/MsbuildFixture.cs
@@ -41,7 +41,7 @@ namespace WixToolsetTest.Sdk
                 var testMessages = result.Output.Where(line => line.Contains("TEST:")).Select(line => line.Trim()).ToArray();
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"TEST: SignBundleEngine: obj\x86\Release\SimpleBundle.exe",
+                    @"TEST: SignBundleEngine: obj\x86\Release\SimpleBundle-engine.exe",
                     @"TEST: SignBundle: obj\x86\Release\SimpleBundle.exe",
                 }, testMessages);
 
@@ -84,7 +84,7 @@ namespace WixToolsetTest.Sdk
                 var testMessages = result.Output.Where(line => line.Contains("TEST:")).Select(line => line.Trim()).ToArray();
                 WixAssert.CompareLineByLine(new[]
                 {
-                    @"TEST: SignBundleEngine: obj\x86\Release\UncompressedBundle.exe",
+                    @"TEST: SignBundleEngine: obj\x86\Release\UncompressedBundle-engine.exe",
                 }, testMessages);
 
                 var paths = Directory.EnumerateFiles(binFolder, @"*.*", SearchOption.AllDirectories)


### PR DESCRIPTION
* Sign WixAdditionalTools bundle - fixes wixtoolset/issues#7083
* Ensure engine inscribe path is different from the original engine path - fixes wixtoolset/issues#7085
