### PR TITLE
WIX Toolset v4-rc.4 fixes

### DIFF
--- a/src/api/wix/WixToolset.Data/WarningMessages.cs
+++ b/src/api/wix/WixToolset.Data/WarningMessages.cs
@@ -613,9 +613,9 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.UnclearShortcut, "Because it is an advertised shortcut, the target of shortcut '{0}' will be the keypath of component '{2}' rather than parent file '{1}'. To eliminate this warning, you can (1) make the Shortcut element a child of the File element that is the keypath of component '{2}', (2) make file '{1}' the keypath of component '{2}', or (3) remove the @Advertise attribute so the shortcut is a non-advertised shortcut.", shortcutId, fileId, componentId);
         }
 
-        public static Message UnexpectedEntrySection(SourceLineNumber sourceLineNumbers, string sectionType, string expectedType, string outputExtension)
+        public static Message UnexpectedEntrySection(SourceLineNumber sourceLineNumbers, string sectionType, string expectedType)
         {
-            return Message(sourceLineNumbers, Ids.UnexpectedEntrySection, "Found mismatched entry point <{0}>. Expected <{1}> for specified output package type {2}.", sectionType, expectedType, outputExtension);
+            return Message(sourceLineNumbers, Ids.UnexpectedEntrySection, "Found entry point <{0}> that does not match expected <{1}> output type. Verify that your source code is correct and matches the expected output type.", sectionType, expectedType);
         }
 
         public static Message UnexpectedTableInProduct(SourceLineNumber sourceLineNumbers, string tableName)

--- a/src/ext/UI/test/WixToolsetTest.UI/TestData/InvalidUIRef/Package.wxs
+++ b/src/ext/UI/test/WixToolsetTest.UI/TestData/InvalidUIRef/Package.wxs
@@ -1,0 +1,23 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+    <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" InstallerVersion="200">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <Feature Id="ProductFeature" Title="MsiPackage">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="example.txt" />
+            </Component>
+        </ComponentGroup>
+
+        <UIRef Id="WixUI_Mondo" />
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
+++ b/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
@@ -2,11 +2,10 @@
 
 namespace WixToolsetTest.UI
 {
-    using System;
     using System.IO;
     using System.Linq;
-    using WixInternal.TestSupport;
     using WixInternal.Core.TestPackage;
+    using WixInternal.TestSupport;
     using WixToolset.Data.WindowsInstaller;
     using WixToolset.UI;
     using Xunit;
@@ -16,8 +15,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIAdvanced()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Advanced");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Advanced");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -52,8 +51,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIAdvancedX64()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Advanced");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Advanced");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -88,8 +87,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIAdvancedARM64()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Advanced");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Advanced");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(BuildARM64, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -124,8 +123,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIFeatureTree()
         {
-            var folder = TestData.Get(@"TestData\WixUI_FeatureTree");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_FeatureTree");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -155,8 +154,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIInstallDir()
         {
-            var folder = TestData.Get(@"TestData\WixUI_InstallDir");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_InstallDir");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "Property", "ControlEvent");
@@ -191,8 +190,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIMinimal()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Minimal");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Minimal");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -220,8 +219,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIMinimalInKazakh()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Minimal");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Minimal");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(BuildInKazakh, "Dialog");
@@ -232,8 +231,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIMinimalAndReadPdb()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Minimal");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Minimal");
+            var bindFolder = TestData.Get(@"TestData", "data");
 
             using (var fs = new DisposableFileSystem())
             {
@@ -258,8 +257,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIMondo()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Mondo");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Mondo");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(Build, "Binary", "Dialog", "CustomAction", "ControlEvent");
@@ -292,8 +291,8 @@ namespace WixToolsetTest.UI
         [Fact]
         public void CanBuildUsingWixUIMondoLocalized()
         {
-            var folder = TestData.Get(@"TestData\WixUI_Mondo");
-            var bindFolder = TestData.Get(@"TestData\data");
+            var folder = TestData.Get(@"TestData", "WixUI_Mondo");
+            var bindFolder = TestData.Get(@"TestData", "data");
             var build = new Builder(folder, typeof(UIExtensionFactory), new[] { bindFolder });
 
             var results = build.BuildAndQuery(BuildInGerman, "Control");
@@ -301,6 +300,31 @@ namespace WixToolsetTest.UI
             {
                 "&Ja",
             }, results.Where(s => s.StartsWith("Control:ErrorDlg\tY")).Select(s => s.Split('\t')[9]).ToArray());
