### PR TITLE
Convert old style WIX Custom Actions names

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/BaseCompilerExtension.cs
+++ b/src/api/wix/WixToolset.Extensibility/BaseCompilerExtension.cs
@@ -41,6 +41,11 @@ namespace WixToolset.Extensibility
         protected IComponentKeyPath CreateComponentKeyPath() => this.Context.ServiceProvider.GetService<IComponentKeyPath>();
 
         /// <summary>
+        /// Returns list of old fasion WIX custom action names (prefixed with WiX and without platform suffix)
+        /// </summary>
+        public virtual List<string> ActionNames { get { return new List<string>(); } }  
+
+        /// <summary>
         /// Called at the beginning of the compilation of a source file.
         /// </summary>
         public virtual void PreCompile(ICompileContext context)

--- a/src/api/wix/WixToolset.Extensibility/ICompilerExtension.cs
+++ b/src/api/wix/WixToolset.Extensibility/ICompilerExtension.cs
@@ -19,6 +19,11 @@ namespace WixToolset.Extensibility
         XNamespace Namespace { get; }
 
         /// <summary>
+        /// Keeps list os actions that can be converted from old style names to WiX 4 format
+        /// </summary>
+        List<string> ActionNames { get; }
+
+        /// <summary>
         /// Called at the beginning of the compilation of a source file.
         /// </summary>
         void PreCompile(ICompileContext context);

--- a/src/ext/ComPlus/wixext/ComPlusCompiler.cs
+++ b/src/ext/ComPlus/wixext/ComPlusCompiler.cs
@@ -28,6 +28,8 @@ namespace WixToolset.ComPlus
 
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/complus";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4ConfigureComPlusInstall", "Wix4ConfigureComPlusUninstall" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/Dependency/wixext/DependencyCompiler.cs
+++ b/src/ext/Dependency/wixext/DependencyCompiler.cs
@@ -15,6 +15,9 @@ namespace WixToolset.Dependency
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/dependency";
 
+
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4DependencyRequire", "Wix4DependencyCheck" };
+
         /// <summary>
         /// Processes an attribute for the Compiler.
         /// </summary>

--- a/src/ext/DirectX/wixext/DirectXCompiler.cs
+++ b/src/ext/DirectX/wixext/DirectXCompiler.cs
@@ -16,6 +16,8 @@ namespace WixToolset.DirectX
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/directx";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4QueryDirectXCaps" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/Firewall/wixext/FirewallCompiler.cs
+++ b/src/ext/Firewall/wixext/FirewallCompiler.cs
@@ -17,6 +17,9 @@ namespace WixToolset.Firewall
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/firewall";
 
+
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4SchedFirewallExceptionsInstall" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/Http/wixext/HttpCompiler.cs
+++ b/src/ext/Http/wixext/HttpCompiler.cs
@@ -17,6 +17,8 @@ namespace WixToolset.Http
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/http";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4SchedHttpUrlReservationsInstall", "Wix4SchedHttpSniSslCertsInstall" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/Iis/wixext/IIsCompiler.cs
+++ b/src/ext/Iis/wixext/IIsCompiler.cs
@@ -18,6 +18,8 @@ namespace WixToolset.Iis
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/iis";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4ConfigureIIs", "Wix4InstallCertificates" };
+
         /// <summary>
         /// Types of objects that custom HTTP Headers can be applied to.
         /// </summary>

--- a/src/ext/Msmq/wixext/MsmqCompiler.cs
+++ b/src/ext/Msmq/wixext/MsmqCompiler.cs
@@ -17,6 +17,8 @@ namespace WixToolset.Msmq
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/msmq";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4MessageQueuingInstall" };
+
         /// <summary>
         /// </summary>
         /// <remarks></remarks>

