### PR TITLE
Full support for multitargeting project references in a .wixproj 

### DIFF
--- a/src/ext/Bal/bal.cmd
+++ b/src/ext/Bal/bal.cmd
@@ -3,35 +3,56 @@
 
 @set _C=Debug
 @set _L=%~dp0..\..\..\build\logs
+
 :parse_args
 @if /i "%1"=="release" set _C=Release
+@if /i "%1"=="inc" set _INC=1
+@if /i "%1"=="clean" set _CLEAN=1
 @if not "%1"=="" shift & goto parse_args
+
+@set _B=%~dp0..\..\..\build\Bal.wixext\%_C%
+
+:: Clean
+
+@if "%_INC%"=="" call :clean
+@if NOT "%_CLEAN%"=="" goto :end
 
 @echo Building ext\Bal %_C% using %_N%
 
 :: Restore
 nuget restore dnchost\packages.config || exit /b
-msbuild -t:Restore -p:Configuration=%_C% || exit /b
 
 :: Build
-msbuild -p:Configuration=%_C%;Platform=x86 test\examples\TestEngine\Example.TestEngine.vcxproj || exit /b
-msbuild -p:Configuration=%_C%;Platform=x64 test\examples\TestEngine\Example.TestEngine.vcxproj || exit /b
-msbuild -p:Configuration=%_C%;Platform=ARM64 test\examples\TestEngine\Example.TestEngine.vcxproj || exit /b
+msbuild -Restore -p:Configuration=%_C% -bl:%_L%\ext_bal_build.binlog || exit /b
 
-msbuild -p:Configuration=%_C% -bl:%_L%\bal_build.binlog || exit /b
-
-dotnet test test\WixToolsetTest.Dnc.HostGenerator -c %_C% --nologo --no-build -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.Dnc.HostGenerator.trx" || exit /b
-
-msbuild -Restore -p:Configuration=%_C% test\examples\examples.proj -bl:%_L%\bal_examples_build.binlog  || exit /b
+msbuild -Restore -p:Configuration=%_C% test\examples\examples.proj -m -bl:%_L%\bal_examples_build.binlog  || exit /b
 
 :: Test
-dotnet test test\WixToolsetTest.Bal -c %_C% --no-build -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.Bal.trx" || exit /b
-dotnet test test\WixToolsetTest.ManagedHost -c %_C% --no-build -l "trx;LogFileName=%_L%\TestResults\WixToolsetTest.ManagedHost.trx" || exit /b
+dotnet test ^
+ %_B%\net6.0\WixToolsetTest.Dnc.HostGenerator.dll ^
+ %_B%\net6.0\WixToolsetTest.Bal.dll ^
+ %_B%\net6.0\WixToolsetTest.ManagedHost.dll ^
+ --nologo -l "trx;LogFileName=%_L%\TestResults\bal.wixext.trx" || exit /b
 
 :: Pack
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.Bal.wixext.csproj || exit /b
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true WixToolset.Dnc.HostGenerator\WixToolset.Dnc.HostGenerator.csproj || exit /b
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true WixToolset.Mba.Host\WixToolset.Mba.Host.csproj || exit /b
 
+@goto :end
+
+:clean
+@rd /s/q "..\..\..\build\Bal.wixext" 2> nul
+@del "..\..\..\build\artifacts\WixToolset.Bal.wixext.*.nupkg" 2> nul
+@del "..\..\..\build\artifacts\WixToolset.Dnc.HostGenerator.*.nupkg" 2> nul
+@del "..\..\..\build\artifacts\WixToolset.Mba.Host.*.nupkg" 2> nul
+@del "%_L%\ext_bal_build.binlog" 2> nul
+@del "%_L%\TestResults\bal.wixext.trx" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.bal.wixext" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.dnc.hostgenerator" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.mba.host" 2> nul
+@exit /b
+
+:end
 @popd
 @endlocal

--- a/src/ext/Bal/test/WixToolsetTest.ManagedHost/WixToolsetTest.ManagedHost.csproj
+++ b/src/ext/Bal/test/WixToolsetTest.ManagedHost/WixToolsetTest.ManagedHost.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\examples\TestEngine\Example.TestEngine.vcxproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\examples\TestEngine\Example.TestEngine.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\examples\TestEngine\Example.TestEngine.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\examples\TestEngine\Example.TestEngine.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/Bal/wixlib/BalExtension_platform.wxi
+++ b/src/ext/Bal/wixlib/BalExtension_platform.wxi
@@ -6,8 +6,8 @@
 
     <Fragment>
         <BootstrapperApplication Id="WixDotNetCoreBootstrapperApplicationHost$(var.Suffix)">
