### PR TITLE
VSExtension cleanup:

### DIFF
--- a/src/ext/VisualStudio/ca/vsca.vcxproj
+++ b/src/ext/VisualStudio/ca/vsca.vcxproj
@@ -19,6 +19,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
 
   <PropertyGroup Label="Globals">

--- a/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/TestData/UsingVsixPackage/Package.wxs
+++ b/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/TestData/UsingVsixPackage/Package.wxs
@@ -1,9 +1,10 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:vs="http://wixtoolset.org/schemas/v4/wxs/vs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:vs="http://wixtoolset.org/schemas/v4/wxs/vs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
     <vs:FindVisualStudio />
     <PropertyRef Id="VS2017DEVENV" />
+    <PropertyRef Id="VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" />
     <PropertyRef Id="VS2022_ROOT_FOLDER" />
 
     <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">

--- a/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/VisualStudioExtensionFixture.cs
+++ b/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/VisualStudioExtensionFixture.cs
@@ -6,6 +6,7 @@ namespace WixToolsetTest.VisualStudio
     using WixInternal.Core.TestPackage;
     using WixToolset.VisualStudio;
     using Xunit;
+    using System.Linq;
 
     public class VisualStudioExtensionFixture
     {
@@ -35,10 +36,46 @@ namespace WixToolsetTest.VisualStudio
             }, results);
         }
 
+        [Fact]
+        public void CanBuildUsingVsixPackageOnArm64()
+        {
+            var folder = TestData.Get(@"TestData\UsingVsixPackage");
+            var build = new Builder(folder, typeof(VSExtensionFactory), new[] { folder });
+
+            var results = build.BuildAndQuery(BuildARM64, "CustomAction");
+            WixAssert.CompareLineByLine(new[]
+            {
+                "CustomAction:SetVS2010Vsix\t51\tVS_VSIX_INSTALLER_PATH\t[VS2010_VSIX_INSTALLER_PATH]\t",
+                "CustomAction:SetVS2012Vsix\t51\tVS_VSIX_INSTALLER_PATH\t[VS2012_VSIX_INSTALLER_PATH]\t",
+                "CustomAction:SetVS2013Vsix\t51\tVS_VSIX_INSTALLER_PATH\t[VS2013_VSIX_INSTALLER_PATH]\t",
+                "CustomAction:SetVS2015Vsix\t51\tVS_VSIX_INSTALLER_PATH\t[VS2015_VSIX_INSTALLER_PATH]\t",
+                "CustomAction:vimLa9TyFoAVwf8JmA0_ZJHA69J2fo\t3122\tVS_VSIX_INSTALLER_PATH\t/q  \"[#filzi8nwT8Ta133xcfp7qSIdGdRiC0]\" /admin\t",
+                "CustomAction:viuMpl8IvFSDAzTulrmpAzBwAmCRTQ\t1074\tVS_VSIX_INSTALLER_PATH\t/q  \"[#filzi8nwT8Ta133xcfp7qSIdGdRiC0]\"\t",
+                "CustomAction:vrmLa9TyFoAVwf8JmA0_ZJHA69J2fo\t3442\tVS_VSIX_INSTALLER_PATH\t/q  /u:\"ExampleVsix\" /admin\t",
+                "CustomAction:vruMpl8IvFSDAzTulrmpAzBwAmCRTQ\t1394\tVS_VSIX_INSTALLER_PATH\t/q  /u:\"ExampleVsix\"\t",
+                "CustomAction:vumLa9TyFoAVwf8JmA0_ZJHA69J2fo\t3186\tVS_VSIX_INSTALLER_PATH\t/q  /u:\"ExampleVsix\" /admin\t",
+                "CustomAction:vuuMpl8IvFSDAzTulrmpAzBwAmCRTQ\t1138\tVS_VSIX_INSTALLER_PATH\t/q  /u:\"ExampleVsix\"\t",
+                "CustomAction:Vwd2012VsixWhenVSAbsent\t51\tVS_VSIX_INSTALLER_PATH\t[VWD2012_VSIX_INSTALL_ROOT]\\Common7\\IDE\\VSIXInstaller.exe\t",
+                "CustomAction:Vwd2013VsixWhenVSAbsent\t51\tVS_VSIX_INSTALLER_PATH\t[VWD2013_VSIX_INSTALL_ROOT]\\Common7\\IDE\\VSIXInstaller.exe\t",
+                "CustomAction:Vwd2015VsixWhenVSAbsent\t51\tVS_VSIX_INSTALLER_PATH\t[VWD2015_VSIX_INSTALL_ROOT]\\Common7\\IDE\\VSIXInstaller.exe\t",
+                "CustomAction:Wix4VSFindInstances_A64\t257\tVSCA_A64\tFindInstances\t",
+            }, results);
+        }
+
         private static void Build(string[] args)
         {
             var result = WixRunner.Execute(args)
                                   .AssertSuccess();
+        }
+
+        private static void BuildARM64(string[] args)
+        {
+            var newArgs = args.ToList();
+            newArgs.Add("-platform");
+            newArgs.Add("arm64");
+
+            var result = WixRunner.Execute(newArgs.ToArray());
+            result.AssertSuccess();
         }
     }
 }

