### PR TITLE
Stop Richedit control from scrolling during load.

### DIFF
--- a/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
@@ -6229,7 +6229,7 @@ static HRESULT LoadControls(
             }
 
             wzWindowClass = vhModuleMsftEdit ? MSFTEDIT_CLASS : RICHEDIT_CLASSW;
-            dwWindowBits |= ES_AUTOVSCROLL | ES_MULTILINE | WS_VSCROLL | ES_READONLY;
+            dwWindowBits |= ES_SAVESEL | ES_MULTILINE | WS_VSCROLL | ES_READONLY;
             break;
 
         case THEME_CONTROL_TYPE_STATIC:


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/7113.