### PR TITLE
Add ability to use old style WIX Custom actions names

### DIFF
--- a/src/ext/UI/test/WixToolsetTest.UI/TestData/WixUI_FlatAction/Package.wxs
+++ b/src/ext/UI/test/WixToolsetTest.UI/TestData/WixUI_FlatAction/Package.wxs
@@ -1,0 +1,26 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+    <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" InstallerVersion="200">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <Feature Id="ProductFeature" Title="MsiPackage">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="example.txt" />
+            </Component>
+        </ComponentGroup>
+
+        <ui:WixUI Id="WixUI_Minimal" />
+        <UI>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="4" />
+        </UI>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
+++ b/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
@@ -303,6 +303,24 @@ namespace WixToolsetTest.UI
             }, results.Where(s => s.StartsWith("Control:ErrorDlg\tY")).Select(s => s.Split('\t')[9]).ToArray());
         }
 
+        [Fact]
+        public void CanRunFlatActions()
+        {
+            var folder = TestData.Get(@"TestData\WisUI_FlatAction");
+            var bindFolder = TestData.Get(@"TestData\data");
+            var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
+
+            var results = build.BuildAndQuery(Build, "CustomAction", "ControlEvent");
+            WixAssert.CompareLineByLine(new[]
+            {
+               "ControlEvent:WelcomeDlg\tNext\tDoAction\tWixUIValidatePath_X86\t1\t4",
+               "ControlEvent:WelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1"
+            }, results.Where(s => s.Contains("DoAction")).OrderBy(s => s).ToArray());
+
+               
+
+        }
+
         private static void Build(string[] args)
         {
             var result = WixRunner.Execute(args)

--- a/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
+++ b/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
@@ -18,4 +18,8 @@
   <ItemGroup>
     <PackageReference Include="WixInternal.Core.TestPackage" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestData\WisUI_FlatAction\" />
+  </ItemGroup>
 </Project>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/Package.en-us.wxl
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/Package.en-us.wxl
@@ -1,0 +1,9 @@
+﻿<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
+  <String Id="FeatureTitle" Value="MsiPackage" />
+
+</WixLocalization>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/Package.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/Package.wxs
@@ -1,0 +1,19 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+        <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+        <InstallExecuteSequence>
+            <Custom Action="Wix4SchedXmlConfig" After="InstallFiles" Condition="SOME_CONDITION"/>
+            <Custom Action="Wix4ConfigureSmbInstall" After="Wix4SchedXmlConfig" Condition="Another_Condition"/>
+        </InstallExecuteSequence>
+    </Package>
+
+    <Fragment>
+            <StandardDirectory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+            </StandardDirectory>
+        </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/PackageComponents.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/PackageComponents.wxs
@@ -1,0 +1,14 @@
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Fragment>
+        <util:User Id="Everyone" Name="Everyone" />
+
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="example.txt" />
+                <util:FileShare Id="ExampleFileShare" Description="An example file share" Name="example">
+                    <util:FileSharePermission User="Everyone" Read="yes" />
+                </util:FileShare>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/example.txt
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/FlatActionsNames/example.txt
@@ -1,0 +1,1 @@
+This is example.txt.

--- a/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
+++ b/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
@@ -10,6 +10,7 @@ namespace WixToolsetTest.Util
     using WixToolset.Util;
     using Xunit;
     using System.Xml.Linq;
+    using System;
 
     public class UtilExtensionFixture
     {
@@ -511,6 +512,43 @@ namespace WixToolsetTest.Util
                     "The WindowsFeatureSearch/@Variable attribute's value, 'NTProductType', is one of the illegal options: 'AdminToolsFolder', 'AppDataFolder', 'CommonAppDataFolder', 'CommonFiles64Folder', 'CommonFiles6432Folder', 'CommonFilesFolder', 'CompatibilityMode', 'ComputerName', 'Date', 'DesktopFolder', 'FavoritesFolder', 'FontsFolder', 'InstallerName', 'InstallerVersion', 'LocalAppDataFolder', 'LogonUser', 'MyPicturesFolder', 'NativeMachine', 'NTProductType', 'NTSuiteBackOffice', 'NTSuiteDataCenter', 'NTSuiteEnterprise', 'NTSuitePersonal', 'NTSuiteSmallBusiness', 'NTSuiteSmallBusinessRestricted', 'NTSuiteWebServer', 'PersonalFolder', 'Privileged', 'ProcessorArchitecture', 'ProgramFiles64Folder', 'ProgramFiles6432Folder', 'ProgramFilesFolder', 'ProgramMenuFolder', 'RebootPending', 'SendToFolder', 'ServicePackLevel', 'StartMenuFolder', 'StartupFolder', 'System64Folder', 'SystemFolder', 'SystemLanguageID', 'TempFolder', 'TemplateFolder', 'TerminalServer', 'UserLanguageID', 'UserUILanguageID', 'VersionMsi', 'VersionNT', 'VersionNT64', 'WindowsBuildNumber', 'WindowsFolder', 'WindowsVolume', 'WixBundleAction', 'WixBundleActiveParent', 'WixBundleCommandLineAction', 'WixBundleElevated', 'WixBundleExecutePackageAction', 'WixBundleExecutePackageCacheFolder', 'WixBundleForcedRestartPackage', 'WixBundleInstalled', 'WixBundleProviderKey', 'WixBundleSourceProcessFolder', 'WixBundleSourceProcessPath', 'WixBundleTag', 'WixBundleUILevel', or 'WixBundleVersion'.",
                 }, messages.ToArray());
             }
