### PR TITLE
Change wixiuiba to request FORCE_PRESENT instead of REPAIR

### DIFF
--- a/src/ext/Bal/wixiuiba/WixInternalUIBootstrapperApplication.cpp
+++ b/src/ext/Bal/wixiuiba/WixInternalUIBootstrapperApplication.cpp
@@ -166,7 +166,7 @@ public: // IBootstrapperApplication
         else if (BOOTSTRAPPER_DISPLAY_FULL == m_command.display && !m_fAutomaticRemoval)
         {
             // Make sure the MSI UI is shown regardless of the current state of the package.
-            *pRequestState = BOOTSTRAPPER_REQUEST_STATE_REPAIR;
+            *pRequestState = BOOTSTRAPPER_REQUEST_STATE_FORCE_PRESENT;
         }
 
         return __super::OnPlanPackageBegin(wzPackageId, state, fCached, installCondition, repairCondition, recommendedState, recommendedCacheType, pRequestState, pRequestedCacheType, pfCancel);


### PR DESCRIPTION
Sending REINSTALL on the command line doesn't allow the maintenance dialog to be shown. The reason it worked when initially developed was because Burn temporarily had a bug where it wasn't passing REINSTALL during repair.

Fixes https://github.com/wixtoolset/issues/issues/7184