-            <BootstrapperApplicationDll Id="WixDotNetCoreBootstrapperApplicationHost" SourceFile="!(bindpath.$(var.platform))\dnchost.dll" />
-            <Payload SourceFile="!(bindpath.$(var.platform))\wixstdba.dll" Name="dncpreq.dll" />
+            <BootstrapperApplicationDll Id="WixDotNetCoreBootstrapperApplicationHost" SourceFile="!(bindpath.dnchost.$(var.platform))\dnchost.dll" />
+            <Payload SourceFile="!(bindpath.wixstdba.$(var.platform))\wixstdba.dll" Name="dncpreq.dll" />
         </BootstrapperApplication>
     </Fragment>
 
@@ -20,8 +20,8 @@
 
     <Fragment>
         <BootstrapperApplication Id="WixInternalUIBootstrapperApplication$(var.Suffix)">
-            <BootstrapperApplicationDll Id="WixInternalUIBootstrapperApplication" SourceFile="!(bindpath.$(var.platform))\wixiuiba.dll" />
-            <Payload SourceFile="!(bindpath.$(var.platform))\wixstdba.dll" Name="prereqba.dll" />
+            <BootstrapperApplicationDll Id="WixInternalUIBootstrapperApplication" SourceFile="!(bindpath.wixiuiba.$(var.platform))\wixiuiba.dll" />
+            <Payload SourceFile="!(bindpath.wixstdba.$(var.platform))\wixstdba.dll" Name="prereqba.dll" />
         </BootstrapperApplication>
     </Fragment>
 
@@ -34,7 +34,7 @@
 
     <Fragment>
         <BootstrapperApplication Id="WixStandardBootstrapperApplication$(var.Suffix)">
-            <BootstrapperApplicationDll Id="WixStandardBootstrapperApplication" SourceFile="!(bindpath.$(var.platform))\wixstdba.dll" />
+            <BootstrapperApplicationDll Id="WixStandardBootstrapperApplication" SourceFile="!(bindpath.wixstdba.$(var.platform))\wixstdba.dll" />
         </BootstrapperApplication>
     </Fragment>
 

--- a/src/ext/Bal/wixlib/Mbahost_platform.wxi
+++ b/src/ext/Bal/wixlib/Mbahost_platform.wxi
@@ -6,8 +6,8 @@
 
     <Fragment>
         <BootstrapperApplication Id="WixManagedBootstrapperApplicationHost$(var.Suffix)">
-            <BootstrapperApplicationDll Id="WixManagedBootstrapperApplicationHost" SourceFile="!(bindpath.$(var.platform))\mbahost.dll" />
-            <Payload SourceFile="!(bindpath.$(var.platform))\wixstdba.dll" Name="mbapreq.dll" />
+            <BootstrapperApplicationDll Id="WixManagedBootstrapperApplicationHost" SourceFile="!(bindpath.mbahost.$(var.platform))\mbahost.dll" />
+            <Payload SourceFile="!(bindpath.wixstdba.$(var.platform))\wixstdba.dll" Name="mbapreq.dll" />
             <PayloadGroupRef Id="WixManagedBootstrapperApplicationHostManagedPayloads" />
         </BootstrapperApplication>
     </Fragment>

--- a/src/ext/Bal/wixlib/bal.wixproj
+++ b/src/ext/Bal/wixlib/bal.wixproj
@@ -8,26 +8,14 @@
 
   <ItemGroup>
     <BindPath Include="..\wixstdba\Resources\" />
-    <BindPath Include="$(OutputPath)net6.0" />
     <BindPath Include="$(OutputPath)net20" />
-    <BindPath Include="$(OutputPath)x86" BindName="x86" />
-    <BindPath Include="$(OutputPath)x64" BindName="x64" />
-    <BindPath Include="$(OutputPath)arm64" BindName="arm64" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dnchost\dnchost.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\dnchost\dnchost.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\dnchost\dnchost.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\mbahost\mbahost.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\mbahost\mbahost.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\mbahost\mbahost.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixiuiba\wixiuiba.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixiuiba\wixiuiba.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixiuiba\wixiuiba.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixstdba\wixstdba.vcxproj" Properties="Platform=x86" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixstdba\wixstdba.vcxproj" Properties="Platform=x64" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\wixstdba\wixstdba.vcxproj" Properties="Platform=ARM64" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\dnchost\dnchost.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\mbahost\mbahost.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\wixiuiba\wixiuiba.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\wixstdba\wixstdba.vcxproj" Platforms="arm64,x86,x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/NetFx/netfx.cmd
+++ b/src/ext/NetFx/netfx.cmd
@@ -3,24 +3,46 @@
 
 @set _C=Debug
 @set _L=%~dp0..\..\..\build\logs
+
 :parse_args
 @if /i "%1"=="release" set _C=Release
+@if /i "%1"=="inc" set _INC=1
+@if /i "%1"=="clean" set _CLEAN=1
 @if not "%1"=="" shift & goto parse_args