--- a/src/ext/VisualStudio/wixext/VSCompiler.cs
+++ b/src/ext/VisualStudio/wixext/VSCompiler.cs
@@ -76,7 +76,7 @@ namespace WixToolset.VisualStudio
 
             this.ParseHelper.ParseForExtensionElements(this.Context.Extensions, intermediate, section, element);
 
-            this.ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "Wix4VSFindInstances", this.Context.Platform, CustomActionPlatforms.X86 | CustomActionPlatforms.X64);
+            this.ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "Wix4VSFindInstances", this.Context.Platform, CustomActionPlatforms.X86 | CustomActionPlatforms.X64 | CustomActionPlatforms.ARM64);
         }
 
         private void ParseVsixPackageElement(Intermediate intermediate, IntermediateSection section, XElement element, string componentId, string fileId)

--- a/src/ext/VisualStudio/wixlib/VS2017.wxs
+++ b/src/ext/VisualStudio/wixlib/VS2017.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -91,7 +91,6 @@
     <!-- C# language tools were installed as a part of VS 2017 setup.              -->
     <Fragment>
         <Property Id="VS2017_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Basic project system is installed as a part of -->
@@ -100,7 +99,6 @@
     <!-- Basic language tools were installed as a part of VS 2017 setup.             -->
     <Fragment>
         <Property Id="VS2017_IDE_VB_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Web Developer project system is installed as a part of -->
@@ -109,7 +107,6 @@
     <!-- Web Developer language tools were installed as a part of VS 2017 setup.             -->
     <Fragment>
         <Property Id="VS2017_IDE_VWD_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual C++ project system is installed as a part of -->
@@ -118,24 +115,20 @@
     <!-- C++ language tools were installed as a part of VS 2017 setup.             -->
     <Fragment>
         <Property Id="VS2017_IDE_VC_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio 2017 Team Test project system is installed -->
     <Fragment>
         <Property Id="VS2017_IDE_VSTS_TESTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio Modeling project system is installed -->
     <Fragment>
         <Property Id="VS2017_IDE_MODELING_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio F# project system is installed -->
     <Fragment>
         <Property Id="VS2017_IDE_FSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 </Wix>

--- a/src/ext/VisualStudio/wixlib/VS2019.wxs
+++ b/src/ext/VisualStudio/wixlib/VS2019.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -91,7 +91,6 @@
     <!-- C# language tools were installed as a part of VS 2019 setup.              -->
     <Fragment>
         <Property Id="VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Basic project system is installed as a part of -->
@@ -100,7 +99,6 @@
     <!-- Basic language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Web Developer project system is installed as a part of -->
@@ -109,7 +107,6 @@
     <!-- Web Developer language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual C++ project system is installed as a part of -->
