### PR TITLE
Add missing log path for ui.cmd

### DIFF
--- a/src/ext/UI/ui.cmd
+++ b/src/ext/UI/ui.cmd
@@ -2,6 +2,8 @@
 @pushd %~dp0
 
 @set _C=Debug
+@set _L=%~dp0..\..\..\build\logs
+
 :parse_args
 @if /i "%1"=="release" set _C=Release
 @if /i "%1"=="inc" set _INC=1


### PR DESCRIPTION
Fixes wixtoolset/issues#7247