--- a/src/ext/Sql/wixext/SqlCompiler.cs
+++ b/src/ext/Sql/wixext/SqlCompiler.cs
@@ -34,6 +34,8 @@ namespace WixToolset.Sql
 
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/sql";
 
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4InstallSqlData" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/UI/test/WixToolsetTest.UI/TestData/WixUI_OldStyleAction/Package.wxs
+++ b/src/ext/UI/test/WixToolsetTest.UI/TestData/WixUI_OldStyleAction/Package.wxs
@@ -1,0 +1,26 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+    <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" InstallerVersion="200">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <Feature Id="ProductFeature" Title="MsiPackage">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="example.txt" />
+            </Component>
+        </ComponentGroup>
+
+        <ui:WixUI Id="WixUI_Minimal" />
+        <UI>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="4" />
+        </UI>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
+++ b/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
@@ -303,6 +303,24 @@ namespace WixToolsetTest.UI
             }, results.Where(s => s.StartsWith("Control:ErrorDlg\tY")).Select(s => s.Split('\t')[9]).ToArray());
         }
 
+        [Fact]
+        public void CanBuildUsingOldStileActions()
+        {
+            var folder = TestData.Get(@"TestData\WixUI_OldStileAction");
+            var bindFolder = TestData.Get(@"TestData\data");
+            var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
+
+            var results = build.BuildAndQuery(Build, "CustomAction", "ControlEvent");
+            WixAssert.CompareLineByLine(new[]
+            {
+               "ControlEvent:WelcomeDlg\tNext\tDoAction\tWixUIValidatePath_X86\t1\t4",
+               "ControlEvent:WelcomeEulaDlg\tPrint\tDoAction\tWixUIPrintEula_X86\t1\t1"
+            }, results.Where(s => s.Contains("DoAction")).OrderBy(s => s).ToArray());
+
+
+
+        }
+
         private static void Build(string[] args)
         {
             var result = WixRunner.Execute(args)

--- a/src/ext/UI/wixext/UICompiler.cs
+++ b/src/ext/UI/wixext/UICompiler.cs
@@ -16,6 +16,8 @@ namespace WixToolset.UI
     {
         public override XNamespace Namespace => "http://wixtoolset.org/schemas/v4/wxs/ui";
 
+        public override List<string> ActionNames { get; } = new List<string> { "WixUIValidatePath", "WixUIPrintEula" };
+
         /// <summary>
         /// Processes an element for the Compiler.
         /// </summary>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/Package.en-us.wxl
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/Package.en-us.wxl
@@ -1,0 +1,9 @@
+﻿<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
+  <String Id="FeatureTitle" Value="MsiPackage" />
+
+</WixLocalization>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/Package.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/Package.wxs
@@ -1,0 +1,19 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+        <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+        <InstallExecuteSequence>
+            <Custom Action="Wix4SchedXmlConfig" After="InstallFiles" Condition="SOME_CONDITION"/>
+            <Custom Action="Wix4ConfigureSmbInstall" After="Wix4SchedXmlConfig" Condition="Another_Condition"/>
+        </InstallExecuteSequence>
+    </Package>
+
+    <Fragment>
+            <StandardDirectory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+            </StandardDirectory>
+        </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/PackageComponents.wxs
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/PackageComponents.wxs
@@ -1,0 +1,14 @@
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Fragment>
+        <util:User Id="Everyone" Name="Everyone" />
+
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="example.txt" />
+                <util:FileShare Id="ExampleFileShare" Description="An example file share" Name="example">
+                    <util:FileSharePermission User="Everyone" Read="yes" />
+                </util:FileShare>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/example.txt
+++ b/src/ext/Util/test/WixToolsetTest.Util/TestData/OldStyleActionsNames/example.txt
@@ -1,0 +1,1 @@
+This is example.txt.

--- a/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
+++ b/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
@@ -10,6 +10,7 @@ namespace WixToolsetTest.Util
     using WixToolset.Util;
     using Xunit;
     using System.Xml.Linq;
+    using System;
 
     public class UtilExtensionFixture
     {
@@ -511,6 +512,43 @@ namespace WixToolsetTest.Util
                     "The WindowsFeatureSearch/@Variable attribute's value, 'NTProductType', is one of the illegal options: 'AdminToolsFolder', 'AppDataFolder', 'CommonAppDataFolder', 'CommonFiles64Folder', 'CommonFiles6432Folder', 'CommonFilesFolder', 'CompatibilityMode', 'ComputerName', 'Date', 'DesktopFolder', 'FavoritesFolder', 'FontsFolder', 'InstallerName', 'InstallerVersion', 'LocalAppDataFolder', 'LogonUser', 'MyPicturesFolder', 'NativeMachine', 'NTProductType', 'NTSuiteBackOffice', 'NTSuiteDataCenter', 'NTSuiteEnterprise', 'NTSuitePersonal', 'NTSuiteSmallBusiness', 'NTSuiteSmallBusinessRestricted', 'NTSuiteWebServer', 'PersonalFolder', 'Privileged', 'ProcessorArchitecture', 'ProgramFiles64Folder', 'ProgramFiles6432Folder', 'ProgramFilesFolder', 'ProgramMenuFolder', 'RebootPending', 'SendToFolder', 'ServicePackLevel', 'StartMenuFolder', 'StartupFolder', 'System64Folder', 'SystemFolder', 'SystemLanguageID', 'TempFolder', 'TemplateFolder', 'TerminalServer', 'UserLanguageID', 'UserUILanguageID', 'VersionMsi', 'VersionNT', 'VersionNT64', 'WindowsBuildNumber', 'WindowsFolder', 'WindowsVolume', 'WixBundleAction', 'WixBundleActiveParent', 'WixBundleCommandLineAction', 'WixBundleElevated', 'WixBundleExecutePackageAction', 'WixBundleExecutePackageCacheFolder', 'WixBundleForcedRestartPackage', 'WixBundleInstalled', 'WixBundleProviderKey', 'WixBundleSourceProcessFolder', 'WixBundleSourceProcessPath', 'WixBundleTag', 'WixBundleUILevel', or 'WixBundleVersion'.",
                 }, messages.ToArray());
             }