+
+@set _B=%~dp0..\..\..\build\NetFx.wixext\%_C%
+
+:: Clean
+
+@if "%_INC%"=="" call :clean
+@if NOT "%_CLEAN%"=="" goto :end
 
 @echo NetFx.wixext build %_C%
 
 :: Restore
 nuget restore netcoresearch\packages.config || exit /b
-msbuild -t:Restore -p:Configuration=%_C% || exit /b
 
 :: Build
-msbuild -p:Configuration=%_C% -bl:%_L%\netfx_build.binlog || exit /b
+msbuild -Restore -p:Configuration=%_C% -bl:%_L%\ext_netfx_build.binlog || exit /b
 
 :: Test
-dotnet test -c %_C% --no-build test\WixToolsetTest.Netfx || exit /b
+dotnet test ^
+ %_B%\net6.0\WixToolsetTest.NetFx.dll ^
+ --nologo -l "trx;LogFileName=%_L%\TestResults\netfx.wixext.trx" || exit /b
 
 :: Pack
 msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.Netfx.wixext.csproj || exit /b
 
+@goto :end
+
+:clean
+@rd /s/q "..\..\build\NetFx.wixext" 2> nul
+@del "..\..\build\artifacts\WixToolset.NetFx.wixext.*.nupkg" 2> nul
+@del "%_L%\ext_netfx_build.binlog" 2> nul
+@del "%_L%\TestResults\netfx.wixext.trx" 2> nul
+@rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.netfx.wixext" 2> nul
+@exit /b
+
+:end
 @popd
 @endlocal

--- a/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
+++ b/src/ext/NetFx/wixlib/NetFxExtension_Platform.wxi
@@ -28,7 +28,7 @@
 
   <!-- NetFx Custom Action DLL Definitions -->
   <Fragment>
-    <Binary Id="$(var.Prefix)NetFxCA$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))netfxca.dll" />
+    <Binary Id="$(var.Prefix)NetFxCA$(var.Suffix)" SourceFile="!(bindpath.netfxca.$(var.platform))netfxca.dll" />
     <Binary Id="$(var.Prefix)NetCheck_x86" SourceFile="!(bindpath.x86)NetCoreCheck.exe" />
     <Binary Id="$(var.Prefix)NetCheck_x64" SourceFile="!(bindpath.x64)NetCoreCheck.exe" />
     <Binary Id="$(var.Prefix)NetCheck_arm64" SourceFile="!(bindpath.arm64)NetCoreCheck.exe" />

--- a/src/ext/NetFx/wixlib/NetfxBundleExtension_Platform.wxi
+++ b/src/ext/NetFx/wixlib/NetfxBundleExtension_Platform.wxi
@@ -5,10 +5,10 @@
     <?include ..\..\caDecor.wxi ?>
 
     <Fragment>
-        <BundleExtension Id="$(var.Prefix)NetfxBundleExtension$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))netfxbe.dll" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\netfxbe.dll">
+        <BundleExtension Id="$(var.Prefix)NetfxBundleExtension$(var.Suffix)" SourceFile="!(bindpath.netfxbe.$(var.platform))netfxbe.dll" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\netfxbe.dll">
             <?foreach PLATFORM in x86;x64;arm64?>
-            <Payload SourceFile="!(bindpath.$(var.PLATFORM))netcoresearch.exe" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\$(var.PLATFORM)\netcoresearch.exe" />
-            <Payload SourceFile="!(bindpath.$(var.PLATFORM))hostfxr.dll" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\$(var.PLATFORM)\hostfxr.dll" />
+            <Payload SourceFile="!(bindpath.netcoresearch.$(var.PLATFORM))netcoresearch.exe" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\$(var.PLATFORM)\netcoresearch.exe" />
+            <Payload SourceFile="!(bindpath.netcoresearch.$(var.PLATFORM))hostfxr.dll" Name="$(var.Prefix)NetfxBundleExtension$(var.Suffix)\$(var.PLATFORM)\hostfxr.dll" />
             <?endforeach?>
         </BundleExtension>
     </Fragment>

