### PR TITLE
Fix WindowsVolume and SetProperty references

### DIFF
--- a/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
@@ -396,7 +396,6 @@ namespace WixToolset.Data.WindowsInstaller
                 new DirectorySymbol(null, new Identifier(AccessModifier.Global, "TempFolder")) { Name = "Temp" },
                 new DirectorySymbol(null, new Identifier(AccessModifier.Global, "TemplateFolder")) { Name = "Template" },
                 new DirectorySymbol(null, new Identifier(AccessModifier.Global, "WindowsFolder")) { Name = "Windows" },
-                new DirectorySymbol(null, new Identifier(AccessModifier.Global, "WindowsVolume")) { Name = "WinVol" },
             };
 
             standardActionNames = new HashSet<string>(standardActions.Select(a => a.Action));

--- a/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
@@ -780,28 +780,9 @@ namespace WixToolset.Core.ExtensibilityServices
                 Overridable = overridable,
             });
 
-            if (null != beforeAction)
+            if (beforeAction != null || afterAction != null)
             {
-                if (WindowsInstallerStandard.IsStandardAction(beforeAction))
-                {
-                    this.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixAction, sequence.ToString(), beforeAction);
-                }
-                else
-                {
-                    this.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.CustomAction, beforeAction);
-                }
-            }
-
-            if (null != afterAction)
-            {
-                if (WindowsInstallerStandard.IsStandardAction(afterAction))
-                {
-                    this.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixAction, sequence.ToString(), afterAction);
-                }
-                else
-                {
-                    this.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.CustomAction, afterAction);
-                }
+                this.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixAction, sequence.ToString(), beforeAction ?? afterAction);
             }
 
             return actionSymbol;

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
@@ -520,38 +520,6 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
-        public void CanBuildSetProperty()
-        {
-            var folder = TestData.Get(@"TestData\SetProperty");
-
-            using (var fs = new DisposableFileSystem())
-            {
-                var baseFolder = fs.GetFolder();
-                var intermediateFolder = Path.Combine(baseFolder, "obj");
-
-                var result = WixRunner.Execute(new[]
-                {
-                    "build",
-                    Path.Combine(folder, "Package.wxs"),
-                    Path.Combine(folder, "PackageComponents.wxs"),
-                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
-                    "-bindpath", Path.Combine(folder, "data"),
-                    "-intermediateFolder", intermediateFolder,
-                    "-o", Path.Combine(baseFolder, @"bin\test.msi")
-                });
-
-                result.AssertSuccess();
-
-                var output = WindowsInstallerData.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"), false);
-                var caRows = output.Tables["CustomAction"].Rows.Single();
-                WixAssert.StringEqual("SetINSTALLLOCATION", caRows.FieldAsString(0));
-                WixAssert.StringEqual("51", caRows.FieldAsString(1));
-                WixAssert.StringEqual("INSTALLLOCATION", caRows.FieldAsString(2));
-                WixAssert.StringEqual("[INSTALLFOLDER]", caRows.FieldAsString(3));
-            }
-        }
-
-        [Fact]
         public void CanBuildVersionIndependentProgId()
         {
             var folder = TestData.Get(@"TestData\ProgId");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SetProperty/CannotBuildWhenSetPropertyReferencesMissingAction.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SetProperty/CannotBuildWhenSetPropertyReferencesMissingAction.wxs
@@ -1,0 +1,39 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no">
+    <MajorUpgrade DowngradeErrorMessage="Cannot Downgrade" />
+
+    <Feature Id="ProductFeature">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+
+    <SetProperty Id="OnlyScheduledInExecuteSequence" Value="Some=Data" Before="OnlyScheduledInExecuteSequence" />
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="test.txt" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <InstallExecuteSequence>
+      <Custom Action="OnlyScheduledInExecuteSequence" After="InstallFiles" />
+    </InstallExecuteSequence>
+  </Fragment>
+
+  <Fragment>
+    <CustomAction Id="OnlyScheduledInExecuteSequence" BinaryRef="PretendDll" DllEntry="IgnoredByTesting" Execute="immediate" Return="check" />
+  </Fragment>
+
+  <Fragment>
+    <Binary Id="PretendDll" SourceFile="test.txt" />
+  </Fragment>
+</Wix>


### PR DESCRIPTION
* WindowsVolume is not a standard directory - fixes wixtoolset/issues#7233
* Ensure to reference the before/after WixAction when scheduling an action - fixes wixtoolset/issues#7225