+        }
+
+        [Fact]
+        public void CanBuildWithOldStyleActionName()
+        {
+            var folder = TestData.Get(@"TestData\OldStyleActionsNames");
+            var build = new Builder(folder, typeof(UtilExtensionFactory), new[] { folder });
+
+            var results = build.BuildAndQuery(Build, true, "InstallExecuteSequence");
+            WixAssert.CompareLineByLine(new[]
+            {
+                "InstallExecuteSequence:FindRelatedProducts\t\t25",
+                "InstallExecuteSequence:LaunchConditions\t\t100",
+                "InstallExecuteSequence:ValidateProductID\t\t700",
+                "InstallExecuteSequence:CostInitialize\t\t800",
+                "InstallExecuteSequence:FileCost\t\t900",
+                "InstallExecuteSequence:CostFinalize\t\t1000",
+                "InstallExecuteSequence:MigrateFeatureStates\t\t1200",
+                "InstallExecuteSequence:InstallValidate\t\t1400",
+                "InstallExecuteSequence:RemoveExistingProducts\t\t1401",
+                "InstallExecuteSequence:InstallInitialize\t\t1500",
+                "InstallExecuteSequence:ProcessComponents\t\t1600",
+                "InstallExecuteSequence:UnpublishFeatures\t\t1800",
+                "InstallExecuteSequence:RemoveFiles\t\t3500",
+                "InstallExecuteSequence:Wix4ConfigureSmbUninstall_X86\tVersionNT > 400\t3501",
+                "InstallExecuteSequence:RemoveFolders\t\t3600",
+                "InstallExecuteSequence:CreateFolders\t\t3700",
+                "InstallExecuteSequence:InstallFiles\t\t4000",
+                "InstallExecuteSequence:Wix4SchedXmlConfig_X86\tSOME_CONDITION\t4001",
+                "InstallExecuteSequence:Wix4ConfigureSmbInstall_X86\tAnother_Condition\t4002",
+                "InstallExecuteSequence:RegisterUser\t\t6000",
+                "InstallExecuteSequence:RegisterProduct\t\t6100",
+                "InstallExecuteSequence:PublishFeatures\t\t6300",
+                "InstallExecuteSequence:PublishProduct\t\t6400",
+                "InstallExecuteSequence:InstallFinalize\t\t6600"
+            }, results.OrderBy(s => Int32.Parse(s.Substring(s.LastIndexOf('\t')))).ToArray());
+
         }
 
         private static void Build(string[] args)