--- a/src/ext/NetFx/wixlib/netfx.wixproj
+++ b/src/ext/NetFx/wixlib/netfx.wixproj
@@ -8,24 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <BindInputPaths Include="$(OutputPath)x86" BindName='x86' />
-    <BindInputPaths Include="$(OutputPath)x64" BindName='x64' />
-    <BindInputPaths Include="$(OutputPath)arm64" BindName='arm64' />
-    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x86)\win-x86" BindName='x86' />
-    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x64)\win-x64" BindName='x64' />
-    <BindInputPaths Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_arm64)\win-arm64" BindName='arm64' />
+    <BindPath Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x86)\win-x86" BindName='x86' />
+    <BindPath Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_x64)\win-x64" BindName='x64' />
+    <BindPath Include="$(PkgMicrosoft_NET_Tools_NETCoreCheck_arm64)\win-arm64" BindName='arm64' />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\be\netfxbe.vcxproj" Properties="Platform=ARM64" />
-    <ProjectReference Include="..\be\netfxbe.vcxproj" Properties="Platform=x64" />
-    <ProjectReference Include="..\be\netfxbe.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\ca\netfxca.vcxproj" Properties="Platform=ARM64" />
-    <ProjectReference Include="..\ca\netfxca.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\ca\netfxca.vcxproj" Properties="Platform=x64" />
-    <ProjectReference Include="..\netcoresearch\netcoresearch.vcxproj" Properties="Platform=ARM64" />
-    <ProjectReference Include="..\netcoresearch\netcoresearch.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\netcoresearch\netcoresearch.vcxproj" Properties="Platform=x64" />
+    <ProjectReference Include="..\be\netfxbe.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\ca\netfxca.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\netcoresearch\netcoresearch.vcxproj" Platforms="arm64,x86,x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/UI/ui.cmd
+++ b/src/ext/UI/ui.cmd
@@ -8,6 +8,8 @@
 @if /i "%1"=="clean" set _CLEAN=1
 @if not "%1"=="" shift & goto parse_args
 
+@set _B=%~dp0..\..\..\build\UI.wixext\%_C%
+
 :: Clean
 
 @if "%_INC%"=="" call :clean
@@ -16,7 +18,7 @@
 @echo UI.wixext build %_C%
 
 :: Build
-msbuild -Restore -p:Configuration=%_C% || exit /b
+msbuild -Restore -p:Configuration=%_C% -warnaserror -bl:%_L%\ext_ui_build.binlog || exit /b
 
 :: Test
 :: dotnet test -c %_C% --no-build test\WixToolsetTest.UI || exit /b
@@ -29,6 +31,7 @@ msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.UI.wixex
 :clean
 @rd /s/q "..\..\..\build\UI.wixext" 2> nul
 @del "..\..\..\build\artifacts\WixToolset.UI.wixext.*.nupkg" 2> nul
+@del "%_L%\ext_ui_build.binlog" 2> nul
 @rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.ui.wixext" 2> nul
 @exit /b
 

--- a/src/ext/UI/wixlib/Common_Platform.wxi
+++ b/src/ext/UI/wixlib/Common_Platform.wxi
@@ -13,6 +13,6 @@
     </Fragment>
 
     <Fragment>
-        <Binary Id="WixUiCa$(Suffix)" SourceFile="!(bindpath.$(platform))uica.dll" />
+        <Binary Id="WixUiCa$(Suffix)" SourceFile="!(bindpath.uica.$(platform))uica.dll" />
     </Fragment>
 </Include>

--- a/src/ext/UI/wixlib/ui.wixproj
+++ b/src/ext/UI/wixlib/ui.wixproj
@@ -5,6 +5,7 @@
     <BindFiles>true</BindFiles>
     <Cultures>en-us</Cultures>
   </PropertyGroup>
+
   <PropertyGroup>
     <DefineConstants>
       $(DefineConstants);
@@ -17,19 +18,15 @@
       upIco=$(MSBuildProjectDirectory)\Bitmaps\up.ico;
     </DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
-    <BindInputPaths Include="$(OutputPath)x86" BindName="x86" />
-    <BindInputPaths Include="$(OutputPath)x64" BindName="x64" />
-    <BindInputPaths Include="$(OutputPath)arm64" BindName="arm64" />
-  </ItemGroup>
+
   <ItemGroup>
     <Content Include="Common_Platform.wxi" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=x64" />
-    <ProjectReference Include="..\ca\uica.vcxproj" Properties="Platform=ARM64" />
+    <ProjectReference Include="..\ca\uica.vcxproj" Platforms="arm64,x86,x64" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ext/Util/util.cmd
+++ b/src/ext/Util/util.cmd
@@ -20,7 +20,7 @@
 @echo Building ext\Util %_C% using %_N%
 
 :: Build
-msbuild -Restore -p:Configuration=%_C% || exit /b
+msbuild -Restore -p:Configuration=%_C% -warnaserror -bl:%_L%\ext_util_build.binlog || exit /b
 
 :: Test
 dotnet test ^
@@ -35,6 +35,7 @@ msbuild -t:Pack -p:Configuration=%_C% -p:NoBuild=true wixext\WixToolset.Util.wix
 :clean
 @rd /s/q "..\..\build\Util.wixext" 2> nul
 @del "..\..\build\artifacts\WixToolset.Util.wixext.*.nupkg" 2> nul
+@del "%_L%\ext_util_build.binlog" 2> nul
 @del "%_L%\TestResults\util.wixext.trx" 2> nul
 @rd /s/q "%USERPROFILE%\.nuget\packages\wixtoolset.util.wixext" 2> nul
 @exit /b

