### PR TITLE
Handle error case when payload is missing both Name and SourceFile

### DIFF
--- a/src/wix/WixToolset.Core/Compile/CompilerPayload.cs
+++ b/src/wix/WixToolset.Core/Compile/CompilerPayload.cs
@@ -207,6 +207,11 @@ namespace WixToolset.Core
                 this.DownloadUrl = null;
             }
 
+            if (String.IsNullOrEmpty(this.Name) && String.IsNullOrEmpty(this.SourceFile))
+            {
+                this.Core.Write(ErrorMessages.ExpectedAttributes(this.SourceLineNumbers, this.Element.Name.LocalName, "Name", "SourceFile"));
+            }
+
             if (!this.Core.EncounteredError)
             {
                 symbol = this.Core.AddSymbol(new WixBundlePayloadSymbol(this.SourceLineNumbers, this.Id)

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -406,6 +406,60 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
+        public void CannotBuildBundleMissingMsiSource()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "BundleWithMissingSource", "BundleMissingMsiSource.wxs"),
+                    "-bindpath", Path.Combine(folder, ".Data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.exe")
+                });
+
+                var message = result.Messages.Where(m => m.Level == MessageLevel.Error).Select(m => m.ToString().Replace(folder, "<testdata>")).ToArray();
+                WixAssert.CompareLineByLine(new[]
+                {
+                    @"The MsiPackage element's Name or SourceFile attribute was not found; one of these is required."
+                }, message);
+            }
+        }
+
+        [Fact]
+        public void CannotBuildBundleMissingMsuSource()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "BundleWithMissingSource", "BundleMissingMsuSource.wxs"),
+                    "-bindpath", Path.Combine(folder, ".Data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.exe")
+                });
+
+                var message = result.Messages.Where(m => m.Level == MessageLevel.Error).Select(m => m.ToString().Replace(folder, "<testdata>")).ToArray();
+                WixAssert.CompareLineByLine(new[]
+                {
+                    @"The MsuPackage element's Name or SourceFile attribute was not found; one of these is required."
+                }, message);
+            }
+        }
+
+        [Fact]
         public void CannotBuildBundleWithInvalidIcon()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundleWithMissingSource/BundleMissingMsiSource.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundleWithMissingSource/BundleMissingMsiSource.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Bundle Name="BundleMissingMsiSource"
+            Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="B94478B1-E1F3-4700-9CE8-6AA090854AEC">
+        <BootstrapperApplication>
+            <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+        </BootstrapperApplication>
+
+        <Chain>
+            <MsiPackage
+               Id="MsiPackage1"
+               DisplayName="Msi Package #1"
+               DownloadUrl="http://example.com/test.msi" />
+        </Chain>
+    </Bundle>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundleWithMissingSource/BundleMissingMsuSource.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/BundleWithMissingSource/BundleMissingMsuSource.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Bundle Name="BundleMissingMsuSource"
+            Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="B94478B1-E1F3-4700-9CE8-6AA090854AEC">
+        <BootstrapperApplication>
+            <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+        </BootstrapperApplication>
+
+        <Chain>
+            <MsuPackage
+               Id="MsuPackage1"
+               DetectCondition="TODO"
+               DisplayName="MSU Package #1"
+               DownloadUrl="http://example.com/test.msu" />
+        </Chain>
+    </Bundle>
+</Wix>


### PR DESCRIPTION
Fixes wixtoolset/issues#7333
Fixes wixtoolset/issues#7347