### PR TITLE
Warn when using `embedded` as the pdbType and fallback to `full`

### DIFF
--- a/src/api/wix/WixToolset.Data/WarningMessages.cs
+++ b/src/api/wix/WixToolset.Data/WarningMessages.cs
@@ -643,6 +643,11 @@ namespace WixToolset.Data
             return Message(null, Ids.UnsupportedCommandLineArgument, "'{0}' is not a valid command line argument.", arg);
         }
 
+        public static Message UnsupportedCommandLineArgumentValue(string arg, string value, string fallback)
+        {
+            return Message(null, Ids.UnsupportedCommandLineArgument, "The value '{0}' is not a valid value for command line argument '{1}'. Using the value '{2}' instead.", value, arg, fallback);
+        }
+
         public static Message UpdateOfNonKeyPathFile(string nonKeyPathFileId, string componentId, string keyPathFileId)
         {
             return Message(null, Ids.UpdateOfNonKeyPathFile, "File '{0}' in Component '{1}' was changed, but the KeyPath file '{2}' was not. This file will not be patched on the target system if the REINSTALLMODE does not contain 'A'. The KeyPath file should also be changed and included in your patch.", nonKeyPathFileId, componentId, keyPathFileId);

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -682,7 +682,16 @@ namespace WixToolset.Core.CommandLine
                             }
                             else if (!String.IsNullOrEmpty(value))
                             {
-                                parser.ReportErrorArgument(arg, ErrorMessages.IllegalCommandLineArgumentValue(arg, value, Enum.GetNames(typeof(PdbType)).Select(s => s.ToLowerInvariant())));
+                                if (value.Equals("embedded", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    this.Messaging.Write(WarningMessages.UnsupportedCommandLineArgumentValue(arg, value, "full"));
+
+                                    this.PdbType = PdbType.Full;
+                                }
+                                else
+                                {
+                                    parser.ReportErrorArgument(arg, ErrorMessages.IllegalCommandLineArgumentValue(arg, value, Enum.GetNames(typeof(PdbType)).Select(s => s.ToLowerInvariant())));
+                                }
                             }
 
                             return true;


### PR DESCRIPTION
Fixes wixtoolset/issues#7152