+        }
+
+        [Fact]
+        public void CannotBuildWithV3LikeUIRef()
+        {
+            var folder = TestData.Get(@"TestData", "InvalidUIRef");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var intermediateFolder = fs.GetFolder();
+                var outputPath = Path.Combine(intermediateFolder, "bin", "test.msi");
+
+                var args = new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    "-ext", typeof(UIExtensionFactory).Assembly.Location,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", outputPath,
+                };
+
+                var results = WixRunner.Execute(args);
+                var message = results.Messages.Single();
+                Assert.Equal("The identifier 'WixUI:WixUI_Mondo' is inaccessible due to its protection level.", message.ToString());
+            }
         }
 
         private static void Build(string[] args)

--- a/src/ext/UI/wixext/UICompiler.cs
+++ b/src/ext/UI/wixext/UICompiler.cs
@@ -87,7 +87,6 @@ namespace WixToolset.UI
             else
             {
                 var platform = this.Context.Platform == Platform.ARM64 ? "A64" : this.Context.Platform.ToString();
-                this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixUI, id);
                 this.ParseHelper.CreateSimpleReference(section, sourceLineNumbers, SymbolDefinitions.WixUI, $"{id}_{platform}");
 
                 if (installDirectory != null)

--- a/src/ext/UI/wixlib/WixUI_Advanced.wxs
+++ b/src/ext/UI/wixlib/WixUI_Advanced.wxs
@@ -1,7 +1,5 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
-
 <!--
 WixUI_Advanced offers a two-click install (EULA checkbox and Install button)
 and offers an Advanced button that lets users choose per-machine or per-user
@@ -22,6 +20,18 @@ Todo:
 -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_Advanced_$(WIXUIARCH)">
+            <Publish Dialog="AdvancedWelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="1" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+
+        <UIRef Id="WixUI_Advanced" />
+    </Fragment>
+    <?endforeach?>
+
     <Fragment>
         <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
         <WixVariable Id="WixUISupportPerMachine" Value="1" Overridable="yes" />
@@ -46,7 +56,7 @@ Todo:
             <Custom Action="WixSetPerMachineFolder" After="WixSetPerUserFolder" Condition="ACTION=&quot;INSTALL&quot; AND APPLICATIONFOLDER=&quot;&quot; AND (ALLUSERS=1 OR (ALLUSERS=2 AND Privileged))" />
         </InstallUISequence>
 
-        <UI Id="WixUI_Advanced">
+        <UI Id="file WixUI_Advanced">
             <TextStyle Id="WixUI_Font_Normal" FaceName="!(loc.Advanced_Font_FaceName)" Size="!(loc.Advanced_Font_Normal_Size)" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="!(loc.Advanced_Font_FaceName)" Size="!(loc.Advanced_Font_Bigger_Size)" />
             <TextStyle Id="WixUI_Font_Title" FaceName="!(loc.Advanced_Font_FaceName)" Size="!(loc.Advanced_Font_Title_Size)" Bold="yes" />
@@ -115,14 +125,4 @@ Todo:
         <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
         <UIRef Id="WixUI_Common" />
     </Fragment>