+        }
+
+        [Fact]
+        public void CanBuildWithFlatActionName()
+        {
+            var folder = TestData.Get(@"TestData\FlatActionsNames");
+            var build = new Builder(folder, typeof(UtilExtensionFactory), new[] { folder });
+
+            var results = build.BuildAndQuery(Build, true, "InstallExecuteSequence");
+            WixAssert.CompareLineByLine(new[]
+            {
+                "InstallExecuteSequence:FindRelatedProducts\t\t25",
+                "InstallExecuteSequence:LaunchConditions\t\t100",
+                "InstallExecuteSequence:ValidateProductID\t\t700",
+                "InstallExecuteSequence:CostInitialize\t\t800",
+                "InstallExecuteSequence:FileCost\t\t900",
+                "InstallExecuteSequence:CostFinalize\t\t1000",
+                "InstallExecuteSequence:MigrateFeatureStates\t\t1200",
+                "InstallExecuteSequence:InstallValidate\t\t1400",
+                "InstallExecuteSequence:RemoveExistingProducts\t\t1401",
+                "InstallExecuteSequence:InstallInitialize\t\t1500",
+                "InstallExecuteSequence:ProcessComponents\t\t1600",
+                "InstallExecuteSequence:UnpublishFeatures\t\t1800",
+                "InstallExecuteSequence:RemoveFiles\t\t3500",
+                "InstallExecuteSequence:Wix4ConfigureSmbUninstall_X86\tVersionNT > 400\t3501",
+                "InstallExecuteSequence:RemoveFolders\t\t3600",
+                "InstallExecuteSequence:CreateFolders\t\t3700",
+                "InstallExecuteSequence:InstallFiles\t\t4000",
+                "InstallExecuteSequence:Wix4SchedXmlConfig_X86\tSOME_CONDITION\t4001",
+                "InstallExecuteSequence:Wix4ConfigureSmbInstall_X86\tAnother_Condition\t4002",
+                "InstallExecuteSequence:RegisterUser\t\t6000",
+                "InstallExecuteSequence:RegisterProduct\t\t6100",
+                "InstallExecuteSequence:PublishFeatures\t\t6300",
+                "InstallExecuteSequence:PublishProduct\t\t6400",
+                "InstallExecuteSequence:InstallFinalize\t\t6600"
+            }, results.OrderBy(s => Int32.Parse(s.Substring(s.LastIndexOf('\t')))).ToArray());
+
         }
 
         private static void Build(string[] args)

--- a/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
+++ b/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
@@ -18,4 +18,8 @@
   <ItemGroup>
     <PackageReference Include="WixInternal.Core.TestPackage" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestData\FlatActionsNames\" />
+  </ItemGroup>
 </Project>

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -2466,7 +2466,7 @@ namespace WixToolset.Core
                         case "Action":
                             if (customAction)
                             {
-                                actionName = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
+                                actionName = this.ConvertActionName( this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
                                 this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.CustomAction, actionName);
                             }
                             else
@@ -2477,7 +2477,7 @@ namespace WixToolset.Core
                         case "After":
                             if (customAction || showDialog || specialAction || specialStandardAction)
                             {
-                                afterAction = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
+                                afterAction = this.ConvertActionName(this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
                                 this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), afterAction);
                             }
                             else
@@ -2488,7 +2488,7 @@ namespace WixToolset.Core
                         case "Before":
                             if (customAction || showDialog || specialAction || specialStandardAction)
                             {
-                                beforeAction = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
+                                beforeAction = this.ConvertActionName( this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
                                 this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), beforeAction);
                             }
                             else