--- a/src/ext/Util/wixlib/UtilBundleExtension_Platform.wxi
+++ b/src/ext/Util/wixlib/UtilBundleExtension_Platform.wxi
@@ -5,6 +5,6 @@
     <?include ..\..\caDecor.wxi ?>
 
     <Fragment>
-        <BundleExtension Id="$(var.Prefix)UtilBundleExtension$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))utilbe.dll" Name="$(var.Prefix)UtilBundleExtension$(var.Suffix)\utilbe.dll" />
+        <BundleExtension Id="$(var.Prefix)UtilBundleExtension$(var.Suffix)" SourceFile="!(bindpath.utilbe.$(var.platform))utilbe.dll" Name="$(var.Prefix)UtilBundleExtension$(var.Suffix)\utilbe.dll" />
     </Fragment>
 </Include>

--- a/src/ext/Util/wixlib/UtilExtension_Platform.wxi
+++ b/src/ext/Util/wixlib/UtilExtension_Platform.wxi
@@ -367,6 +367,6 @@
     </Fragment>
 
     <Fragment>
-        <Binary Id="$(var.Prefix)UtilCA$(var.Suffix)" SourceFile="!(bindpath.$(var.platform))utilca.dll" />
+        <Binary Id="$(var.Prefix)UtilCA$(var.Suffix)" SourceFile="!(bindpath.utilca.$(var.platform))utilca.dll" />
     </Fragment>
 </Include>

--- a/src/ext/Util/wixlib/util.wixproj
+++ b/src/ext/Util/wixlib/util.wixproj
@@ -6,18 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <BindInputPaths Include="$(OutputPath)x86" BindName='x86' />
-    <BindInputPaths Include="$(OutputPath)x64" BindName='x64' />
-    <BindInputPaths Include="$(OutputPath)arm64" BindName='arm64' />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\be\utilbe.vcxproj" Properties="Platform=ARM64" />
-    <ProjectReference Include="..\be\utilbe.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\be\utilbe.vcxproj" Properties="Platform=x64" />
-    <ProjectReference Include="..\ca\utilca.vcxproj" Properties="Platform=ARM64" />
-    <ProjectReference Include="..\ca\utilca.vcxproj" Properties="Platform=x86" />
-    <ProjectReference Include="..\ca\utilca.vcxproj" Properties="Platform=x64" />
+    <ProjectReference Include="..\be\utilbe.vcxproj" Platforms="arm64,x86,x64" />
+    <ProjectReference Include="..\ca\utilca.vcxproj" Platforms="arm64,x86,x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/testresultfilelist.txt
+++ b/src/testresultfilelist.txt
@@ -3,10 +3,8 @@ build/logs/TestResults/burn.trx
 build/logs/TestResults/libs.trx
 build/logs/TestResults/tools.trx
 build/logs/TestResults/wix.trx
-build/logs/TestResults/WixToolsetTest.Bal.trx
 build/logs/TestResults/WixToolsetTest.BurnE2E.trx
-build/logs/TestResults/WixToolsetTest.Dnc.HostGenerator.trx
-build/logs/TestResults/WixToolsetTest.ManagedHost.trx
 build/logs/TestResults/util.wixext.trx
+build/logs/TestResults/bal.wixext.trx
 build/logs/TestResults/WixToolsetTest.MsiE2E.trx
 build/logs/TestResults/WixToolsetTest.WixE2ETests.trx

--- a/src/wix/WixToolset.BuildTasks/CreateProjectReferenceDefineConstantsAndBindPaths.cs
+++ b/src/wix/WixToolset.BuildTasks/CreateProjectReferenceDefineConstantsAndBindPaths.cs
@@ -31,7 +31,7 @@ namespace WixToolset.BuildTasks
         public override bool Execute()
         {
             var bindPaths = new Dictionary<string, List<ITaskItem>>(StringComparer.OrdinalIgnoreCase);
-            var defineConstants = new Dictionary<string, string>();
+            var defineConstants = new SortedDictionary<string, string>();
 
             foreach (var resolvedReference in this.ResolvedProjectReferences)
             {
@@ -46,7 +46,7 @@ namespace WixToolset.BuildTasks
             return true;
         }
 
-        private void AddBindPathsForResolvedReference(Dictionary<string, List<ITaskItem>> bindPathByPaths, ITaskItem resolvedReference)
+        private void AddBindPathsForResolvedReference(IDictionary<string, List<ITaskItem>> bindPathByPaths, ITaskItem resolvedReference)
         {
             // If the BindName was not explicitly provided, try to use the source project's filename
             // as the bind name.
@@ -84,7 +84,7 @@ namespace WixToolset.BuildTasks
             }
         }
 
