### PR TITLE
Wix4 rc4 Patch creation outputs erroneous warning WIX1097

### DIFF
--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateTransformsWithFileFacades.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/UpdateTransformsWithFileFacades.cs
@@ -419,7 +419,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 var componentId = row.Component;
 
                 // If this file is the keypath of a component
-                if (componentKeyPath.ContainsValue(componentId))
+                if (componentKeyPath.ContainsValue(fileId))
                 {
                     if (!componentWithChangedKeyPath.ContainsKey(componentId))
                     {


### PR DESCRIPTION
Fix for [Wix4 rc4 atch creation outputs erroneous warning WIX1097](https://github.com/wixtoolset/issues/issues/7315)