### PR TITLE
Set packagetype is MSBuildSdk in WixToolset.Sdk.nuspec

### DIFF
--- a/src/wix/WixToolset.Sdk/WixToolset.Sdk.nuspec
+++ b/src/wix/WixToolset.Sdk/WixToolset.Sdk.nuspec
@@ -12,6 +12,9 @@
     <copyright>$copyright$</copyright>
     <projectUrl>$projectUrl$</projectUrl>
     <repository type="$repositorytype$" url="$repositoryurl$" commit="$repositorycommit$" />
+    <packageTypes>
+      <packageType name="MSBuildSdk" />
+    </packageTypes>
   </metadata>
 
   <files>


### PR DESCRIPTION
Nuget uses `MSBuildSdk` to indicate the SDK package type, so I think we should add that to the nuspec file.

They will show like this
![image](https://user-images.githubusercontent.com/42184238/228791376-c9af8136-e24c-4a9b-89d6-d056e57ddd00.png)

- [Search packagetype=MSBuildSdk - Nuget.org](https://www.nuget.org/packages?packagetype=MSBuildSdk)
- [nuget packagetypes - Microsoft Docs](https://learn.microsoft.com/nuget/reference/nuspec#packagetypes)