--- a/src/ext/Util/wixext/UtilCompiler.cs
+++ b/src/ext/Util/wixext/UtilCompiler.cs
@@ -35,10 +35,43 @@ namespace WixToolset.Util
         internal const int UserDontCreateUser = 0x00000200;
         internal const int UserNonVital = 0x00000400;
         internal const int UserRemoveComment = 0x00000800;
-
+        
         private static readonly Regex FindPropertyBrackets = new Regex(@"\[(?!\\|\])|(?<!\[\\\]|\[\\|\\\[)\]", RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
         public override XNamespace Namespace => UtilConstants.Namespace;
+
+
+        public override List<string> ActionNames { get; } = new List<string> { "Wix4SchedXmlFile",
+                 "Wix4SchedXmlConfig",
+                 "Wix4WaitForEvent",
+                 "Wix4WaitForEventDeferred",
+                 "Wix4ExitEarlyWithSuccess",             
+                 "Wix4BroadcastSettingChange",
+                 "Wix4BroadcastEnvironmentChange",
+                 "Wix4ShellExecBinary",
+                 "Wix4ShellExec",
+                 "Wix4UnelevatedShellExec",
+                 "Wix4QuietExec",
+                 "Wix4SilentExec",
+                 "Wix4CheckRebootRequired",
+                 "Wix4CloseApplications",
+                 "Wix4ConfigureUsers",
+                 "Wix4ConfigureSmbInstall",
+                 "Wix4ConfigureSmbUninstall",
+                 "Wix4InstallPerfCounterData",
+                 "Wix4UninstallPerfCounterData",
+                 "Wix4ConfigurePerfmonInstall",
+                 "Wix4ConfigurePerfmonUninstall",
+                 "Wix4ConfigurePerfmonManifestRegister",
+                 "Wix4ConfigurePerfmonManifestUnregister",
+                 "Wix4ConfigureEventManifestRegister",
+                 "Wix4ConfigureEventManifestUnregister",
+                 "Wix4SchedServiceConfig",
+                 "Wix4TouchFileDuringInstall",
+                 "Wix4TouchFileDuringUninstall",
+                 "Wix4SchedInternetShortcuts",
+                 "Wix4SchedSecureObjects"}; 
+              
 
         /// <summary>
         /// Types of Internet shortcuts.

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -37,6 +37,8 @@ namespace WixToolset.Core
 
         private string activeName;
         private string activeLanguage;
+        protected List<string> ActionsToConvert;
+
 
         /// <summary>
         /// Type of RadioButton element in a group.
@@ -59,6 +61,7 @@ namespace WixToolset.Core
         internal Compiler(IServiceProvider serviceProvider)
         {
             this.Messaging = serviceProvider.GetService<IMessaging>();
+            this.ActionsToConvert = new List<string>();
         }
 
         public IMessaging Messaging { get; }
@@ -78,6 +81,8 @@ namespace WixToolset.Core
         /// </summary>
         /// <value>The option to show pedantic messages.</value>
         public bool ShowPedanticMessages { get; set; }
+
+       
 
         /// <summary>
         /// Compiles the provided Xml document into an intermediate object
@@ -109,6 +114,7 @@ namespace WixToolset.Core
                 }
 
                 extension.PreCompile(this.Context);