-
-    <?foreach WIXUIARCH in X86;X64;A64 ?>
-    <Fragment>
-        <UI Id="WixUI_Advanced_$(WIXUIARCH)">
-            <Publish Dialog="AdvancedWelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="1" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-        </UI>
-    </Fragment>
-    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_FeatureTree.wxs
+++ b/src/ext/UI/wixlib/WixUI_FeatureTree.wxs
@@ -1,7 +1,5 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
-
 <!--
 First-time install dialog sequence:
  - WixUI_WelcomeDlg
@@ -22,8 +20,18 @@ Patch dialog sequence:
 -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="WixUI_FeatureTree">
+        <UI Id="WixUI_FeatureTree_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+        </UI>
+
+        <UIRef Id="WixUI_FeatureTree" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file WixUI_FeatureTree">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
@@ -65,12 +73,4 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
-
-    <?foreach WIXUIARCH in X86;X64;A64 ?>
-    <Fragment>
-        <UI Id="WixUI_FeatureTree_$(WIXUIARCH)">
-            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
-        </UI>
-    </Fragment>
-    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_InstallDir.wxs
+++ b/src/ext/UI/wixlib/WixUI_InstallDir.wxs
@@ -1,7 +1,5 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
-
 <!--
 First-time install dialog sequence:
  - WixUI_WelcomeDlg
@@ -23,8 +21,20 @@ Patch dialog sequence:
 -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="WixUI_InstallDir">
+        <UI Id="WixUI_InstallDir_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file WixUI_InstallDir">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
@@ -72,14 +82,4 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
-
-    <?foreach WIXUIARCH in X86;X64;A64 ?>
-    <Fragment>
-        <UI Id="WixUI_InstallDir_$(WIXUIARCH)">
-            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-        </UI>
-    </Fragment>
-    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_Minimal.wxs
+++ b/src/ext/UI/wixlib/WixUI_Minimal.wxs
@@ -1,7 +1,5 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
-
 <!--
 First-time install dialog sequence:
  - WixUI_WelcomeEulaDlg
@@ -17,8 +15,18 @@ Patch dialog sequence:
 -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="WixUI_Minimal">
+        <UI Id="WixUI_Minimal_$(WIXUIARCH)">
+            <Publish Dialog="WelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+        </UI>
+
+        <UIRef Id="WixUI_Minimal" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file WixUI_Minimal">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
@@ -59,12 +67,4 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
-
-    <?foreach WIXUIARCH in X86;X64;A64 ?>
-    <Fragment>
-        <UI Id="WixUI_Minimal_$(WIXUIARCH)">
-            <Publish Dialog="WelcomeEulaDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
-        </UI>
-    </Fragment>
-    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/WixUI_Mondo.wxs
+++ b/src/ext/UI/wixlib/WixUI_Mondo.wxs
@@ -1,7 +1,5 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
-
-
 <!--
 First-time install dialog sequence:
 - WixUI_WelcomeDlg
@@ -24,8 +22,20 @@ Patch dialog sequence:
 -->
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="WixUI_Mondo">
+        <UI Id="WixUI_Mondo_$(WIXUIARCH)">
+            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+
+        <UIRef Id="WixUI_Mondo" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file WixUI_Mondo">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
@@ -74,14 +84,4 @@ Patch dialog sequence:
 
         <UIRef Id="WixUI_Common" />
     </Fragment>
-
-    <?foreach WIXUIARCH in X86;X64;A64 ?>
-    <Fragment>
-        <UI Id="WixUI_Mondo_$(WIXUIARCH)">
-            <Publish Dialog="LicenseAgreementDlg" Control="Print" Event="DoAction" Value="WixUIPrintEula_$(WIXUIARCH)" />
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
-        </UI>
-    </Fragment>
-    <?endforeach?>
 </Wix>

