### PR TITLE
File and folder names that start with dots are not valid short names

### DIFF
--- a/src/wix/WixToolset.Core/Common.cs
+++ b/src/wix/WixToolset.Core/Common.cs
@@ -249,7 +249,7 @@ namespace WixToolset.Core
                 {
                     return filename.Length < 9;
                 }
-                else if (expectedDot > 8 || filename[expectedDot] != '.' || expectedDot + 4 < filename.Length)
+                else if (expectedDot == 0 || expectedDot > 8 || filename[expectedDot] != '.' || expectedDot + 4 < filename.Length)
                 {
                     return false;
                 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -282,6 +282,7 @@ namespace WixToolsetTest.CoreIntegration
                     "Directory:Folder12\tINSTALLFOLDER\tFolder.12",
                     "Directory:Folder123\tINSTALLFOLDER\tFolder.123",
                     "Directory:Folder1234\tINSTALLFOLDER\tyakwclwy|Folder.1234",
+                    "Directory:GitFolder\tINSTALLFOLDER\t69sdfw2d|.git",
                     "Directory:INSTALLFOLDER\tProgramFiles6432Folder\t1egc1laj|MsiPackage",
                     "Directory:NAMEANDSHORTNAME\tINSTALLFOLDER\tSHORTNAM|NameAndShortName",
                     "Directory:NAMEANDSHORTSOURCENAME\tINSTALLFOLDER\tNAMEASSN|NameAndShortSourceName",

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/DefaultDir.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/DefaultDir.wxs
@@ -21,6 +21,7 @@
             <Directory Id="Folder12" Name="Folder.12"></Directory>
             <Directory Id="Folder123" Name="Folder.123"></Directory>
             <Directory Id="Folder1234" Name="Folder.1234"></Directory>
+            <Directory Id="GitFolder" Name=".git"></Directory>
         </DirectoryRef>
     </Fragment>
 </Wix>


### PR DESCRIPTION
Fixes wixtoolset/issues#7313