### PR TITLE
Remove extension data after extensions get PreDecompileTables callback

### DIFF
--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/Queries/Package.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/Queries/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
     <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
         <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
@@ -13,10 +13,10 @@
     </Package>
 
     <Fragment><util:BroadcastSettingChange />
-        
-        
-    
-            <StandardDirectory Id="ProgramFilesFolder">
+        <util:QueryNativeMachine />
+
+
+        <StandardDirectory Id="ProgramFilesFolder">
                 <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
             </StandardDirectory>
         </Fragment>

--- a/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
+++ b/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
@@ -9,6 +9,7 @@ namespace WixToolsetTest.Util
     using WixInternal.Core.TestPackage;
     using WixToolset.Util;
     using Xunit;
+    using System.Xml.Linq;
 
     public class UtilExtensionFixture
     {
@@ -62,9 +63,20 @@ namespace WixToolsetTest.Util
             var output = Path.Combine(folder, "decompile.xml");
 
             build.BuildAndDecompileAndBuild(Build, Decompile, output);
-            File.Exists(output);
-        }
 
+            var doc = XDocument.Load(output);
+            var utilElementNames = doc.Descendants()
+                .Where(e => e.Name.Namespace == "http://wixtoolset.org/schemas/v4/wxs/util")
+                .Select(e => e.Name.LocalName)
+                .OrderBy(s => s)
+                .ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileShare",
+                "FileSharePermission",
+                "User",
+            }, utilElementNames);
+        }
 
         [Fact]
         public void CanBuildCloseApplication()
@@ -225,9 +237,36 @@ namespace WixToolsetTest.Util
                 "CustomAction:Wix4BroadcastEnvironmentChange_A64\t65\tWix4UtilCA_A64\tWixBroadcastEnvironmentChange\t",
                 "CustomAction:Wix4BroadcastSettingChange_A64\t65\tWix4UtilCA_A64\tWixBroadcastSettingChange\t",
                 "CustomAction:Wix4CheckRebootRequired_A64\t65\tWix4UtilCA_A64\tWixCheckRebootRequired\t",
+                "CustomAction:Wix4QueryNativeMachine_A64\t257\tWix4UtilCA_A64\tWixQueryNativeMachine\t",
                 "CustomAction:Wix4QueryOsDriverInfo_A64\t257\tWix4UtilCA_A64\tWixQueryOsDriverInfo\t",
                 "CustomAction:Wix4QueryOsInfo_A64\t257\tWix4UtilCA_A64\tWixQueryOsInfo\t",
             }, results.OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void CanBuildAndDecompiileQueries()
+        {
+            var folder = TestData.Get(@"TestData\Queries");
+            var build = new Builder(folder, typeof(UtilExtensionFactory), new[] { folder });
+            var output = Path.Combine(folder, "decompile.xml");
+
+            build.BuildAndDecompileAndBuild(Build, Decompile, output);
+
+            var doc = XDocument.Load(output);
+            var utilElementNames = doc.Descendants()
+                .Where(e => e.Name.Namespace == "http://wixtoolset.org/schemas/v4/wxs/util")
+                .Select(e => e.Name.LocalName)
+                .OrderBy(s => s)
+                .ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "BroadcastEnvironmentChange",
+                "BroadcastSettingChange",
+                "CheckRebootRequired",
+                "QueryNativeMachine",
+                "QueryWindowsDriverInfo",
+                "QueryWindowsSuiteInfo",
+            }, utilElementNames);
         }
 
         [Fact]

--- a/src/ext/Util/wixext/UtilConstants.cs
+++ b/src/ext/Util/wixext/UtilConstants.cs
@@ -11,6 +11,9 @@ namespace WixToolset.Util
     {
         internal static readonly XNamespace Namespace = "http://wixtoolset.org/schemas/v4/wxs/util";
 
+        internal static readonly XName BroadcastEnvironmentChange = Namespace + "BroadcastEnvironmentChange";
+        internal static readonly XName BroadcastSettingChange = Namespace + "BroadcastSettingChange";
+        internal static readonly XName CheckRebootRequired = Namespace + "CheckRebootRequired";
         internal static readonly XName CloseApplicationName = Namespace + "CloseApplication";
         internal static readonly XName EventManifestName = Namespace + "EventManifest";
         internal static readonly XName FileShareName = Namespace + "FileShare";
@@ -21,6 +24,9 @@ namespace WixToolset.Util
         internal static readonly XName PerfCounterName = Namespace + "PerfCounter";
         internal static readonly XName PerfCounterManifestName = Namespace + "PerfCounterManifest";
         internal static readonly XName PermissionExName = Namespace + "PermissionEx";
+        internal static readonly XName QueryNativeMachine = Namespace + "QueryNativeMachine";
+        internal static readonly XName QueryWindowsDriverInfo = Namespace + "QueryWindowsDriverInfo";
+        internal static readonly XName QueryWindowsSuiteInfo = Namespace + "QueryWindowsSuiteInfo";
         internal static readonly XName RemoveFolderExName = Namespace + "RemoveFolderEx";
         internal static readonly XName RestartResourceName = Namespace + "RestartResource";
         internal static readonly XName ServiceConfigName = Namespace + "ServiceConfig";

--- a/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
@@ -2384,12 +2384,12 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                 this.DecompilerHelper.RootElement.SetAttributeValue("Guid", this.ModularizationGuid);
             }
 
-            this.RemoveExtensionDataFromTables(tables);
-
             foreach (var extension in this.Extensions)
             {
                 extension.PreDecompileTables(tables);
             }
+
+            this.RemoveExtensionDataFromTables(tables);
         }
 
         private void RemoveExtensionDataFromTables(TableIndexedCollection tables)


### PR DESCRIPTION
Also update Util.wixext decompiler extension to handle the new elements that compile into CustomActions with no additional table data. These exposed the weakness in the decompiler where extension data was removed before extensions got a chance to pre-decompile.

Fixes wixtoolset/issues#7151