--- a/src/ext/UI/wixlib/ui.v3.ncrunchproject
+++ b/src/ext/UI/wixlib/ui.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
+++ b/src/ext/Util/test/WixToolsetTest.Util/UtilExtensionFixture.cs
@@ -301,7 +301,7 @@ namespace WixToolsetTest.Util
         public void CanBuildModuleWithXmlConfig()
         {
             var folder = TestData.Get(@"TestData", "XmlConfigModule");
-            var build = new Builder(folder, typeof(UtilExtensionFactory), new[] { folder });
+            var build = new Builder(folder, typeof(UtilExtensionFactory), new[] { folder }, "test.msm");
 
             var results = build.BuildAndQuery(BuildX64, "Wix4XmlConfig");
             WixAssert.CompareLineByLine(new[]

--- a/src/wix/WixToolset.Converters/WixConverter.cs
+++ b/src/wix/WixToolset.Converters/WixConverter.cs
@@ -1687,7 +1687,7 @@ namespace WixToolset.Converters
                 && value?.StartsWith("WixUI", StringComparison.OrdinalIgnoreCase) == true
                 && this.OnInformation(ConverterTestType.CustomActionIdsIncludePlatformSuffix, element, "Custom action ids have changed in WiX v4 extensions to support platform-specific custom actions. For more information, see https://wixtoolset.org/docs/fourthree/#converting-custom-wixui-dialog-sets."))
             {
-                // Just warn.
+                element.Attribute("Value").Value = value + "_$(sys.BUILDARCHSHORT)";
             }
         }
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/ValidateSubcommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/CommandLine/ValidateSubcommand.cs
@@ -90,7 +90,14 @@ namespace WixToolset.Core.WindowsInstaller.CommandLine
 
                 if (File.Exists(this.WixpdbPath))
                 {
-                    data = WindowsInstallerData.Load(this.WixpdbPath);
+                    try
+                    {
+                        data = WindowsInstallerData.Load(this.WixpdbPath);
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        this.Messaging.Write(WindowsInstallerBackendErrors.InvalidWindowsInstallerWixpdbForValidation(this.WixpdbPath));
+                    }
                 }
 
                 var command = new ValidateDatabaseCommand(this.Messaging, this.FileSystem, this.IntermediateFolder, this.DatabasePath, data, this.CubeFiles, this.Ices, this.SuppressIces);

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendErrors.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendErrors.cs
@@ -29,6 +29,11 @@ namespace WixToolset.Core.WindowsInstaller
             return Message(originalLineNumber, Ids.InvalidModuleVersion, "The Module/@Version was not be able to be used as a four-part version. A valid four-part version has a max value of \"65535.65535.65535.65535\" and must be all numeric.", version);
         }
 
+        public static Message InvalidWindowsInstallerWixpdbForValidation(string wixpdbPath)
+        {
+            return Message(null, Ids.InvalidWindowsInstallerWixpdbForValidation, "The validation .wixpdb file: {0} was not from a Windows Installer database build (.msi or .msm). Verify that the output type was actually an MSI Package or Merge Module.", wixpdbPath);
+        }
+
         public static Message UnknownDecompileType(string decompileType, string filePath)
         {
             return Message(null, Ids.UnknownDecompileType, "Unknown decompile type '{0}' from input: {1}", decompileType, filePath);
@@ -52,6 +57,7 @@ namespace WixToolset.Core.WindowsInstaller
             ExceededMaximumAllowedFeatureDepthInMsi = 7503,
             UnknownDecompileType = 7504,
             UnknownValidationTargetFileExtension = 7505,
+            InvalidWindowsInstallerWixpdbForValidation = 7506,
         } // last available is 7999. 8000 is BurnBackendErrors.
     }
 }