-        private void AddDefineConstantsForResolvedReference(Dictionary<string, string> defineConstants, ITaskItem resolvedReference)
+        private void AddDefineConstantsForResolvedReference(IDictionary<string, string> defineConstants, ITaskItem resolvedReference)
         {
             var configuration = resolvedReference.GetMetadata("Configuration");
             var fullConfiguration = resolvedReference.GetMetadata("FullConfiguration");
@@ -96,7 +96,7 @@ namespace WixToolset.BuildTasks
             var projectFileName = Path.GetFileName(projectPath);
             var projectName = Path.GetFileNameWithoutExtension(projectPath);
 
-            var referenceName = ToolsCommon.GetIdentifierFromName(ToolsCommon.GetMetadataOrDefault(resolvedReference, "Name", projectName));
+            var referenceName = ToolsCommon.CreateIdentifierFromValue(ToolsCommon.GetMetadataOrDefault(resolvedReference, "Name", projectName));
 
             var targetPath = resolvedReference.GetMetadata("FullPath");
             var targetDir = Path.GetDirectoryName(targetPath) + Path.DirectorySeparatorChar;
@@ -156,12 +156,12 @@ namespace WixToolset.BuildTasks
                 }
 
                 // If there was only one targetpath we need to create its culture specific define
-                if (!oldTargetPath.Contains(";"))
+                if (!oldTargetPath.Contains("%3B"))
                 {
                     var oldSubFolder = FindSubfolder(oldTargetPath, targetDir, targetFileName);
                     if (!String.IsNullOrEmpty(oldSubFolder))
                     {
-                        defineConstants[referenceName + "." + oldSubFolder.Replace('\\', '_') + ".TargetPath"] = oldTargetPath;
+                        defineConstants[referenceName + "." + ToolsCommon.CreateIdentifierFromValue(oldSubFolder) + ".TargetPath"] = oldTargetPath;
                     }
                 }
 
@@ -169,7 +169,7 @@ namespace WixToolset.BuildTasks
                 var subFolder = FindSubfolder(targetPath, targetDir, targetFileName);
                 if (!String.IsNullOrEmpty(subFolder))
                 {
-                    defineConstants[referenceName + "." + subFolder.Replace('\\', '_') + ".TargetPath"] = targetPath;
+                    defineConstants[referenceName + "." + ToolsCommon.CreateIdentifierFromValue(subFolder) + ".TargetPath"] = targetPath;
                 }
             }
             else

--- a/src/wix/WixToolset.BuildTasks/MetadataValue.cs
+++ b/src/wix/WixToolset.BuildTasks/MetadataValue.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.BuildTasks
+{
+    using System;
+    using Microsoft.Build.Framework;
+
+    internal class MetadataValue
+    {
+        public MetadataValue(ITaskItem item, string name, string valuePrefix = null, string defaultValue = "")
+        {
+            this.Item = item;
+            this.Name = name;
+
+            var value = item.GetMetadata(name);
+
+            this.HadValue = !String.IsNullOrWhiteSpace(value);
+            this.OriginalValue = value;
+
+            if (!this.HadValue)
+            {
+                this.Value = defaultValue;
+                this.ValidValue = true;
+            }
+            else if (String.IsNullOrWhiteSpace(valuePrefix))
+            {
+                this.Value = value;
+                this.ValidValue = true;
+            }
+            else if (value.StartsWith(valuePrefix) && value.Length > valuePrefix.Length)
+            {
+                this.Value = value.Substring(valuePrefix.Length);
+                this.ValidValue = true;
+            }
+        }
+
+        public ITaskItem Item { get; }
+
+        public string Name { get; }
+
+        public bool HadValue { get; }
+
+        public bool Modified => !String.Equals(this.OriginalValue, this.Value, StringComparison.Ordinal);
+
+        public string OriginalValue { get; }
+
+        public string Value { get; private set; }
+
+        public bool ValidValue { get; }
+
+        public void SetValue(string value)
+        {
+            this.Value = value;
+        }
+
+        public void Apply()
+        {
+            if (String.IsNullOrWhiteSpace(this.Value))
+            {
+                this.Item.RemoveMetadata(this.Name);
+            }
+            else
+            {
+                this.Item.SetMetadata(this.Name, this.Value);
+            }
+        }
+    }
+}

