### PR TITLE
Hide visible NetCoreCheck.exe window.

### DIFF
--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/NetfxExtensionFixture.cs
@@ -177,6 +177,29 @@ namespace WixToolsetTest.Netfx
             }, results.OrderBy(s => s).ToArray());
         }
 
+        [Fact]
+        public void CanBuildUsingDotNetCompatibilityCheck()
+        {
+            var folder = TestData.Get(@"TestData\UsingDotNetCompatibilityCheck");
+            var build = new Builder(folder, typeof(NetfxExtensionFactory), new[] { folder });
+
+            var results = build.BuildAndQuery(BuildX64, "Binary", "CustomAction", "Wix4NetFxDotNetCheck");
+            WixAssert.CompareLineByLine(new[]
+            {
+                "Binary:Wix4NetCheck_arm64\t[Binary data]",
+                "Binary:Wix4NetCheck_x64\t[Binary data]",
+                "Binary:Wix4NetCheck_x86\t[Binary data]",
+                "Binary:Wix4NetFxCA_X64\t[Binary data]",
+                "CustomAction:Wix4NetFxDotNetCompatibilityCheck_X64\t1\tWix4NetFxCA_X64\tDotNetCompatibilityCheck\t",
+                "CustomAction:Wix4NetFxExecuteNativeImageCommitInstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
+                "CustomAction:Wix4NetFxExecuteNativeImageCommitUninstall_X64\t3649\tWix4NetFxCA_X64\tExecNetFx\t",
+                "CustomAction:Wix4NetFxExecuteNativeImageInstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
+                "CustomAction:Wix4NetFxExecuteNativeImageUninstall_X64\t3137\tWix4NetFxCA_X64\tExecNetFx\t",
+                "CustomAction:Wix4NetFxScheduleNativeImage_X64\t1\tWix4NetFxCA_X64\tSchedNetFx\t",
+                "Wix4NetFxDotNetCheck:DotNetCoreCheckManualId\tMicrosoft.NETCore.App\tx64\t7.0.1\tLatestMajor\tDOTNETCORECHECKRESULT",
+            }, results.OrderBy(s => s).ToArray());
+        }
+
         private static void Build(string[] args)
         {
             var result = WixRunner.Execute(args);

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/Package.en-us.wxl
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/Package.en-us.wxl
@@ -1,0 +1,9 @@
+﻿<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
+  <String Id="FeatureTitle" Value="MsiPackage" />
+
+</WixLocalization>

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/Package.wxs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/Package.wxs
@@ -1,0 +1,17 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx">
+  <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+    <netfx:DotNetCompatibilityCheck Id="DotNetCoreCheckManualId" Property="DOTNETCORECHECKRESULT" Platform="x64" RuntimeType="core" RollForward="latestMajor" Version="7.0.1" />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+      <StandardDirectory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/PackageComponents.wxs
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/PackageComponents.wxs
@@ -1,0 +1,9 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Name="fake.dll" Source="example.txt" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/example.txt
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/TestData/UsingDotNetCompatibilityCheck/example.txt
@@ -1,0 +1,1 @@
+This is example.txt.

--- a/src/ext/NetFx/wixext/NetFxCompiler.cs
+++ b/src/ext/NetFx/wixext/NetFxCompiler.cs
@@ -697,9 +697,6 @@ namespace WixToolset.Netfx
                         case "Platform":
                             platform = this.ParsePlatform(element, sourceLineNumbers, attrib);
                             break;
-                        case "FeatureBand":
-                            platform = this.ParseFeatureBand(element, sourceLineNumbers, attrib);
-                            break;
                         case "Version":
                             version = this.ParseHelper.GetAttributeVersionValue(sourceLineNumbers, attrib);
                             break;
@@ -810,20 +807,6 @@ namespace WixToolset.Netfx
             }
 
             return platform;
-        }
-
-        private string ParseFeatureBand(XElement element, SourceLineNumber sourceLineNumbers, XAttribute attrib)
-        {
-            string featureBand = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attrib);
-
-            if (!Int32.TryParse(featureBand, out var intFeatureBand) || (100 > intFeatureBand) || (intFeatureBand > 999))
-            {
-                this.Messaging.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, element.Name.LocalName,
-                    attrib.Name.LocalName, featureBand, "An integer in the range [100 - 999]"));
-
-            }
-
-            return featureBand;
         }
 
         private string ParseRuntimeType(XElement element, SourceLineNumber sourceLineNumbers, XAttribute attrib)

--- a/src/libs/dutil/WixToolset.DUtil/procutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/procutil.cpp
@@ -352,6 +352,7 @@ extern "C" HRESULT DAPI ProcExec(
     ProcExitOnFailure(hr, "Failed to allocate full command-line.");
 
     si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
     si.wShowWindow = static_cast<WORD>(nCmdShow);
     if (!::CreateProcessW(wzExecutablePath, sczFullCommandLine, NULL, NULL, FALSE, 0, 0, NULL, &si, &pi))
     {


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/7353.

Also adds unit test and removes dead code.