@@ -118,24 +115,20 @@
     <!-- C++ language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VC_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio 2019 Team Test project system is installed -->
     <Fragment>
         <Property Id="VS2019_IDE_VSTS_TESTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio Modeling project system is installed -->
     <Fragment>
         <Property Id="VS2019_IDE_MODELING_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio F# project system is installed -->
     <Fragment>
         <Property Id="VS2019_IDE_FSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 </Wix>

--- a/src/ext/VisualStudio/wixlib/VS2022.wxs
+++ b/src/ext/VisualStudio/wixlib/VS2022.wxs
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
@@ -91,7 +91,6 @@
     <!-- C# language tools were installed as a part of VS 2019 setup.              -->
     <Fragment>
         <Property Id="VS2022_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Basic project system is installed as a part of -->
@@ -100,7 +99,6 @@
     <!-- Basic language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2022_IDE_VB_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Web Developer project system is installed as a part of -->
@@ -109,7 +107,6 @@
     <!-- Web Developer language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2022_IDE_VWD_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual C++ project system is installed as a part of -->
@@ -118,24 +115,20 @@
     <!-- C++ language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2022_IDE_VC_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio 2019 Team Test project system is installed -->
     <Fragment>
         <Property Id="VS2022_IDE_VSTS_TESTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio Modeling project system is installed -->
     <Fragment>
         <Property Id="VS2022_IDE_MODELING_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Studio F# project system is installed -->
     <Fragment>
         <Property Id="VS2022_IDE_FSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
-        <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 </Wix>

--- a/src/ext/VisualStudio/wixlib/VSExtension_arm64.wxs
+++ b/src/ext/VisualStudio/wixlib/VSExtension_arm64.wxs
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?define platform=arm64 ?>
+    <?include VSExtension_Platform.wxi ?>
+</Wix>

--- a/src/ext/VisualStudio/wixlib/vs.wixproj
+++ b/src/ext/VisualStudio/wixlib/vs.wixproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ca\vsca.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ca\vsca.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ca\vsca.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/WixToolset.Converters/WixConverter.cs
+++ b/src/wix/WixToolset.Converters/WixConverter.cs
@@ -1532,13 +1532,6 @@ namespace WixToolset.Converters
                     newElementName = "QueryNativeMachine";
                     break;
                 case "VS2017_ROOT_FOLDER":
-                case "VS2017DEVENV":
-                case "VS2017_EXTENSIONS_DIR":
-                case "VS2017_ITEMTEMPLATES_DIR":
-                case "VS2017_PROJECTTEMPLATES_DIR":
-                case "VS2017_SCHEMAS_DIR":
-                case "VS2017_IDE_DIR":
-                case "VS2017_BOOTSTRAPPER_PACKAGE_FOLDER":
                 case "VS2017_IDE_FSHARP_PROJECTSYSTEM_INSTALLED":
                 case "VS2017_IDE_VB_PROJECTSYSTEM_INSTALLED":
                 case "VS2017_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED":
@@ -1547,13 +1540,6 @@ namespace WixToolset.Converters
                 case "VS2017_IDE_VWD_PROJECTSYSTEM_INSTALLED":
                 case "VS2017_IDE_MODELING_PROJECTSYSTEM_INSTALLED":
                 case "VS2019_ROOT_FOLDER":
-                case "VS2019DEVENV":
-                case "VS2019_EXTENSIONS_DIR":
-                case "VS2019_ITEMTEMPLATES_DIR":
-                case "VS2019_PROJECTTEMPLATES_DIR":
-                case "VS2019_SCHEMAS_DIR":
-                case "VS2019_IDE_DIR":
-                case "VS2019_BOOTSTRAPPER_PACKAGE_FOLDER":
                 case "VS2019_IDE_FSHARP_PROJECTSYSTEM_INSTALLED":
                 case "VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED":
                 case "VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED":