--- a/src/wix/WixToolset.Core/Link/FindEntrySectionAndLoadSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/FindEntrySectionAndLoadSymbolsCommand.cs
@@ -60,12 +60,10 @@ namespace WixToolset.Core.Link
                 // Try to find the one and only entry section.
                 if (SectionType.Package == section.Type || SectionType.Module == section.Type || SectionType.PatchCreation == section.Type || SectionType.Patch == section.Type || SectionType.Bundle == section.Type)
                 {
-                    // TODO: remove this?
-                    //if (SectionType.Unknown != expectedEntrySectionType && section.Type != expectedEntrySectionType)
-                    //{
-                    //    string outputExtension = Output.GetExtension(this.ExpectedOutputType);
-                    //    this.Messaging.Write(WixWarnings.UnexpectedEntrySection(section.SourceLineNumbers, section.Type.ToString(), expectedEntrySectionType.ToString(), outputExtension));
-                    //}
+                    if (SectionType.Unknown != expectedEntrySectionType && section.Type != expectedEntrySectionType)
+                    {
+                        this.Messaging.Write(WarningMessages.UnexpectedEntrySection(section.Symbols.FirstOrDefault()?.SourceLineNumbers, section.Type.ToString(), expectedEntrySectionType.ToString()));
+                    }
 
                     if (null == this.EntrySection)
                     {

--- a/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/ConditionFixture.cs
@@ -382,19 +382,15 @@ namespace WixToolsetTest.Converters
             var parse = String.Join(Environment.NewLine,
                 "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
                 "<Include xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
-                "  <Fragment>",
-                "    <Condition Message='from wxi'>",
-                "        wxicondition",
-                "    </Condition>",
-                "  </Fragment>",
+                "  <Condition Message='from wxi'>",
+                "      wxicondition",
+                "  </Condition>",
                 "</Include>");
 
             var expected = new[]
             {
                 "<Include xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
-                "  <Fragment>",
-                "    <Launch Condition=\"wxicondition\" Message=\"from wxi\" />",
-                "  </Fragment>",
+                "  <Launch Condition=\"wxicondition\" Message=\"from wxi\" />",
                 "</Include>"
             };
 
@@ -485,7 +481,7 @@ namespace WixToolsetTest.Converters
         }
 
         [Fact]
-        public void FixLaunchCondition()
+        public void FixLaunchConditionInFragment()
         {
             var parse = String.Join(Environment.NewLine,
                 "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
@@ -569,7 +565,7 @@ namespace WixToolsetTest.Converters
                 "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
                 "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
                 "  <Product>",
-                "  <Package />",
+                "    <Package />",
                 "    <Condition Message='Stop the install'>",
                 "      1&lt;2",
                 "    </Condition>",
@@ -583,7 +579,7 @@ namespace WixToolsetTest.Converters
             {
                 "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
                 "  <Package Compressed=\"no\">",
-                "  ",
+                "    ",
                 "    <Launch Condition=\"1&lt;2\" Message=\"Stop the install\" />",
                 "    <Launch Condition=\"1=2\" Message=\"Do not stop\" />",
                 "  </Package>",

--- a/src/wix/test/WixToolsetTest.Converters/ConverterFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/ConverterFixture.cs
@@ -542,42 +542,5 @@ namespace WixToolsetTest.Converters
             Assert.Equal(2, errors);
             WixAssert.CompareLineByLine(expected, actual);
         }
-
-        [Fact]
-        public void WarnsOnWixUIDoActionControlEvents()
-        {
-            var parse = String.Join(Environment.NewLine,
-                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
-                "  <Fragment>",
-                "    <UI Id='WixUI_Test'>",
-                "      <Publish Dialog='BrowseDlg' Control='OK' Event='DoAction' Value='WixUIValidatePath' Order='3' />",
-                "    </UI>",
-                "  </Fragment>",
-                "</Wix>");
-
-            var expected = new[]
-            {
-                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
-                "  <Fragment>",
-                "    <UI Id=\"WixUI_Test\">",
-                "      <Publish Dialog=\"BrowseDlg\" Control=\"OK\" Event=\"DoAction\" Value=\"WixUIValidatePath\" Order=\"3\" />",
-                "    </UI>",
-                "  </Fragment>",
-                "</Wix>",
-            };
-
-            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
-
-            var messaging = new MockMessaging();
-            var converter = new WixConverter(messaging, 2, null, null);
-
-            var errors = converter.ConvertDocument(document);
-
-            var actual = UnformattedDocumentLines(document);
-
-            Assert.Equal(2, errors);
-            Assert.Single(messaging.Messages.Where(m => m.Id == 65));
-            WixAssert.CompareLineByLine(expected, actual);
-        }
     }
 }

--- a/src/wix/test/WixToolsetTest.Converters/UIExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/UIExtensionFixture.cs
@@ -3,6 +3,7 @@
 namespace WixToolsetTest.Converters
 {
     using System;
+    using System.Linq;
     using System.Xml.Linq;
     using WixInternal.TestSupport;
     using WixToolset.Converters;
@@ -54,6 +55,87 @@ namespace WixToolsetTest.Converters
 
             var actualLines = UnformattedDocumentLines(document);
             WixAssert.CompareLineByLine(expected, actualLines);
+        }
+
+        [Fact]
+        public void FixPrintCustomAction()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id='CustomResumeDlg' Width='370' Height='270' Title='!(loc.ResumeDlg_Title)'>",
+                "        <Control Id='Print' Type='PushButton' X='112' Y='243' Width='56' Height='17' Text='!(loc.WixUIPrint)'>",
+                "          <Publish Event='DoAction' Value='WixUIPrintEula'>1</Publish>",
+                "        </Control>",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <UI>",
+                "      <Dialog Id=\"CustomResumeDlg\" Width=\"370\" Height=\"270\" Title=\"!(loc.ResumeDlg_Title)\">",
+                "        <Control Id=\"Print\" Type=\"PushButton\" X=\"112\" Y=\"243\" Width=\"56\" Height=\"17\" Text=\"!(loc.WixUIPrint)\">",
+                "          <Publish Event=\"DoAction\" Value=\"WixUIPrintEula_$(sys.BUILDARCHSHORT)\" />",
+                "        </Control>",
+                "      </Dialog>",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+
+            var actual = UnformattedDocumentLines(document);
+
+            WixAssert.CompareLineByLine(expected, actual);
+            Assert.Equal(4, errors);
+        }
+
+        [Fact]
+        public void FixValidatePathCustomAction()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <UI Id='WixUI_Test'>",
+                "      <Publish Dialog='BrowseDlg' Control='OK' Event='DoAction' Value='WixUIValidatePath' Order='3' />",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <UI Id=\"WixUI_Test\">",
+                "      <Publish Dialog=\"BrowseDlg\" Control=\"OK\" Event=\"DoAction\" Value=\"WixUIValidatePath_$(sys.BUILDARCHSHORT)\" Order=\"3\" />",
+                "    </UI>",
+                "  </Fragment>",
+                "</Wix>",
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+
+            var actual = UnformattedDocumentLines(document);
+
+            WixAssert.CompareLineByLine(expected, actual);
+            Assert.Single(messaging.Messages.Where(m => m.Id == 65));
+            Assert.Equal(2, errors);
         }
     }
 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/ClassFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/ClassFixture.cs
@@ -120,7 +120,7 @@ namespace WixToolsetTest.CoreIntegration
             {
                 var baseFolder = fs.GetFolder();
                 var intermediateFolder = Path.Combine(baseFolder, "obj");
-                var msiPath = Path.Combine(baseFolder, @"bin", "test.msi");
+                var msiPath = Path.Combine(baseFolder, @"bin", "test.msm");
 
                 var result = WixRunner.Execute(new[]
                 {


### PR DESCRIPTION
* Correctly convert LaunchConditions everywhere - fixes wixtoolset/issues#7264
* Prevent direct references to platform-neutral WixUI - fixes wixtoolset/issues#7265
* Warn on mismatched output times and validate only Windows Installer databases - fixes wixtoolset/issues#7250