@@ -4995,6 +4995,83 @@ namespace WixToolset.Core
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Adds platform suffix to old fasion names of WIX custom actions
+        /// This allows to specify WIX custom action names wihout specifying an architecture in Sequnces and dialogs.
+        /// Suffix will be added according to build architecture
+        /// </summary>
+        /// <param name="actionName"></param>
+        /// <returns></returns>
+        private string ConvertActionName(string actionName)
+        {
+            string tmp = actionName;
+
+            switch(actionName)
+            {
+                //Actions from Util extension
+                case "Wix4SchedXmlFile":
+                case "Wix4SchedXmlConfig":
+                case "Wix4WaitForEvent":
+                case "Wix4WaitForEventDeferred":
+                case "Wix4ExitEarlyWithSuccess":             
+                case "Wix4BroadcastSettingChange":
+                case "Wix4BroadcastEnvironmentChange":
+                case "Wix4ShellExecBinary":
+                case "Wix4ShellExec":
+                case "Wix4UnelevatedShellExec":
+                case "Wix4QuietExec":
+                case "Wix4SilentExec":
+                case "Wix4CheckRebootRequired":
+                case "Wix4CloseApplications":
+                case "Wix4ConfigureUsers":
+                case "Wix4ConfigureSmbInstall":
+                case "Wix4ConfigureSmbUninstall":
+                case "Wix4InstallPerfCounterData":
+                case "Wix4UninstallPerfCounterData":
+                case "Wix4ConfigurePerfmonInstall":
+                case "Wix4ConfigurePerfmonUninstall":
+                case "Wix4ConfigurePerfmonManifestRegister":
+                case "Wix4ConfigurePerfmonManifestUnregister":
+                case "Wix4ConfigureEventManifestRegister":
+                case "Wix4ConfigureEventManifestUnregister":
+                case "Wix4SchedServiceConfig":
+                case "Wix4TouchFileDuringInstall":
+                case "Wix4TouchFileDuringUninstall":
+                case "Wix4SchedInternetShortcuts":
+                case "Wix4SchedSecureObjects":
+                // Actions from IIS extension
+                case "Wix4ConfigureIIs":
+                case "Wix4InstallCertificates":
+                //Actions from ComPlus extension
+                case "Wix4ConfigureComPlusInstall":
+                case "Wix4ConfigureComPlusUninstall":
+                // Actions from dependency extension
+                case "Wix4DependencyRequire":
+                case "Wix4DependencyCheck":
+                // Actions from DirectX extension
+                case "Wix4QueryDirectXCaps":
+                //Actions from  firewall extension
+                case "Wix4SchedFirewallExceptionsInstall":
+                // Actions from HTTP extension
+                case "Wix4SchedHttpUrlReservationsInstall":
+                case "Wix4SchedHttpSniSslCertsInstall":
+                //Actions from MSMQ extension
+                case "Wix4MessageQueuingInstall":
+                //Actions from UI extension
+                case "WixUIValidatePath":
+                case "WixUIPrintEula":
+                // Actions from SQL extension
+                case "Wix4InstallSqlData":
+                    tmp = tmp + "_" + this.CurrentPlatform;
+                    break;
+                default:
+                    break;
+            }
+
+            return tmp;
+
         }
     }
 }

--- a/src/wix/WixToolset.Core/Compiler_UI.cs
+++ b/src/wix/WixToolset.Core/Compiler_UI.cs
@@ -4,6 +4,7 @@ namespace WixToolset.Core
 {
     using System;
     using System.Collections;
+    using System.Linq;
     using System.Xml.Linq;
     using WixToolset.Data;
     using WixToolset.Data.Symbols;
@@ -1727,6 +1728,18 @@ namespace WixToolset.Core
 
             this.Core.ParseForExtensionElements(node);
 
+            if ("DoAction" == controlEvent && null != argument)
+            {
+                // if we're not looking at a standard action or a formatted string then create a reference
+                // to the custom action.
+                if (!WindowsInstallerStandard.IsStandardAction(argument) && !this.Core.ContainsProperty(argument))
+                {
+                    // Convert old style custom action names to Wix4 standard
+                    argument = this.ConvertActionName(argument);
+                    this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.CustomAction, argument);
+                }
+            }
+
             if (!this.Core.EncounteredError)
             {
                 this.Core.AddSymbol(new ControlEventSymbol(sourceLineNumbers)
@@ -1740,15 +1753,7 @@ namespace WixToolset.Core
                 });
             }
 
-            if ("DoAction" == controlEvent && null != argument)
-            {
-                // if we're not looking at a standard action or a formatted string then create a reference
-                // to the custom action.
-                if (!WindowsInstallerStandard.IsStandardAction(argument) && !this.Core.ContainsProperty(argument))
-                {
-                    this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.CustomAction, argument);
-                }
-            }
+            
 
             // if we're referring to a dialog but not through a property, add it to the references
             if (("NewDialog" == controlEvent || "SpawnDialog" == controlEvent || "SpawnWaitDialog" == controlEvent || "SelectionBrowse" == controlEvent) && Common.IsIdentifier(argument))


### PR DESCRIPTION
This is fix for issues #6821 and #7178.
Description:
If compiler faces old fasion name (prefixed with Wix4 to differ from WIX 3 actions) then suffix of platform is added. The action names are stored in the code. I have added action names that may be mentioned explicitly in a project, by my opinion.