+                this.ActionsToConvert.AddRange(extension.ActionNames);
             }
 
             // Try to compile it.
@@ -7991,6 +7997,19 @@ namespace WixToolset.Core
             }
 
             return directoryId;
+        }
+
+        private string ConvertActionName(string actionName)
+        {
+            string tmp = actionName;
+
+            if (this.ActionsToConvert.Contains(actionName))
+            {
+                tmp = tmp + "_" + this.CurrentPlatform;
+            }      
+
+            return tmp;
+
         }
     }
 }

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -2466,8 +2466,8 @@ namespace WixToolset.Core
                         case "Action":
                             if (customAction)
                             {
-                                actionName = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
-                                this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.CustomAction, actionName);
+                                    actionName = this.ConvertActionName(this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
+                                    this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.CustomAction, actionName);
                             }
                             else
                             {
@@ -2477,8 +2477,8 @@ namespace WixToolset.Core
                         case "After":
                             if (customAction || showDialog || specialAction || specialStandardAction)
                             {
-                                afterAction = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
-                                this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), afterAction);
+                                    afterAction = this.ConvertActionName(this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
+                                    this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), afterAction);
                             }
                             else
                             {
@@ -2488,8 +2488,8 @@ namespace WixToolset.Core
                         case "Before":
                             if (customAction || showDialog || specialAction || specialStandardAction)
                             {
-                                beforeAction = this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib);
-                                this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), beforeAction);
+                                    beforeAction = this.ConvertActionName(this.Core.GetAttributeIdentifierValue(childSourceLineNumbers, attrib));
+                                    this.Core.CreateSimpleReference(childSourceLineNumbers, SymbolDefinitions.WixAction, sequenceTable.ToString(), beforeAction);
                             }
                             else
                             {

--- a/src/wix/WixToolset.Core/Compiler_UI.cs
+++ b/src/wix/WixToolset.Core/Compiler_UI.cs
@@ -1729,6 +1729,18 @@ namespace WixToolset.Core
 
             if (!this.Core.EncounteredError)
             {
+
+                if ("DoAction" == controlEvent && null != argument)
+                {
+                    // if we're not looking at a standard action or a formatted string then create a reference
+                    // to the custom action.
+                    if (!WindowsInstallerStandard.IsStandardAction(argument) && !this.Core.ContainsProperty(argument))
+                    {
+                        // Convert old style custom action names to Wix4 standard
+                        argument = this.ConvertActionName(argument);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.CustomAction, argument);
+                    }
+                }
                 this.Core.AddSymbol(new ControlEventSymbol(sourceLineNumbers)
                 {
                     DialogRef = dialog,
@@ -1740,15 +1752,7 @@ namespace WixToolset.Core
                 });
             }
 
-            if ("DoAction" == controlEvent && null != argument)
-            {
-                // if we're not looking at a standard action or a formatted string then create a reference
-                // to the custom action.
-                if (!WindowsInstallerStandard.IsStandardAction(argument) && !this.Core.ContainsProperty(argument))
-                {
-                    this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.CustomAction, argument);
-                }
-            }
+            
 
             // if we're referring to a dialog but not through a property, add it to the references
             if (("NewDialog" == controlEvent || "SpawnDialog" == controlEvent || "SpawnWaitDialog" == controlEvent || "SelectionBrowse" == controlEvent) && Common.IsIdentifier(argument))


### PR DESCRIPTION
Second try. (Issues #6821 and #7178)
Add ability to reference WIX custom actions without suffix.
Description:
To the BaseCompilerExtension class added new virtual property of type string list. Each extension compiler overrides this property with list of actual WIX custom action names without suffix. Core compiler reads this list while loading extension and uses it to add platform suffix to each Custom Action