@@ -1562,13 +1548,6 @@ namespace WixToolset.Converters
                 case "VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED":
                 case "VS2019_IDE_MODELING_PROJECTSYSTEM_INSTALLED":
                 case "VS2022_ROOT_FOLDER":
-                case "VS2022DEVENV":
-                case "VS2022_EXTENSIONS_DIR":
-                case "VS2022_ITEMTEMPLATES_DIR":
-                case "VS2022_PROJECTTEMPLATES_DIR":
-                case "VS2022_SCHEMAS_DIR":
-                case "VS2022_IDE_DIR":
-                case "VS2022_BOOTSTRAPPER_PACKAGE_FOLDER":
                 case "VS2022_IDE_FSHARP_PROJECTSYSTEM_INSTALLED":
                 case "VS2022_IDE_VB_PROJECTSYSTEM_INSTALLED":
                 case "VS2022_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED":
@@ -1576,6 +1555,33 @@ namespace WixToolset.Converters
                 case "VS2022_IDE_VC_PROJECTSYSTEM_INSTALLED":
                 case "VS2022_IDE_VWD_PROJECTSYSTEM_INSTALLED":
                 case "VS2022_IDE_MODELING_PROJECTSYSTEM_INSTALLED":
+                    newElementName = "FindVisualStudio";
+                    newNamespace = WixVSNamespace;
+                    newNamespaceName = "vs";
+                    break;
+                case "VS2017DEVENV":
+                case "VS2017_EXTENSIONS_DIR":
+                case "VS2017_ITEMTEMPLATES_DIR":
+                case "VS2017_PROJECTTEMPLATES_DIR":
+                case "VS2017_SCHEMAS_DIR":
+                case "VS2017_IDE_DIR":
+                case "VS2017_BOOTSTRAPPER_PACKAGE_FOLDER":
+                case "VS2019DEVENV":
+                case "VS2019_EXTENSIONS_DIR":
+                case "VS2019_ITEMTEMPLATES_DIR":
+                case "VS2019_PROJECTTEMPLATES_DIR":
+                case "VS2019_SCHEMAS_DIR":
+                case "VS2019_IDE_DIR":
+                case "VS2019_BOOTSTRAPPER_PACKAGE_FOLDER":
+                case "VS2022DEVENV":
+                case "VS2022_EXTENSIONS_DIR":
+                case "VS2022_ITEMTEMPLATES_DIR":
+                case "VS2022_PROJECTTEMPLATES_DIR":
+                case "VS2022_SCHEMAS_DIR":
+                case "VS2022_IDE_DIR":
+                case "VS2022_BOOTSTRAPPER_PACKAGE_FOLDER":
+                    // These PropertyRefs need to stay (in addition to the `FindVisualStudio`
+                    // addition) because they're constructed from deeper AppSearches.
                     newElementName = "FindVisualStudio";
                     newNamespace = WixVSNamespace;
                     newNamespaceName = "vs";

--- a/src/wix/test/WixToolsetTest.Converters/VSExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/VSExtensionFixture.cs
@@ -27,7 +27,7 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\" xmlns:vs=\"http://wixtoolset.org/schemas/v4/wxs/vs\">",
                 "  <Fragment>",
-                "    <vs:FindVisualStudio /><PropertyRef Id=\"VS2019_ROOT_FOLDER\" />",
+                "    <vs:FindVisualStudio />",
                 "    <vs:FindVisualStudio /><PropertyRef Id=\"VS2022_BOOTSTRAPPER_PACKAGE_FOLDER\" />",
                 "    <CustomActionRef Id=\"VS2017Setup\" />",
                 "  </Fragment>",


### PR DESCRIPTION
- Add ARM64-specific custom action.
- Remove "naked" `CustomActionRef`s.
- Clean up `wix convert` behavior:
  - Remove `PropertyRef`s for properties CA always sets.

Fixes https://github.com/wixtoolset/issues/issues/7100. 
Fixes https://github.com/wixtoolset/issues/issues/7153.