--- a/src/wix/WixToolset.BuildTasks/MetadataValueList.cs
+++ b/src/wix/WixToolset.BuildTasks/MetadataValueList.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.BuildTasks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Build.Framework;
+
+    internal class MetadataValueList
+    {
+        private static readonly char[] MetadataListSplitter = new char[] { ',', ';' };
+
+        public MetadataValueList(ITaskItem item, string name)
+        {
+            this.Item = item;
+            this.Name = name;
+
+            var value = item.GetMetadata(name);
+
+            this.HadValue = !String.IsNullOrWhiteSpace(value);
+            this.OriginalValue = value;
+
+            this.Values = value.Split(MetadataListSplitter).Where(s => !String.IsNullOrWhiteSpace(s)).ToList();
+        }
+
+        public ITaskItem Item { get; }
+
+        public string Name { get; }
+
+        public bool HadValue { get; }
+
+        public string OriginalValue { get; }
+
+        public bool Modified { get; private set; }
+
+        public List<string> Values { get; }
+
+        public void Clear()
+        {
+            if (this.Values.Count > 0)
+            {
+                this.Modified = true;
+                this.Values.Clear();
+            }
+        }
+
+        public void SetValue(string prefix, string value)
+        {
+            if (!String.IsNullOrEmpty(prefix))
+            {
+                value = String.IsNullOrWhiteSpace(value) ? null : prefix + value;
+
+                for (var i = 0; i < this.Values.Count; ++i)
+                {
+                    if (this.Values[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (value == null)
+                        {
+                            this.Values.RemoveAt(i);
+                        }
+                        else
+                        {
+                            this.Values[i] = value;
+                        }
+
+                        this.Modified = true;
+                        return;
+                    }
+                }
+            }
+
+            if (!String.IsNullOrWhiteSpace(value) && !this.Values.Contains(value))
+            {
+                this.Modified = true;
+                this.Values.Add(value);
+            }
+        }
+
+        public void AddRange(IEnumerable<string> values)
+        {
+            foreach (var value in values)
+            {
+                this.SetValue(null, value);
+            }
+        }
+
+        public void Apply()
+        {
+            if (this.Values.Count == 0)
+            {
+                this.Item.RemoveMetadata(this.Name);
+            }
+            else
+            {
+                this.Item.SetMetadata(this.Name, String.Join(";", this.Values));
+            }
+        }
+    }
+}

--- a/src/wix/WixToolset.BuildTasks/ToolsCommon.cs
+++ b/src/wix/WixToolset.BuildTasks/ToolsCommon.cs
@@ -18,18 +18,17 @@ namespace WixToolset.BuildTasks
         private static readonly Regex IllegalIdentifierCharacters = new Regex(@"[^A-Za-z0-9_\.]|\.{2,}"); // non 'words' and assorted valid characters
 
         /// <summary>
-        /// Return an identifier based on passed file/directory name
+        /// Return an identifier based on passed value.
         /// </summary>
-        /// <param name="name">File/directory name to generate identifer from</param>
-        /// <returns>A version of the name that is a legal identifier.</returns>
-        /// <remarks>This is duplicated from WiX's Common class.</remarks>
-        public static string GetIdentifierFromName(string name)
+        /// <param name="value">Value to create identifer from.</param>
+        /// <returns>A version of the value that is a legal identifier.</returns>
+        public static string CreateIdentifierFromValue(string value)
         {
-            var result = IllegalIdentifierCharacters.Replace(name, "_"); // replace illegal characters with "_".
+            var result = IllegalIdentifierCharacters.Replace(value, "_"); // replace illegal characters with "_".
 
             // MSI identifiers must begin with an alphabetic character or an
             // underscore. Prefix all other values with an underscore.
-            if (AddPrefix.IsMatch(name))
+            if (AddPrefix.IsMatch(value))
             {
                 result = String.Concat("_", result);
             }

--- a/src/wix/WixToolset.Core/Librarian.cs
+++ b/src/wix/WixToolset.Core/Librarian.cs
@@ -65,6 +65,11 @@ namespace WixToolset.Core
 
                 trackedFiles = this.ResolveFilePathsToEmbed(context, sections);
 
+                if (this.Messaging.EncounteredError)
+                {
+                    return null;
+                }
+
                 foreach (var section in sections)
                 {
                     section.AssignToLibrary(context.LibraryId);
@@ -116,18 +121,18 @@ namespace WixToolset.Core
                         {
                             var resolution = variableResolver.ResolveVariables(symbol.SourceLineNumbers, pathField.Path);
 
-                            var file = this.FileResolver.ResolveFile(resolution.Value, context.Extensions, bindPaths, symbol.SourceLineNumbers, symbol.Definition);
-
-                            if (!String.IsNullOrEmpty(file))
+                            try
                             {
+                                var file = this.FileResolver.ResolveFile(resolution.Value, context.Extensions, bindPaths, symbol.SourceLineNumbers, symbol.Definition);
+
                                 // File was successfully resolved so track the embedded index as the embedded file index.
                                 field.Set(new IntermediateFieldPathValue { Embed = true, Path = file });
 
                                 trackedFiles.Add(this.LayoutServices.TrackFile(file, TrackedFileType.Input, symbol.SourceLineNumbers));
                             }
-                            else
+                            catch (WixException e)
                             {
-                                this.Messaging.Write(ErrorMessages.FileNotFound(symbol.SourceLineNumbers, pathField.Path, symbol.Definition.Name));
+                                this.Messaging.Write(e.Error);
                             }
                         }
                     }

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/Directory.Build.props
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Reset any Directory.Build.props that might exists above this folder -->
+</Project>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/Directory.Build.targets
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Reset any Directory.Build.targets that might exists above this folder -->
+</Project>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/Package.wxs
@@ -1,0 +1,36 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="Test Package" Manufacturer="~Test" Version="0" Compressed="false" UpgradeCode="11111111-1111-1111-1111-111111111111">
+        <Feature Id="Main">
+            <ComponentGroupRef Id="Stuff"/>
+        </Feature>
+    </Package>
+
+    <Fragment>
+        <ComponentGroup Id="Stuff" Directory="ProgramFilesFolder">
+            <Component Subdirectory="debug_net472_x86">
+                <File Id="debug_net472_x86" Source="!(bindpath.TestExe.Debug.net472.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="debug_net472_x64">
+                <File Id="debug_net472_x64" Source="!(bindpath.TestExe.Debug.net472.win_x64)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="debug_net6_x86">
+                <File Id="debug_net6_x86" Source="!(bindpath.TestExe.Debug.net6.0.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="debug_net6_x64">
+                <File Id="debug_net6_x64" Source="!(bindpath.TestExe.Debug.net6.0.win_x64)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="release_net472_x86">
+                <File Id="release_net472_x86" Source="!(bindpath.TestExe.Release.net472.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="release_net472_x64">
+                <File Id="release_net472_x64" Source="!(bindpath.TestExe.Release.net472.win_x64)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="release_net6_x86">
+                <File Id="release_net6_x86" Source="!(bindpath.TestExe.Release.net6.0.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="release_net6_x64">
+                <File Id="release_net6_x64" Source="!(bindpath.TestExe.Release.net6.0.win_x64)\e_sqlite3.dll" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/PackageReleaseAndDebug.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/PackageReleaseAndDebug.wixproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$(WixMSBuildProps)" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" Configurations="Debug,Release" TargetFrameworks="net6.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
+  </ItemGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+</Project>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/Package.wxs
@@ -1,0 +1,26 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="Test Package" Manufacturer="~Test" Version="0" Compressed="false" UpgradeCode="11111111-1111-1111-1111-111111111111">
+        <Feature Id="Main">
+            <ComponentGroupRef Id="Stuff"/>
+        </Feature>
+    </Package>
+
+    <Fragment>
+        <ComponentGroup Id="Stuff" Directory="ProgramFilesFolder">
+            <Component Subdirectory="net472_x64">
+                <File Id="net472_x64" Source="!(bindpath.TestExe.net472.win_x64)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="net6_x86">
+                <File Id="net6_x86" Source="!(bindpath.TestExe.net6.0.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="net6_x64">
+                <File Id="net6_x64" Source="!(bindpath.TestExe.net6.0.win_x64)\e_sqlite3.dll" />
+            </Component>
+
+            <!-- This is explicitly not built and causes the build to fail -->
+            <Component Subdirectory="net472_x86">
+                <File Id="net472_x86" Source="!(bindpath.TestExe.net472.win_x86)\e_sqlite3.dll" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/PackageUsingExplicitTfmAndRids.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/PackageUsingExplicitTfmAndRids.wixproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$(WixMSBuildProps)" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net6.0,net472|win-x64" RuntimeIdentifiers="win-x86,win-x64" />
+  </ItemGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+</Project>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/Package.wxs
@@ -1,0 +1,24 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="Test Package" Manufacturer="~Test" Version="0" Compressed="false" UpgradeCode="11111111-1111-1111-1111-111111111111">
+        <Feature Id="Main">
+            <ComponentGroupRef Id="Stuff"/>
+        </Feature>
+    </Package>
+
+    <Fragment>
+        <ComponentGroup Id="Stuff" Directory="ProgramFilesFolder">
+            <Component Subdirectory="net472_x86">
+                <File Id="net472_x86" Source="!(bindpath.TestExe.net472.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="net472_x64">
+                <File Id="net472_x64" Source="!(bindpath.TestExe.net472.win_x64)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="net6_x86">
+                <File Id="net6_x86" Source="!(bindpath.TestExe.net6.0.win_x86)\e_sqlite3.dll" />
+            </Component>
+            <Component Subdirectory="net6_x64">
+                <File Id="net6_x64" Source="!(bindpath.TestExe.net6.0.win_x64)\e_sqlite3.dll" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/PackageUsingRids.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/PackageUsingRids.wixproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$(WixMSBuildProps)" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net6.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
+  </ItemGroup>
+
+  <Import Project="$(WixTargetsPath)" />
+</Project>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/Program.cs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/Program.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.Sdk.TestData.MultiTargetingWixlib.MultiTargetingClassLib
+{
+    using System;
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("This is Test.exe");
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/TestExe.csproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/TestExe.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Also:
* Display errors for all missing files when building a bound wixlib
* Update some extensions to take advantage of multitargeting project references

Closes wixtoolset/issues#7241